### PR TITLE
Parametrise Content-Type in Runner's input stream

### DIFF
--- a/packages/api-client/src/instance-client.ts
+++ b/packages/api-client/src/instance-client.ts
@@ -103,8 +103,8 @@ export class InstanceClient {
         return this.clientUtils.sendStream(`${this.instanceURL}/${streamId}`, stream, options);
     }
 
-    async sendInput(stream: Stream | string) {
-        return this.sendStream("input", stream);
+    async sendInput(stream: Stream | string, options ?: SendStreamOptions) {
+        return this.sendStream("input", stream, options);
     }
 
     async sendStdin(stream: Stream | string) {

--- a/packages/api-server/src/handlers/stream.ts
+++ b/packages/api-server/src/handlers/stream.ts
@@ -80,12 +80,14 @@ export function createStreamHandlers(router: SequentialCeroRouter) {
     const downstream = (
         path: string | RegExp,
         stream: StreamOutput,
-        { json = false, text = false, end: _end = false, encoding = "utf-8" }: StreamConfig = {}
+        { json: _json = false, text: _text = false, end: _end = false, encoding = "utf-8" }: StreamConfig = {}
     ): void => {
         router.post(path, async (req, res, next) => {
             try {
 
-                checkAccepts(req.headers["content-type"], text, json);
+                // ASSUMPTION: we're not using content-type anywhere else besides validation
+                // @TODO fix it
+                // checkAccepts(req.headers["content-type"], text, json);
                 if (req.headers.expect === "100-continue") res.writeContinue();
 
                 const end = checkEndHeader(req, _end);

--- a/packages/api-server/src/handlers/stream.ts
+++ b/packages/api-server/src/handlers/stream.ts
@@ -80,14 +80,15 @@ export function createStreamHandlers(router: SequentialCeroRouter) {
     const downstream = (
         path: string | RegExp,
         stream: StreamOutput,
-        { json: _json = false, text: _text = false, end: _end = false, encoding = "utf-8" }: StreamConfig = {}
+        { json = false, text = false, end: _end = false, encoding = "utf-8", checkContentType = true }: StreamConfig = {}
     ): void => {
         router.post(path, async (req, res, next) => {
             try {
 
-                // ASSUMPTION: we're not using content-type anywhere else besides validation
-                // @TODO fix it
-                // checkAccepts(req.headers["content-type"], text, json);
+                if (checkContentType) {
+                    checkAccepts(req.headers["content-type"], text, json);
+                }
+
                 if (req.headers.expect === "100-continue") res.writeContinue();
 
                 const end = checkEndHeader(req, _end);

--- a/packages/cli/src/lib/commands/instance.ts
+++ b/packages/cli/src/lib/commands/instance.ts
@@ -75,12 +75,17 @@ export const instance: CommandDefinition = (program) => {
         });
 
     instanceCmd.command("input <id> [<file>]")
+        .option("-t, --content-type <value>", "Content-Type", "text/plain")
         .description("send file to input, if file not given the data will be read from stdin")
-        .action((id, stream) => {
+        .action((id, stream, { contentType }) => {
             const instanceClient = getInstance(program, id);
 
             return displayEntity(program,
-                instanceClient.sendInput(stream ? createReadStream(stream) : process.stdin));
+                instanceClient.sendInput(
+                    stream ? createReadStream(stream) : process.stdin,
+                    { type: contentType }
+                )
+            );
         });
 
     instanceCmd.command("output <id>")

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -255,7 +255,7 @@ export class CSIController extends EventEmitter {
             router.upstream("/output", this.upStreams[CommunicationChannel.OUT]);
 
 
-            router.downstream("/input", (req, res) => {
+            router.downstream("/input", (req) => {
                 const stream = this.upStreams![CommunicationChannel.IN];
                 const contentType = req.headers["content-type"];
 

--- a/packages/runner/src/input-stream.ts
+++ b/packages/runner/src/input-stream.ts
@@ -1,0 +1,85 @@
+import { BufferStream, DataStream, StringStream } from "scramjet";
+import { Readable } from "stream";
+
+function loopStream<T extends unknown>(
+    stream: Readable,
+    iter: (chunk: Buffer) => { action: "continue" } | { action: "end", data: T, unconsumedData?: Buffer }
+): Promise<T> {
+    return new Promise((res, rej) => {
+        const onReadable = () => {
+            let chunk;
+
+            while ((chunk = stream.read()) !== null) {
+                const result = iter(chunk);
+
+                if (result.action === "continue") {
+                    continue;
+                }
+
+                stream.off("error", rej);
+                stream.off("readable", onReadable);
+                if (result.unconsumedData?.length) {
+                    stream.unshift(result.unconsumedData);
+                }
+
+                res(result.data);
+                break;
+            }
+        };
+
+        stream.on("error", rej);
+
+        // run it in case readable was already triggered
+        onReadable();
+        stream.on("readable", onReadable);
+    });
+}
+
+const HEADERS_ENDING_SEQ = "\r\n\r\n";
+
+/**
+ *
+ * @param stream readable stream
+ * @returns object with header key/values (header names are lower case)
+ */
+export function readInputStreamHeaders(stream: Readable): Promise<Record<string, string>> {
+    let buffer = "";
+
+    return loopStream<Record<string, string>>(stream, (chunk) => {
+        const str = chunk.toString("utf-8");
+
+        buffer += str;
+        const headEndSeqIndex = buffer.indexOf(HEADERS_ENDING_SEQ);
+
+        if (headEndSeqIndex === -1) {
+            return { action: "continue" };
+        }
+        const rawHeaders = buffer.slice(0, headEndSeqIndex);
+        const bodyBeginning = buffer.slice(headEndSeqIndex + HEADERS_ENDING_SEQ.length);
+        const headersMap: Record<string, string> = rawHeaders
+            .split("\r\n")
+            .map(headerStr => headerStr.split(": "))
+            .reduce((obj, [key, val]) => ({ ...obj, [key.toLowerCase()]: val }), {});
+
+
+        return { action: "end", data: headersMap, unconsumedData: Buffer.from(bodyBeginning, "utf8") };
+    });
+}
+
+export function mapToInputDataStream(stream: Readable, contentType: string): DataStream {
+    if (contentType === undefined) {
+        throw new Error("Content-Type is undefined");
+    }
+
+    if (contentType.endsWith("x-ndjson")) {
+        return StringStream
+            .from(stream, { encoding: "utf-8" })
+            .JSONParse(true);
+    } else if (contentType === "text/plain") {
+        return StringStream.from(stream, { encoding: "utf-8" });
+    } else if (contentType === "application/octet-stream") {
+        return BufferStream.from(stream);
+    }
+
+    throw new Error(`Content-Type does not match any supported value. The actual value is ${contentType}`);
+}

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -248,11 +248,12 @@ export class Runner<X extends AppConfig> implements IComponent {
                 throw new Error("Content-Type is undefined");
             }
 
+            this.logger.log(`Content-Type: ${contentType}`);
+
             if (contentType.endsWith("x-ndjson")) {
                 this.inputDataStream = StringStream
                     .from(this.inputStream, { encoding: "utf-8" })
-                    .lines()
-                    .JSONParse();
+                    .JSONParse(true);
             } else if (contentType === "text/plain") {
                 this.inputDataStream = StringStream.from(this.inputStream, { encoding: "utf-8" });
             } else if (contentType === "application/octet-stream") {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -257,7 +257,7 @@ export class Runner<X extends AppConfig> implements IComponent {
             } else if (contentType === "text/plain") {
                 this.inputDataStream = StringStream.from(this.inputStream, { encoding: "utf-8" });
             } else if (contentType === "application/octet-stream") {
-                this.inputDataStream = DataStream.from(this.inputStream);
+                this.inputDataStream = BufferStream.from(this.inputStream);
             } else {
                 throw new Error(`Content-Type does not match any supported value. The actual value is ${contentType}`);
             }

--- a/packages/runner/test/runner.spec.ts
+++ b/packages/runner/test/runner.spec.ts
@@ -39,7 +39,7 @@ test("Run main", async (t: any) => {
         // eslint-disable-next-line no-console
         runner["loggerStream"] = new DataStream().each(console.log);
         runner["monitorStream"] = new Writable();
-        return Promise.resolve([undefined, undefined, undefined, undefined, undefined]);
+        return Promise.resolve([undefined, undefined, undefined, undefined]);
     });
     const sendHandshakeMessage = sinon.stub(runner, "sendHandshakeMessage");
 
@@ -83,7 +83,7 @@ test("Stop sequence", async (t: any) => {
         runner["inputStream"] = new Readable();
         runner["outputStream"] = new Writable();
 
-        return Promise.resolve([undefined, undefined, undefined, undefined, undefined]);
+        return Promise.resolve([undefined, undefined, undefined, undefined]);
     });
 
     sinon.stub(runner, "sendHandshakeMessage");

--- a/packages/types/src/api-expose.ts
+++ b/packages/types/src/api-expose.ts
@@ -38,6 +38,11 @@ export type StreamConfig = {
      * Encoding used in the stream
      */
     encoding?: BufferEncoding;
+
+    /**
+     * Perform stream content-type type checks
+     */
+    checkContentType?: boolean;
 };
 
 export interface APIError extends Error {


### PR DESCRIPTION
Changes include:

* Sending `Content-Type` header in Host to Runner's input stream
* Reading headers in Runner's input stream
* Mapping instance `inputDataStream` according to `Content-Type` value
* Enabling logger in Runner a bit sooner to catch logs from initialization
* Disabling `checkAccepts` to allow any Content-Type value in /input endpoint

https://app.asana.com/0/1200747048063058/1200808622558080