### PR TITLE
Fix E2E-004 TC-002 test by modifying event-sequence-2 ref app

### DIFF
--- a/packages/reference-apps/event-sequence-2/index.ts
+++ b/packages/reference-apps/event-sequence-2/index.ts
@@ -7,7 +7,7 @@ const exp: [ReadableApp<{a: number}, [], {x: number}>, WritableApp<{a: number}, 
      * @param _stream - dummy input
      * @returns data
      */
-    async function(_stream) {
+    async function*(_stream) {
         const data = this.initialState;
 
         let x = data?.x || 0;
@@ -16,13 +16,11 @@ const exp: [ReadableApp<{a: number}, [], {x: number}>, WritableApp<{a: number}, 
             console.log("-event sent and received-")
         );
 
-        return async function* () {
-            while (++x < 10) {
-                await new Promise(res => setTimeout(res, 1000));
+        while (++x < 10) {
+            await new Promise(res => setTimeout(res, 1000));
 
-                yield { a: x };
-            }
-        };
+            yield { a: x };
+        }
     },
     /**
      *


### PR DESCRIPTION
Tbh I am not entirely sure how this is a fix.
I was getting this error in runtime of this sequence:
```
2021-08-17T16:57:15.666Z error (object:Runner) Error occured during sequence execution:  TypeError: o[Symbol.iterator] is not a function
    at __asyncValues (/package/index.js:26:98)
    at RunnerAppContext.<anonymous> (/package/index.js:56:33)
    at Generator.next (<anonymous>)
    at /package/index.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/package/index.js:4:12)
    at RunnerAppContext.exp (/package/index.js:50:16)
    at Runner.<anonymous> (/app/runner/runner.js:365:32)
    at Generator.next (<anonymous>)
    at fulfilled (/app/runner/runner.js:5:58)
```

I suspected that it might be some bug with the way async generators are polyfilled.

Tests pass now though ✅

https://app.asana.com/0/1200747048063058/1200787625956059