### PR TITLE
Enable no-console eslint rule. 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,7 +18,7 @@
     "rules": {
         /* possible errors */
         "no-cond-assign" : 2,
-        // "no-console" : 2,
+        "no-console" : 2,
         "no-constant-condition" : 2,
         "no-control-regex" : 2,
         "no-debugger" : 2,

--- a/bdd/lib/host-utils.ts
+++ b/bdd/lib/host-utils.ts
@@ -43,6 +43,7 @@ export class HostUtils {
 
     async spawnHost() {
         if (this.hostUrl) {
+            // eslint-disable-next-line no-console
             console.error("Host is supposedly running at", this.hostUrl);
             const hostClient = new HostClient(this.hostUrl);
 
@@ -64,7 +65,10 @@ export class HostUtils {
 
             if (process.env.LOCAL_HOST_PORT) command.push("-P", process.env.LOCAL_HOST_PORT);
             if (process.env.LOCAL_HOST_SOCKET_PATH) command.push("-S", process.env.LOCAL_HOST_SOCKET_PATH);
-            if (process.env.SCRAMJET_TEST_LOG) console.error("Spawning with command:", ...command);
+            if (process.env.SCRAMJET_TEST_LOG) {
+                // eslint-disable-next-line no-console
+                console.error("Spawning with command:", ...command);
+            }
 
             this.host = spawn("/usr/bin/env", command);
 
@@ -86,6 +90,7 @@ export class HostUtils {
             });
 
             this.host.on("exit", (code, signal) => {
+                // eslint-disable-next-line no-console
                 console.log("sequence process exited with code: ", code, " and signal: ", signal);
                 this.hostProcessStopped = true;
 

--- a/bdd/lib/utils.ts
+++ b/bdd/lib/utils.ts
@@ -95,6 +95,7 @@ export async function streamToString(_stream: Readable): Promise<string> {
 
 export async function getOccurenceNumber(searchedValue: any, filePath: any) {
     try {
+        // eslint-disable-next-line no-console
         console.log(`${JSON.stringify(searchedValue)}`);
         return Number((await promisify(exec)(`sudo grep -oa ${JSON.stringify(searchedValue)}  ${filePath} | wc -l`)).stdout);
     } catch {
@@ -121,7 +122,10 @@ export async function removeFile(filePath: any) {
 export async function getStreamsFromSpawn(
     command: string, options: string[], env: NodeJS.ProcessEnv = process.env
 ): Promise<[string, string, any]> {
-    if (process.env.SCRAMJET_TEST_LOG) console.error("Spawning command", command, ...options);
+    if (process.env.SCRAMJET_TEST_LOG) {
+        // eslint-disable-next-line no-console
+        console.error("Spawning command", command, ...options);
+    }
 
     const child = spawn(command, options, {
         env
@@ -143,7 +147,11 @@ export async function getStreamsFromSpawnSuccess(
 ): Promise<[string, string]> {
     const [stdout, stderr, code] = await getStreamsFromSpawn(command, options, env);
 
-    if (process.env.SCRAMJET_TEST_LOG) console.error("Results", { stdout, stderr });
+    if (process.env.SCRAMJET_TEST_LOG) {
+        // eslint-disable-next-line no-console
+        console.error("Results", { stdout, stderr });
+    }
+
     if (code) throw new Error(`Non zero exit code: ${code}`);
 
     return [stdout, stderr];

--- a/bdd/step-definitions/e2e/cli.ts
+++ b/bdd/step-definitions/e2e/cli.ts
@@ -31,6 +31,7 @@ Then("I get a help information", function() {
 
 Then("the exit status is {int}", function(status: number) {
     if (stdio[2] !== status) {
+        // eslint-disable-next-line no-console
         console.error(stdio);
         assert.equal(stdio[2], status);
     }
@@ -61,11 +62,17 @@ Then("I get array of information about sequences", function() {
 Then("I start Sequence", async function() {
     try {
         stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "start", sequenceId, ...formatFlags(), ...connectionFlags()]);
-        if (process.env.SCRAMJET_TEST_LOG) console.error(stdio[0]);
+
+        if (process.env.SCRAMJET_TEST_LOG) {
+            // eslint-disable-next-line no-console
+            console.error(stdio[0]);
+        }
+
         const instance = JSON.parse(stdio[0].replace("\n", ""));
 
         instanceId = instance._id;
     } catch (e: any) {
+        // eslint-disable-next-line no-console
         console.error(e.stack, stdio);
         assert.fail("Error occurred");
     }

--- a/bdd/step-definitions/e2e/host-steps.ts
+++ b/bdd/step-definitions/e2e/host-steps.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 // eslint-disable-next-line no-extra-parens
 import { Given, When, Then, Before, BeforeAll, AfterAll } from "@cucumber/cucumber";
 import { strict as assert } from "assert";

--- a/bdd/step-definitions/performance-tests/delay-test-steps.ts
+++ b/bdd/step-definitions/performance-tests/delay-test-steps.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { strict as assert, fail } from "assert";
 import { When } from "@cucumber/cucumber";
 import { getOccurenceNumber, removeFile, getOccurenceFileNumber } from "../../lib/utils";

--- a/bdd/step-definitions/performance-tests/durability-tcp.ts
+++ b/bdd/step-definitions/performance-tests/durability-tcp.ts
@@ -35,7 +35,7 @@ Then("check every {int} seconds if instances respond with correct data for {floa
 
             await instance.sendEvent("check", hash);
 
-            console.log("SENT:", hash);
+            logger.log("SENT:", hash);
 
             await defer(500);
 
@@ -57,7 +57,7 @@ Then("check every {int} seconds if instances respond with correct data for {floa
                         .on("end", () => {
                             response = chunks.join("");
 
-                            console.log("RECV:", response);
+                            logger.log("RECV:", response);
                             if (response === hash) {
                                 resolve();
                             } else {

--- a/bdd/step-definitions/performance-tests/durability.ts
+++ b/bdd/step-definitions/performance-tests/durability.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { HostClient, InstanceClient } from "@scramjet/api-client";
 import { When, Then } from "@cucumber/cucumber";
 import { strict as assert } from "assert";

--- a/bdd/step-definitions/performance-tests/ports.ts
+++ b/bdd/step-definitions/performance-tests/ports.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { When } from "@cucumber/cucumber";
 import { InstanceClient, InstanceOutputStream } from "@scramjet/api-client";
 import * as net from "net";

--- a/packages/adapters/src/instance-adapter.ts
+++ b/packages/adapters/src/instance-adapter.ts
@@ -76,6 +76,7 @@ IComponent {
 
             exec(`mkfifo ${fifoPath}`, async (error) => {
                 if (error) {
+                    // eslint-disable-next-line no-console
                     console.error(`exec error: ${error}`);
                     reject(error);
                 }

--- a/packages/api-server/src/handlers/stream.ts
+++ b/packages/api-server/src/handlers/stream.ts
@@ -134,6 +134,7 @@ export function createStreamHandlers(router: SequentialCeroRouter) {
 
                 res.end();
             } catch (e: any) {
+                // eslint-disable-next-line no-console
                 console.error(e);
                 next(new CeroError("ERR_INTERNAL_ERROR", e));
             }

--- a/packages/cli/src/bin/index.ts
+++ b/packages/cli/src/bin/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env ts-node
+/* eslint-disable no-console */
 
 import { Command } from "commander";
 import { ClientError } from "@scramjet/api-client";

--- a/packages/cli/src/lib/commands/instance.ts
+++ b/packages/cli/src/lib/commands/instance.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { createReadStream } from "fs";
 import { CommandDefinition } from "../../types";
 import { attachStdio, getHostClient, getInstance } from "../common";
@@ -33,7 +34,9 @@ export const instance: CommandDefinition = (program) => {
 
     instanceCmd.command("status <id>")
         .description("status data about the instance")
-        .action(() => console.log("Not implemented"));
+        .action(() => {
+            console.log("Not implemented");
+        });
 
     instanceCmd.command("health <id>")
         .description("show the instance health status")

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -16,12 +16,14 @@ let currentConfig: Config;
 
 export const getConfig = () => {
     if (currentConfig) return currentConfig;
+
     if (existsSync(location)) {
         try {
             const overlay = JSON.parse(readFileSync(location, "utf-8"));
 
             return { ...defaultConfig, ...overlay } as Config;
         } catch {
+            // eslint-disable-next-line no-console
             console.error(`WARN: Parse error in config at ${location}.`);
         }
     }

--- a/packages/cli/src/lib/output.ts
+++ b/packages/cli/src/lib/output.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { Response, ResponseStream } from "@scramjet/api-client";
 import { Command } from "commander";
 

--- a/packages/host/src/bin/start.ts
+++ b/packages/host/src/bin/start.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env ts-node
+/* eslint-disable no-console */
 
 import { configService } from "@scramjet/sth-config";
 import { HostOptions } from "../lib/host";
@@ -8,6 +9,7 @@ const opts = require("minimist")(process.argv.slice(2));
 
 if (opts.h || opts.help || opts["?"]) {
     console.log(`Usage: ${process.argv[1]} [--identify-existing]`);
+
     process.exitCode = 1;
     process.exit();
 }

--- a/packages/host/src/lib/socket-server.ts
+++ b/packages/host/src/lib/socket-server.ts
@@ -118,7 +118,7 @@ export class SocketServer extends EventEmitter implements IComponent {
     close() {
         this.server?.close((err) => {
             if (err) {
-                console.error(err);
+                this.logger.error(err);
             }
         });
     }

--- a/packages/model/src/stream-handler.ts
+++ b/packages/model/src/stream-handler.ts
@@ -108,6 +108,7 @@ export class CommunicationHandler implements ICommunicationHandler {
 
     safeHandle(promisePotentiallyRejects: MaybePromise<any>): void {
         Promise.resolve(promisePotentiallyRejects).catch(
+            // eslint-disable-next-line no-console
             (e: any) => console.error(e?.stack || e) // TODO: push this to log file
         );
     }

--- a/packages/reference-apps/durability-preservation-tcp/index.ts
+++ b/packages/reference-apps/durability-preservation-tcp/index.ts
@@ -68,7 +68,7 @@ export = async function(_stream: any, ...args: any) {
     const stream = new StringStream();
     const files = args[1];
 
-    console.log(`Args: MemAlloc: ${allocMemSize}, Files: ${files}]`);
+    this.logger.log(`Args: MemAlloc: ${allocMemSize}, Files: ${files}]`);
 
     startServer(this.logger);
 
@@ -88,7 +88,7 @@ export = async function(_stream: any, ...args: any) {
                 });
             });
         } catch (err: any) {
-            console.log(err);
+            this.logger.log(err);
         }
     }, 1000);
 

--- a/packages/reference-apps/durability-preservation/index.ts
+++ b/packages/reference-apps/durability-preservation/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console, no-extra-parens */
 import * as http from "https";
 import { IncomingMessage } from "http";
 import { PassThrough } from "stream";
@@ -52,7 +53,6 @@ export = async function(_stream: any, allocMemSize: string, files: string[] = [
 
     setInterval(async () => {
         try {
-            // eslint-disable-next-line no-extra-parens
             (await Promise.all(
                 files.map(downloadFile)
             ) as IncomingMessage[]).map((file: IncomingMessage) => {

--- a/packages/reference-apps/endless-names-output/index.ts
+++ b/packages/reference-apps/endless-names-output/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { ReadableApp, SynchronousStreamable } from "@scramjet/types";
 import { PassThrough } from "stream";
 

--- a/packages/reference-apps/event-sequence-2/index.ts
+++ b/packages/reference-apps/event-sequence-2/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-loop-func */
+/* eslint-disable no-loop-func, no-console */
 
 import { ReadableApp, WritableApp } from "@scramjet/types";
 

--- a/packages/reference-apps/healthy-sequence/index.ts
+++ b/packages/reference-apps/healthy-sequence/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-loop-func */
+/* eslint-disable no-loop-func, no-console */
 import { InertApp } from "@scramjet/types";
 
 /**

--- a/packages/reference-apps/hello-alice-out/src/index.ts
+++ b/packages/reference-apps/hello-alice-out/src/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { ReadableApp } from "@scramjet/types";
 
 const scramjet = require("scramjet");
@@ -19,7 +20,6 @@ const mod: ReadableApp = function(_input, ffrom = `${__dirname}/data.json`) {
     return fs.createReadStream(ffrom)
         .on("end", () => {
             this.logger.info("File read end");
-            //this.end();
         })
         .pipe(JSONStream.parse("*"))
         .pipe(new scramjet.DataStream())

--- a/packages/reference-apps/hello-input-out/src/index.ts
+++ b/packages/reference-apps/hello-input-out/src/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console, no-extra-parens */
 import { Streamable, TransformApp } from "@scramjet/types";
 import { StringStream } from "scramjet";
 import { PassThrough } from "stream";
@@ -8,7 +9,7 @@ const mod: (TransformApp | { requires: string, contentType: string})[] = [
         const out = new PassThrough({ objectMode: true });
 
         console.log("Instance started");
-        // eslint-disable-next-line no-extra-parens
+
         (input as StringStream)
             .map((data: any) => "Name is: " + data.name + "\n")
             .pipe(out);

--- a/packages/reference-apps/inert-function/index.ts
+++ b/packages/reference-apps/inert-function/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-loop-func */
+/* eslint-disable no-loop-func, no-console */
 import { InertApp } from "@scramjet/types";
 
 /**

--- a/packages/reference-apps/inert-sequence-2/index.ts
+++ b/packages/reference-apps/inert-sequence-2/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-loop-func */
+/* eslint-disable no-loop-func, no-console */
 
 import { ReadableApp, WritableApp } from "@scramjet/types";
 

--- a/packages/reference-apps/inert-sequence-3/index.ts
+++ b/packages/reference-apps/inert-sequence-3/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-loop-func */
+/* eslint-disable no-loop-func, no-console */
 
 import { ReadableApp, TransformApp, WritableApp } from "@scramjet/types";
 

--- a/packages/reference-apps/multi-outputs/index.ts
+++ b/packages/reference-apps/multi-outputs/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { ReadableApp } from "@scramjet/types";
 import { PassThrough } from "stream";
 

--- a/packages/reference-apps/read-sequence-1/index.ts
+++ b/packages/reference-apps/read-sequence-1/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-loop-func */
+/* eslint-disable no-loop-func, no-console */
 
 import { ReadableApp } from "@scramjet/types";
 

--- a/packages/reference-apps/read-sequence-2/index.ts
+++ b/packages/reference-apps/read-sequence-2/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-loop-func */
+/* eslint-disable no-loop-func, no-console */
 
 import { ReadableApp, TransformApp } from "@scramjet/types";
 

--- a/packages/reference-apps/read-sequence-3/index.ts
+++ b/packages/reference-apps/read-sequence-3/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-loop-func */
+/* eslint-disable no-loop-func, no-console */
 
 import { ReadableApp, TransformApp } from "@scramjet/types";
 

--- a/packages/reference-apps/sequence-20s-kill-handler/index.ts
+++ b/packages/reference-apps/sequence-20s-kill-handler/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-loop-func */
+/* eslint-disable no-loop-func, no-console */
 
 import { ReadableApp, WritableApp } from "@scramjet/types";
 

--- a/packages/reference-apps/sequence-20s/index.ts
+++ b/packages/reference-apps/sequence-20s/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-loop-func */
+/* eslint-disable no-loop-func, no-console */
 
 import { ReadableApp, WritableApp } from "@scramjet/types";
 

--- a/packages/reference-apps/sequence-with-error/index.ts
+++ b/packages/reference-apps/sequence-with-error/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-loop-func */
+/* eslint-disable no-loop-func, no-console */
 import { InertApp } from "@scramjet/types";
 
 /**

--- a/packages/reference-apps/transform-sequence-1/index.ts
+++ b/packages/reference-apps/transform-sequence-1/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-loop-func */
+/* eslint-disable no-loop-func, no-console */
 
 import { TransformApp } from "@scramjet/types";
 
@@ -8,6 +8,7 @@ const exp: [
     (stream) => {
         return async function* () {
             console.log("Sequence returning generator.");
+
             for await (const a of stream) {
                 console.log("Sequence loop on stream. Value of chunk is ", a);
                 yield { b: a };

--- a/packages/reference-apps/unhealthy-sequence/index.ts
+++ b/packages/reference-apps/unhealthy-sequence/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-loop-func */
+/* eslint-disable no-loop-func, no-console */
 import { InertApp } from "@scramjet/types";
 
 /**

--- a/packages/reference-apps/write-function/index.ts
+++ b/packages/reference-apps/write-function/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-loop-func */
+/* eslint-disable no-loop-func, no-console */
 
 import { WritableApp } from "@scramjet/types";
 

--- a/packages/reference-apps/write-sequence-1/index.ts
+++ b/packages/reference-apps/write-sequence-1/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-loop-func */
+/* eslint-disable no-loop-func, no-console */
 
 import { WritableApp } from "@scramjet/types";
 

--- a/packages/reference-apps/write-sequence-2/index.ts
+++ b/packages/reference-apps/write-sequence-2/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-loop-func */
+/* eslint-disable no-loop-func, no-console */
 
 import { TransformApp, WritableApp } from "@scramjet/types";
 

--- a/packages/reference-apps/write-sequence-3/index.ts
+++ b/packages/reference-apps/write-sequence-3/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-loop-func */
+/* eslint-disable no-loop-func, no-console */
 
 import { TransformApp, WritableApp } from "@scramjet/types";
 

--- a/packages/sth/src/bin/hub.ts
+++ b/packages/sth/src/bin/hub.ts
@@ -47,6 +47,7 @@ require("@scramjet/host").startHost({}, configService.getConfig().host.socketPat
     identifyExisting: options.identifyExisting as boolean
 })
     .catch((e: Error & { exitCode?: number }) => {
+        // eslint-disable-next-line no-console
         console.error(e.stack);
         process.exitCode = e.exitCode || 1;
         process.exit();


### PR DESCRIPTION
`console` is not allowed anymore. 
Allow to use console in several files (ie, reference apps,)  
Use logger when possible