### PR TITLE
Fix 422 when docker images are not pulled

### DIFF
--- a/packages/adapters/src/dockerode-docker-helper.ts
+++ b/packages/adapters/src/dockerode-docker-helper.ts
@@ -164,7 +164,7 @@ export class DockerodeDockerHelper implements IDockerHelper {
 
     private pulledImages: {[key: string]: Promise<void> | undefined } = {};
 
-    async pullImage(name: string, fetchOnlyIfNotExists: boolean) {
+    async pullImage(name: string, fetchOnlyIfNotExists = true) {
         if (fetchOnlyIfNotExists) {
             this.logger.log("Checking image", name);
 

--- a/packages/adapters/src/types.ts
+++ b/packages/adapters/src/types.ts
@@ -263,5 +263,5 @@ export interface IDockerHelper {
      * @param name the name of the image, eg. ubuntu:latest
      * @param fetchOnlyIfNotExists fetch only if not exists (defaults to true)
      */
-    pullImage(name: string, fetchOnlyIfNotExists: boolean): Promise<void>
+    pullImage(name: string, fetchOnlyIfNotExists?: boolean): Promise<void>
 }

--- a/packages/adapters/src/types.ts
+++ b/packages/adapters/src/types.ts
@@ -261,7 +261,7 @@ export interface IDockerHelper {
      * Fetches the image from repo
      *
      * @param name the name of the image, eg. ubuntu:latest
-     * @param ifNeeded fetch only if not exists (defaults to true)
+     * @param fetchOnlyIfNotExists fetch only if not exists (defaults to true)
      */
-    pullImage(name: string, ifNeeded: boolean): Promise<void>
+    pullImage(name: string, fetchOnlyIfNotExists: boolean): Promise<void>
 }


### PR DESCRIPTION
Fixed issue: #39 

The reason there wasn't an image in the local registry at the time of creating a container was that `dockerode.pull` does not resolve when the image is pulled, but when pull commands starts.

We had to make an additional wait for the pull command to finish.

Additionally I refactored `pullImage` method a bit.