### PR TITLE
Fix runner not passing correct stream to next sequence fn.

### DIFF
--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -476,7 +476,7 @@ export class Runner<X extends AppConfig> implements IComponent {
 
                 out = func.call(
                     this.context,
-                    intermediate as unknown as ReadableStream<any>,
+                    stream,
                     ...args
                 );
 
@@ -512,7 +512,7 @@ export class Runner<X extends AppConfig> implements IComponent {
 
                 if (intermediate instanceof DataStream) {
                     stream = intermediate;
-                } else if (!isPrimitive(intermediate)) {
+                } else if (intermediate !== undefined && !isPrimitive(intermediate)) {
                     stream = DataStream.from(intermediate as Readable);
                 } else {
                     stream = undefined;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,8 +11,8 @@
     "experimentalDecorators": true,
     "sourceMap": true,
     "allowJs": true,
-    "target": "es6",
-    "lib": ["es7"],
+    "target": "es2019",
+    "lib": ["es2019", "es2020.promise", "es2020.bigint", "es2020.string"],
     "strict": true,
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
We were passing `intermediate` value to the next sequence function instead of `stream` which was wrapping iterable returned from the previous function into DataStream.

This fixes at least one BDD test: https://app.asana.com/0/1200747048063058/1200787625956059

Tbh it fixes every ref-app that contained at least 2 functions and the first one returned async generator.

Additionally to get rid of async generator polyfills which make debugging hard I bumped out TS target and lib to recommended values for node12 (https://www.npmjs.com/package/@tsconfig/node12)
