### PR TITLE
Send and get topic data with CLI

### DIFF
--- a/packages/cli/src/lib/commands/index.ts
+++ b/packages/cli/src/lib/commands/index.ts
@@ -5,11 +5,13 @@ import { host } from "./host";
 import { instance } from "./instance";
 import { pack } from "./pack";
 import { sequence } from "./sequence";
+import { topic } from "./topic";
 
 export const commands: CommandDefinition[] = [
     pack,
     host,
     config,
     sequence,
-    instance
+    instance,
+    topic
 ];

--- a/packages/cli/src/lib/commands/topic.ts
+++ b/packages/cli/src/lib/commands/topic.ts
@@ -1,0 +1,26 @@
+import { createReadStream } from "fs";
+import { CommandDefinition } from "../../types";
+import { getHostClient } from "../common";
+import { displayEntity, displayStream } from "../output";
+
+export const topic: CommandDefinition = (program) => {
+    const topicCmd = program
+        .command("topic [command]")
+        .description("operations on topic");
+
+    topicCmd.command("send <topic> [<file>]")
+        .option("-t, --content-type <value>", "Content-Type", "text/plain")
+        .description("send data to topic")
+        .action(async (topicName, stream, { contentType }) => displayEntity(
+            program,
+            getHostClient(program).sendNamedData(
+                topicName,
+                stream ? createReadStream(stream) : process.stdin,
+                contentType
+            )
+        ));
+
+    topicCmd.command("get <topic>")
+        .description("get data from topic")
+        .action(async (topicName) => displayStream(program, getHostClient(program).getNamedData(topicName)));
+};


### PR DESCRIPTION
send contents of data.json file to topic named "abc"
```si topic send abc data.json```

stdin will be used when filename is not provided 



get data from topic named "abc"
```si topic get abc```


