### PR TITLE
Flush header on upstream responses

### DIFF
--- a/packages/api-server/src/handlers/stream.ts
+++ b/packages/api-server/src/handlers/stream.ts
@@ -48,6 +48,7 @@ export function createStreamHandlers(router: SequentialCeroRouter) {
             res.setHeader("transfer-encoding", "chunked");
             res.setHeader("Access-Control-Allow-Origin", "*");
             res.writeHead(200);
+            res.flushHeaders();
 
             // Error handling on disconnect!
             const disconnect = () => out.unpipe(res);


### PR DESCRIPTION
Resolves following case:
```
13:54 $ curl -v http://127.0.0.1:8000/api/v1/instance/dc22b429-f404-4081-8fbf-efbf400d4fcb/log
*   Trying 127.0.0.1:8000...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 8000 (#0)
> GET /api/v1/instance/dc22b429-f404-4081-8fbf-efbf400d4fcb/log HTTP/1.1
> Host: 127.0.0.1:8000
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< content-type: application/octet-stream
< transfer-encoding: chunked
< Access-Control-Allow-Origin: *
< Date: Thu, 30 Sep 2021 13:55:13 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
< 
2021-09-30T13:54:55.266Z log (object:CSHClient) Log hooked up.
2021-09-30T13:54:55.267Z debug (obje
...
```
all data consumed 

next request - no data - no headers

```
curl -v http://127.0.0.1:8000/api/v1/instance/dc22b429-f404-4081-8fbf-efbf400d4fcb/log
*   Trying 127.0.0.1:8000...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 8000 (#0)
> GET /api/v1/instance/dc22b429-f404-4081-8fbf-efbf400d4fcb/log HTTP/1.1
> Host: 127.0.0.1:8000
> User-Agent: curl/7.68.0
> Accept: */*
> 
^C
```

https://nodejs.org/api/http.html#http_request_flushheaders

fetch will be pending with no headers received
Flushing headers resolves fetch with stream which can provide data much later

before this change
unsolved until any data has been sent
```
stream = (await instanceClient.getStream('log')).data;
```

after this change:
resolved immediately, data listeners can be attached





