### PR TITLE
Stabilize event-sequence bdd test 

### DIFF
--- a/.github/workflows/sth-build-test.yml
+++ b/.github/workflows/sth-build-test.yml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-          cache: yarn
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -47,7 +46,7 @@ jobs:
 
       - name: Run BDD for HUB params
         run: yarn test:bdd-ci-no-host
-        
+
       - name: Run BDD tests
         run: yarn test:bdd-ci
 

--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -157,7 +157,7 @@ Feature: CLI tests
         When I execute CLI with "seq send ../packages/reference-apps/event-sequence.tar.gz --format json" arguments
         And the exit status is 0
         Then I get Sequence id
-        Then I start Sequence
+        Then I start Sequence with arguments "15"
         And the exit status is 0
         Then I get instance info
         Then I send an event named "test-event" with event message "test message" to Instance

--- a/bdd/step-definitions/e2e/cli.ts
+++ b/bdd/step-definitions/e2e/cli.ts
@@ -75,6 +75,21 @@ Then("I start Sequence", async function() {
     }
 });
 
+
+Then("I start Sequence with arguments {string}", async function(args) {
+    try {
+        stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "start", sequenceId, ...args.split(" "), ...formatFlags(), ...connectionFlags()]);
+        if (process.env.SCRAMJET_TEST_LOG) console.error(stdio[0]);
+        const instance = JSON.parse(stdio[0].replace("\n", ""));
+
+        instanceId = instance._id;
+    } catch (e) {
+        console.error(e.stack, stdio);
+        assert.fail("Error occurred");
+    }
+});
+
+
 Then("I get instance id", function() {
     assert.equal(typeof instanceId !== "undefined", true);
 });

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,8 +11,8 @@
     "experimentalDecorators": true,
     "sourceMap": true,
     "allowJs": true,
-    "target": "es2019",
-    "lib": ["es2019", "es2020.promise", "es2020.bigint", "es2020.string"],
+    "lib": ["es2020"],
+    "target": "es2020",
     "strict": true,
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
Changes include:
* Increasing execution time of event-sequence because by default it ends after 5 seconds and sometime it's not enough
* Adding cli-step for starting instance with arguments
* Bumping TS target to NodeJS 14 recommended settings