### PR TITLE
Fix /health endpoint returning results for removed instances 

### DIFF
--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -181,14 +181,14 @@ Feature: CLI tests
         And host is still running
 
     @ci
-    Scenario: E2E-010 TC-013 Package and send with stdout
+    Scenario: E2E-010 TC-017
         Given host is running
-        When I execute CLI with bash command "$SI pack ../packages/reference-apps/transform-function -c | $SI send --format json"
+        When I execute CLI with bash command "$SI seq send ../packages/reference-apps/inert-function.tar.gz --format json"
         And the exit status is 0
         Then I get Sequence id
         Then I start Sequence
         And the exit status is 0
-        Then I get list of instances
-        And the exit status is 0
+        Then I get instance health
+        Then wait for "5000" ms
+        Then health outputs 404
         And host is still running
-

--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -162,7 +162,7 @@ Feature: CLI tests
         Then I get instance info
         Then I send an event named "test-event" with event message "test message" to Instance
         And the exit status is 0
-        And wait for "5000" ms
+        And wait for "4000" ms
         Then I get event "test-event-response" with event message "{\"eventName\":\"test-event-response\",\"message\":\"message from sequence\"}" from instance
         And the exit status is 0
 

--- a/bdd/features/e2e/E2E-012-stream-flooding-test.feature
+++ b/bdd/features/e2e/E2E-012-stream-flooding-test.feature
@@ -25,7 +25,7 @@ Feature: Stream flooding tests. Ensure that even if a large amount of data is se
     Scenario: E2E-012 TC-002 Instance floods wrtites stdout, then Host checks whether even sent by Instance can be still received.
         Given host is running
         When sequence "../packages/reference-apps/flood-stdout-sequence.tar.gz" loaded
-        And instance started with arguments "1000 10000"
+        And instance started with arguments "2000 10000"
         And wait for "1000" ms
         And get instance health
         And get containerId

--- a/bdd/step-definitions/e2e/cli.ts
+++ b/bdd/step-definitions/e2e/cli.ts
@@ -94,6 +94,12 @@ Then("I get instance health", { timeout: 10000 }, async function() {
     assert.equal(typeof msg.healthy !== "undefined", true);
 });
 
+Then("health outputs 404", async () => {
+    stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "health", instanceId, ...connectionFlags()]);
+
+    assert.equal(stdio[1].includes("404"), true);
+});
+
 Then("I get instance log", { timeout: 30000 }, async function() {
     stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "log", instanceId]);
 });

--- a/packages/adapters/src/instance-adapter.ts
+++ b/packages/adapters/src/instance-adapter.ts
@@ -307,25 +307,21 @@ IComponent {
         });
     }
 
-    cleanup(): MaybePromise<void> {
-        return new Promise(async (resolve) => {
-            if (this.resources.volumeId) {
-                this.logger.log("Volume will be removed in 1 sec");
+    async cleanup(): Promise<void> {
+        if (this.resources.volumeId) {
+            this.logger.log("Volume will be removed in 1 sec");
 
-                await defer(1000);
-                await this.dockerHelper.removeVolume(this.resources.volumeId);
+            await defer(1000);
+            await this.dockerHelper.removeVolume(this.resources.volumeId);
 
-                this.logger.log("Volume removed");
-            }
+            this.logger.log("Volume removed");
+        }
 
-            if (this.resources.fifosDir) {
-                await rmdir(this.resources.fifosDir, { recursive: true });
+        if (this.resources.fifosDir) {
+            await rmdir(this.resources.fifosDir, { recursive: true });
 
-                this.logger.log("Fifo folder removed");
-            }
-
-            resolve();
-        });
+            this.logger.log("Fifo folder removed");
+        }
     }
 
     // returns url identifier of made snapshot

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -342,7 +342,7 @@ export class Host implements IComponent {
 
             const index = sequence.instances.indexOf(id);
 
-            if (~index) {
+            if (index > -1) {
                 sequence.instances.splice(index, 1);
             }
         });

--- a/packages/supervisor/src/lib/csh-client.ts
+++ b/packages/supervisor/src/lib/csh-client.ts
@@ -97,8 +97,8 @@ class CSHClient implements ICSHClient {
                 CC.OUT,
                 CC.LOG
             ]
-                .map(streamIndex => streams[streamIndex] as unknown as Writable)
-                .map((stream: Writable) => new Promise(
+                .map(streamIndex => streams[streamIndex] as Writable)
+                .map(stream => new Promise(
                     (res, rej) => stream
                         .on("error", rej)
                         .on("end", res)

--- a/packages/supervisor/src/lib/lifecycle-controller.ts
+++ b/packages/supervisor/src/lib/lifecycle-controller.ts
@@ -92,7 +92,7 @@ class LifeCycleController implements IComponent {
      * Before the Sequence is executed the LifeCycle Adapter Run needs to connect the message and data streams
      * between the client and the LifeCycle Adapter Run.
      *
-     * LifeCycle Controller than requests LifeCycle Adapter Run to run the Sequence.
+     * LifeCycle Controller then requests LifeCycle Adapter Run to run the Sequence.
      *
      * The Sequence runs until it has not terminated, either by itself or by a command sent from the CSH.
      *
@@ -205,7 +205,6 @@ class LifeCycleController implements IComponent {
             // TODO: if we have a non-zero exit code is this expected?
             this.logger.log(`Sequence finished with ${exitcode} status`);
 
-            await this.client.disconnect();
             this.logger.log("Client disconnected");
         } catch (error) {
             this.logger.error("Error caught", error.stack);
@@ -230,8 +229,6 @@ class LifeCycleController implements IComponent {
             await this.lifecycleAdapterRun.cleanup();
 
             this.logger.error("Cleanup done (post error)");
-
-            await this.client.disconnect();
 
             this.scheduleExit(251, 50);
             return;


### PR DESCRIPTION
## Changes include:

### 1. Fixing Supervisor process not exiting
It turns out the supervisor process wasn't exiting after the sequence completion.
I don't know the precise cause yet, but probably some cleanup steps couldn't be completed because the communication channels were closed too soon.
I removed the code that closes communication channels from `LifecycleDockerAdapterInstance.main()` since it's already called in `.finally` block in the `supervisor.ts` script after `main` promise settles.

### 2. Fixing removing of instance
I also encountered strange code in host for removing instances so I fixed it too. 

### 3. Fixing BDD tests
* `Scenario: E2E-010 TC-015 Send event` was failing because the instance was removed after defer. It's possible that this test depended on instance being still available via API even after it ended it's execution.
* `Scenario: E2E-012 TC-002 Instance floods` - I couldn't find a connection with this PR. It may be that this test was just unstable because it assumed backpressure to be triggered after writing 1MB to stdout. Increasing this amount to 2MB gave me consistent  green results.

### 4. Adding BDD test for `health` command to output 404 after instance finished

### 5. Small refactor here and there