### PR TITLE
Support for 'x-end-stream' header in Service Discovery

### DIFF
--- a/packages/host/src/lib/sd-adapter.ts
+++ b/packages/host/src/lib/sd-adapter.ts
@@ -29,17 +29,17 @@ export class ServiceDiscovery {
         this.cpmConnector = cpmConnector;
     }
 
-    addData(outputStream: ReadableStream<any>, config: dataType, localProvider?: string) {
+    addData(outputStream: ReadableStream<any>, config: dataType, end: boolean, localProvider?: string) {
         this.logger.log("Adding data:", config);
 
         if (!this.dataMap.has(config.topic)) {
             this.dataMap.set(config.topic, {
                 contentType: config.contentType,
-                stream: outputStream.pipe(new PassThrough(), { end: false }),
+                stream: outputStream.pipe(new PassThrough(), { end: end }),
                 localProvider
             });
         } else {
-            outputStream.pipe(this.dataMap.get(config.topic)!.stream as WritableStream<any>, { end: false });
+            outputStream.pipe(this.dataMap.get(config.topic)!.stream as WritableStream<any>, { end: end });
         }
 
         if (localProvider) {
@@ -72,7 +72,7 @@ export class ServiceDiscovery {
         }
     }
 
-    getData(dataType: dataType, inputStream?: WritableStream<any>):
+    getData(dataType: dataType, end?: boolean, inputStream?: WritableStream<any>):
         ReadableStream<any> | WritableStream<any> | undefined {
         this.logger.log("Get data:", dataType);
 
@@ -105,9 +105,9 @@ export class ServiceDiscovery {
             return topicData?.stream;
         }
 
-        this.addData(new PassThrough(), dataType);
+        this.addData(new PassThrough(), dataType, end!);
 
-        return this.getData(dataType, inputStream);
+        return this.getData(dataType, end, inputStream);
     }
 
     removeData(topic: string) {


### PR DESCRIPTION
Service Discovery topic stream now supports specifying whether the stream ends using 'x-end-stream' header on SD API POST request.

To verify, please run STH, e.g. with ts-node:
`ts-node packages/sth/src/bin/hub.ts`

Send an example data to topic:
```
curl -X POST \
  'http://localhost:8000/api/v1/topic/names' \
  -H 'Accept: */*' \
  -H 'Content-Type: application/x-ndjson' \
  -H 'x-end-stream: false' \
  -d '{ "name": "a1" }
{ "name": "b2" }
{ "name": "c3" }
'
```
and try to receive them by executing:
`curl 0.0.0.0:8000/api/v1/topic/names -v`

You should notice that the returned stream did not end - it is waiting for potentially more incoming data. You can try to send more data with the above curl POST command and observe the stream is still passing the available data as they come.

Now please try to send data to topic with `'x-end-stream: true'`:
```
curl -X POST \
  'http://localhost:8000/api/v1/topic/names' \
  -H 'Accept: */*' \
  -H 'Content-Type: application/x-ndjson' \
  -H 'x-end-stream: true' \
  -d '{ "name": "a1" }
{ "name": "b2" }
{ "name": "c3" }
'
```

and try to receive it by executing again:
`curl 0.0.0.0:8000/api/v1/topic/names -v`

The stream should end after sending the topic data in response. 

Attached are the screen shots that demonstrate the two ways of sending topic data.
![Zrzut ekranu z 2021-09-19 13-30-18](https://user-images.githubusercontent.com/8177865/133926242-6e4e4ccb-ce59-4c22-b7b2-939911856d19.png)
![Zrzut ekranu z 2021-09-19 13-30-54](https://user-images.githubusercontent.com/8177865/133926251-afaa7923-44a2-4b72-bab5-eb7e7bd32a0c.png)


