### PR TITLE
Fix DuplexStream not sending close event

### DIFF
--- a/packages/api-server/src/lib/duplex-stream.ts
+++ b/packages/api-server/src/lib/duplex-stream.ts
@@ -14,6 +14,9 @@ export class DuplexStream extends Duplex {
             this.push(d);
         });
 
+        this.input.on("close", () => this.destroy());
+        this.output.on("close", () => this.destroy());
+
         this.input.resume();
     }
 


### PR DESCRIPTION
I notice that even though the connection between CPM and STH is closed, the close event from DuplexStream was not emitted.
This fixes that, but I am not sure if that's the proper way that Duplex stream should communicate close events from it's I/O.