### PR TITLE
Add new test event sequence, remove some waits in bdd tests

### DIFF
--- a/bdd/features/e2e/E2E-004-event.feature
+++ b/bdd/features/e2e/E2E-004-event.feature
@@ -3,13 +3,12 @@ Feature: Event e2e tests
     @ci
     Scenario: E2E-004 TC-001 Send test-event through API and get event emitted by sequence
         Given host is running
-        When sequence "../packages/reference-apps/event-sequence.tar.gz" loaded
-        And instance started with arguments "10"
+        When sequence "../packages/reference-apps/event-sequence-v2.tar.gz" loaded
+        And instance started
         And wait for instance healthy is "true"
         And get containerId
         And send event "test-event" to instance with message "test message"
         Then wait for event "test-event-response" from instance
-        When wait for "1000" ms
         Then instance response body is "{\"eventName\":\"test-event-response\",\"message\":\"message from sequence\"}"
         And container is closed
         Then host is still running

--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -154,7 +154,7 @@ Feature: CLI tests
     @ci
     Scenario: E2E-010 TC-015 Send event
         Given host is running
-        When I execute CLI with "seq send ../packages/reference-apps/event-sequence.tar.gz --format json" arguments
+        When I execute CLI with "seq send ../packages/reference-apps/event-sequence-v2.tar.gz --format json" arguments
         And the exit status is 0
         Then I get Sequence id
         Then I start Sequence
@@ -162,7 +162,6 @@ Feature: CLI tests
         Then I get instance info
         Then I send an event named "test-event" with event message "test message" to Instance
         And the exit status is 0
-        And wait for "2000" ms
         Then I get event "test-event-response" with event message "{\"eventName\":\"test-event-response\",\"message\":\"message from sequence\"}" from instance
         And the exit status is 0
 

--- a/bdd/features/e2e/E2E-012-stream-flooding-test.feature
+++ b/bdd/features/e2e/E2E-012-stream-flooding-test.feature
@@ -3,18 +3,15 @@ Feature: Stream flooding tests. Ensure that even if a large amount of data is se
     @ci
     Scenario: E2E-012 TC-001 Flood stdin of Instance, do not consume it and check if Instance responds to event sent.
         Given host is running
-        When sequence "../packages/reference-apps/event-sequence.tar.gz" loaded
+        When sequence "../packages/reference-apps/event-sequence-v2.tar.gz" loaded
         And instance started with arguments "500"
         And wait for instance healthy is "true"
         And get containerId
         When flood the stdin stream with 11000 kilobytes
         And wait for "3000" ms
         And send event "test-event" to instance with message "test message"
-        And wait for "3000" ms
         Then get event "test-event-response" from instance
-        When wait for "1000" ms
         Then instance response body is "{\"eventName\":\"test-event-response\",\"message\":\"message from sequence\"}"
-        And send kill message to instance
         And container is closed
         Then host is still running
 

--- a/bdd/features/e2e/hub/HUB-001-host-config.feature
+++ b/bdd/features/e2e/hub/HUB-001-host-config.feature
@@ -47,7 +47,6 @@ Feature: Host configuration
         When hub process is started with parameters "-H 0.0.0.0"
         Then API starts with "0.0.0.0" server name
         * exit hub process
-        
 
     Scenario: HUB-001 TC-009  Set runner image (--runner-image)
         When hub process is started with parameters "--runner-image repo.int.scp.ovh/scramjet/runner:0.10.0-pre.7"
@@ -81,7 +80,7 @@ Feature: Host configuration
         When hub process is started with parameters "--prerunner-image repo.int.scp.ovh/scramjet/pre-runner:0.10.0-pre.7"
         And get all containers
         And send fake stream as sequence
-        And wait for "20000" ms
+        And wait for "5000" ms
         And get last container info
         And last container uses "repo.int.scp.ovh/scramjet/pre-runner:0.10.0-pre.7" image
         And end fake stream
@@ -92,7 +91,7 @@ Feature: Host configuration
         When hub process is started with parameters "--prerunner-max-mem 64"
         And get all containers
         And send fake stream as sequence
-        And wait for "20000" ms
+        And wait for "5000" ms
         And get last container info
         Then last container memory limit is 64
         And end fake stream

--- a/bdd/step-definitions/hub/config.ts
+++ b/bdd/step-definitions/hub/config.ts
@@ -72,9 +72,12 @@ Then("API starts with {string} server name", async function(this: CustomWorld, s
 
     assert.equal(status, 200);
 
-    const apiURL = this.resources.startOutput.match(/on: \s*(.*)/)[1];
+    const apiURL = this.resources.startOutput.match(/API listening on:\s*(.*)/)[1];
 
-    assert.equal(new RegExp(server).test(apiURL), true);
+    // eslint-disable-next-line no-console
+    console.log(`API is available on ${apiURL}`);
+
+    assert.ok(new RegExp(server).test(apiURL));
 });
 
 Then("exit hub process", function(this: CustomWorld) {

--- a/packages/reference-apps/event-sequence copy/tsconfig.json
+++ b/packages/reference-apps/event-sequence copy/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "outDir": "../event-sequence-v2/dist"
+  },
+  "extends": "../../../tsconfig.base.json",
+  "include": [
+    "../event-sequence-v2/index.ts"
+  ],
+  "exclude": [
+    "../event-sequence-v2/node_modules"
+  ],
+  "typedocOptions": {
+    "gitRevision": "HEAD"
+  }
+}

--- a/packages/reference-apps/event-sequence-v2/.eslintrc.js
+++ b/packages/reference-apps/event-sequence-v2/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+    ignorePatterns: [".eslintrc.js"],
+    parserOptions:{
+        project: "./tsconfig.json",
+        tsconfigRootDir: __dirname
+    }
+};

--- a/packages/reference-apps/event-sequence-v2/index.ts
+++ b/packages/reference-apps/event-sequence-v2/index.ts
@@ -1,0 +1,18 @@
+/* eslint-disable no-loop-func */
+import { InertApp } from "@scramjet/types";
+
+/**
+ * An inert app that is just a function (not wrapped)
+ *
+ * @param _stream - dummy input stream
+ * @param count - how many items to produce
+ */
+export = async function() {
+    await new Promise<void>(resolve => {
+        this.on("test-event", async () => {
+            this.emit("test-event-response", "message from sequence");
+            await new Promise(res => setTimeout(res, 1000));
+            resolve();
+        });
+    });
+} as InertApp;

--- a/packages/reference-apps/event-sequence-v2/package.json
+++ b/packages/reference-apps/event-sequence-v2/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@scramjet/event-sequence-v2",
+  "version": "0.12.1",
+  "description": "This sequnce responds for event, wait 1 sec and exits.",
+  "main": "index.js",
+  "scripts": {
+    "prepack": "node ../../../scripts/publish.js",
+    "build:refapps": "tsc -p tsconfig.json",
+    "postbuild:refapps": "yarn prepack",
+    "packseq": "node ../../../scripts/packsequence.js",
+    "clean": "rm -rf ./dist .bic_cache"
+  },
+  "author": "Scramjet <open-source@scramjet.org>",
+  "license": "ISC",
+  "devDependencies": {
+    "@scramjet/types": "^0.12.1",
+    "@types/node": "15.12.5"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scramjetorg/transform-hub.git"
+  }
+}

--- a/packages/reference-apps/event-sequence-v2/tsconfig.json
+++ b/packages/reference-apps/event-sequence-v2/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "extends": "../../../tsconfig.base.json",
+  "include": [
+    "./index.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ],
+  "typedocOptions": {
+    "gitRevision": "HEAD"
+  }
+}


### PR DESCRIPTION
New "event-sequence-v2" responds for event then exits after 1 second

observe checks to verify 