### PR TITLE
Add /log endpoint for all instances logging

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -164,7 +164,9 @@
         "padded-blocks": [2, "never"],
         "padding-line-between-statements": [2,
             { "blankLine": "always", "prev": ["const", "let"], "next": "*" },
-            { "blankLine": "never", "prev": ["const"], "next": ["const"] },
+            // Function definitions using const should be able to have blankLines between them
+            // but variable definitions shouldn't so let's trust the programmer here ;)
+            { "blankLine": "any", "prev": ["const"], "next": ["const"] },
             { "blankLine": "never", "prev": ["let"], "next": ["let"] },
             { "blankLine": "always", "prev": "directive", "next": "*" },
             { "blankLine": "any", "prev": "directive", "next": "directive" }

--- a/.eslintrc
+++ b/.eslintrc
@@ -167,6 +167,7 @@
             // Function definitions using const should be able to have blankLines between them
             // but variable definitions shouldn't so let's trust the programmer here ;)
             { "blankLine": "any", "prev": ["const"], "next": ["const"] },
+            { "blankLine": "any", "prev": ["const", "let"], "next":["const", "let"] },
             { "blankLine": "never", "prev": ["let"], "next": ["let"] },
             { "blankLine": "always", "prev": "directive", "next": "*" },
             { "blankLine": "any", "prev": "directive", "next": "directive" }

--- a/packages/api-client/src/host-client.ts
+++ b/packages/api-client/src/host-client.ts
@@ -21,9 +21,8 @@ export class HostClient implements ClientProvider {
         return this.client.get("instances");
     }
 
-    // TODO: Dedicated log stream for host not yet implemented.
     async getLogStream() {
-        return this.client.getStream("stream/log");
+        return this.client.getStream("log");
     }
 
     async sendSequence(sequencePackage: Readable): Promise<SequenceClient> {

--- a/packages/cli/src/lib/commands/host.ts
+++ b/packages/cli/src/lib/commands/host.ts
@@ -1,6 +1,6 @@
 import { CommandDefinition } from "../../types";
 import { getHostClient } from "../common";
-import { displayEntity } from "../output";
+import { displayEntity, displayStream } from "../output";
 
 export const host: CommandDefinition = (program) => {
     const hostCmd = program
@@ -12,11 +12,10 @@ export const host: CommandDefinition = (program) => {
         .description("get version")
         .action(async () => displayEntity(program, getHostClient(program).getVersion()));
 
-    // response status 500
     hostCmd
         .command("logs")
-        .description("show all logs")
-        .action(async () => displayEntity(program, getHostClient(program).getLogStream()));
+        .description("show all instances logs")
+        .action(async () => displayStream(program, getHostClient(program).getLogStream()));
 
     hostCmd
         .command("load")

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -32,7 +32,8 @@
     "http-status-codes": "^2.1.4",
     "minimist": "^1.2.5",
     "scramjet": "^4.36.0",
-    "systeminformation": "^5.7.10"
+    "systeminformation": "^5.7.10",
+    "rereadable-stream": "^1.4.12"
   },
   "devDependencies": {
     "@scramjet/types": "^0.12.1",

--- a/packages/host/src/lib/common-logs-pipe.ts
+++ b/packages/host/src/lib/common-logs-pipe.ts
@@ -1,16 +1,6 @@
 import { ReReadable } from "rereadable-stream";
 import { Readable, Transform } from "stream";
 
-const colors = ["[31m", "[32m", "[33m", "[34m", "[35m", "[36m", "[37m"];
-
-const withColor = (txt: string, color: string) => `\x1b${color}${txt}\x1b[0m`;
-
-const colorizeId = (instanceId: string): string => {
-    const index = parseInt(instanceId.split("-")[0], 16) % colors.length;
-
-    return withColor(instanceId, colors[index]);
-};
-
 const prefixWithInstanceId = (instanceId: string) => new Transform({
     transform(chunk, encoding, done) {
         const chunkStr: string = chunk.toString("utf-8");
@@ -33,7 +23,7 @@ export class CommonLogsPipe {
 
     public addInStream(instanceId: string, stream: Readable): void {
         stream
-            .pipe(prefixWithInstanceId(colorizeId(instanceId)))
+            .pipe(prefixWithInstanceId(instanceId))
             .pipe(this.outStream, { end: false });
     }
 

--- a/packages/host/src/lib/common-logs-pipe.ts
+++ b/packages/host/src/lib/common-logs-pipe.ts
@@ -1,4 +1,5 @@
-import { PassThrough, Readable, Transform } from "stream";
+import { ReReadable } from "rereadable-stream";
+import { Readable, Transform } from "stream";
 
 const colors = ["[31m", "[32m", "[33m", "[34m", "[35m", "[36m", "[37m"];
 
@@ -22,7 +23,13 @@ const prefixWithInstanceId = (instanceId: string) => new Transform({
 });
 
 export class CommonLogsPipe {
-    private outStream = new PassThrough()
+    private outStream: ReReadable;
+
+    constructor(bufferLength = 1e6) {
+        this.outStream = new ReReadable({ length: bufferLength });
+        // drain the outStream so that it never pauses instances streams
+        this.outStream.rewind().resume();
+    }
 
     public addInStream(instanceId: string, stream: Readable): void {
         stream
@@ -31,6 +38,6 @@ export class CommonLogsPipe {
     }
 
     get out(): Readable {
-        return this.outStream;
+        return this.outStream.rewind();
     }
 }

--- a/packages/host/src/lib/common-logs-pipe.ts
+++ b/packages/host/src/lib/common-logs-pipe.ts
@@ -1,11 +1,21 @@
 import { PassThrough, Readable, Transform } from "stream";
 
+const colors = ["[31m", "[32m", "[33m", "[34m", "[35m", "[36m", "[37m"];
+
+const withColor = (txt: string, color: string) => `\x1b${color}${txt}\x1b[0m`;
+
+const colorizeId = (instanceId: string): string => {
+    const index = parseInt(instanceId.split("-")[0], 16) % colors.length;
+
+    return withColor(instanceId, colors[index]);
+};
+
 const prefixWithInstanceId = (instanceId: string) => new Transform({
     transform(chunk, encoding, done) {
         const chunkStr: string = chunk.toString("utf-8");
 
         chunkStr.trimEnd().split("\n").forEach((line: string) => {
-            this.push(instanceId + ": " + line);
+            this.push(colorizeId(instanceId) + ": " + line + "\n");
         });
         done();
     }

--- a/packages/host/src/lib/common-logs-pipe.ts
+++ b/packages/host/src/lib/common-logs-pipe.ts
@@ -15,7 +15,7 @@ const prefixWithInstanceId = (instanceId: string) => new Transform({
         const chunkStr: string = chunk.toString("utf-8");
 
         chunkStr.trimEnd().split("\n").forEach((line: string) => {
-            this.push(colorizeId(instanceId) + ": " + line + "\n");
+            this.push(instanceId + ": " + line + "\n");
         });
         done();
     }
@@ -26,7 +26,7 @@ export class CommonLogsPipe {
 
     public addInStream(instanceId: string, stream: Readable): void {
         stream
-            .pipe(prefixWithInstanceId(instanceId))
+            .pipe(prefixWithInstanceId(colorizeId(instanceId)))
             .pipe(this.outStream, { end: false });
     }
 

--- a/packages/host/src/lib/common-logs-pipe.ts
+++ b/packages/host/src/lib/common-logs-pipe.ts
@@ -1,0 +1,26 @@
+import { PassThrough, Readable, Transform } from "stream";
+
+const prefixWithInstanceId = (instanceId: string) => new Transform({
+    transform(chunk, encoding, done) {
+        const chunkStr: string = chunk.toString("utf-8");
+
+        chunkStr.trimEnd().split("\n").forEach((line: string) => {
+            this.push(instanceId + ": " + line);
+        });
+        done();
+    }
+});
+
+export class CommonLogsPipe {
+    private outStream = new PassThrough()
+
+    public addInStream(instanceId: string, stream: Readable): void {
+        stream
+            .pipe(prefixWithInstanceId(instanceId))
+            .pipe(this.outStream, { end: false });
+    }
+
+    get out(): Readable {
+        return this.outStream;
+    }
+}

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -15,7 +15,7 @@ import { ChildProcess, spawn } from "child_process";
 import { EventEmitter } from "events";
 import { resolve as resolvePath } from "path";
 import { DataStream } from "scramjet";
-import { PassThrough } from "stream";
+import { PassThrough, Readable } from "stream";
 import { configService, development } from "@scramjet/sth-config";
 import { Sequence } from "./sequence";
 import { ServerResponse } from "http";
@@ -372,20 +372,16 @@ export class CSIController extends EventEmitter {
         };
     }
 
-    getOutputStream(): ReadableStream<any> | undefined {
-        if (this.upStreams && this.upStreams[CC.OUT]) {
-            return this.upStreams[CC.OUT];
-        }
-
-        return undefined;
+    getOutputStream(): ReadableStream<any> | void {
+        return this.upStreams?.[CC.OUT];
     }
 
     getInputStream(): WritableStream<any> | void {
-        if (this.downStreams && this.downStreams[CC.IN]) {
-            return this.downStreams[CC.IN];
-        }
+        return this.downStreams?.[CC.IN];
+    }
 
-        return undefined;
+    getLogStream(): Readable | void {
+        return this.upStreams?.[CC.LOG];
     }
 
     async confirmInputHook(): Promise<void> {

--- a/packages/host/test/common-logs-pipe.spec.ts
+++ b/packages/host/test/common-logs-pipe.spec.ts
@@ -1,0 +1,93 @@
+import { DataStream } from "scramjet";
+import { PassThrough } from "stream";
+import { CommonLogsPipe } from "../src/lib/common-logs-pipe";
+import test from "ava";
+
+const lineLength = 20;
+const numberOfLogs = 1e4;
+const highWaterMark = lineLength * numberOfLogs / 4;
+const commonLogsBufferLength = numberOfLogs / 4;
+
+test("10k logs pauses instances streams if commonLogsPipe is a PassThrough", async (t) => {
+    const commonLogsPipe = { outStream: new PassThrough({ highWaterMark }) };
+
+    const instances = [new PassThrough(), new PassThrough()];
+
+    instances.forEach((instance, index) => {
+        instance.on("data", (data) => /* consume data */ data);
+        CommonLogsPipe.prototype.addInStream.call(commonLogsPipe, `${index}-${index}`, instance);
+    });
+
+    await DataStream.from(async function* () {
+        let i = 0;
+
+        while (i < numberOfLogs) {
+            yield ++i;
+        }
+    })
+        .do((index) => {
+            instances.forEach(instance => {
+                instance.write(`Log ${index}`);
+            });
+        })
+        .run();
+
+    t.assert(instances.every(instance => instance.isPaused() === true));
+});
+
+test("10k logs does not pause instances streams", async (t) => {
+    const commonLogsPipe = new CommonLogsPipe(commonLogsBufferLength);
+
+    const instances = [new PassThrough(), new PassThrough()];
+
+    instances.forEach((instance, index) => {
+        instance.on("data", (data) => /* consume data */ data);
+        commonLogsPipe.addInStream(`${index}-${index}`, instance);
+    });
+
+    await DataStream.from(async function* () {
+        let i = 0;
+
+        while (i < numberOfLogs) {
+            yield ++i;
+        }
+    })
+        .do((index) => {
+            instances.forEach(instance => {
+                instance.write(`Log ${index}`);
+            });
+        })
+        .run();
+
+    t.assert(instances.every(instance => instance.isPaused() === false));
+});
+
+test("instances streams will automatically resume after a pause", async (t) => {
+    const commonLogsPipe = new CommonLogsPipe(1e3);
+
+    const instances = [new PassThrough(), new PassThrough()];
+
+    instances.forEach((instance, index) => {
+        instance.on("data", (data) => /* consume data */ data);
+        // THIS NEVER GETS CALLED
+        instance.on("pause", () => console.log(`pause ${index}`));
+        instance.on("resume", () => console.log(`resume ${index}`));
+        commonLogsPipe.addInStream(`${index}-${index}`, instance);
+    });
+
+    await DataStream.from(async function* () {
+        let i = 0;
+
+        while (i < 1e4) {
+            yield ++i;
+        }
+    })
+        .do((index) => {
+            instances.forEach(instance => {
+                instance.write(`Log ${index}`);
+            });
+        })
+        .run();
+
+    t.assert(instances.every(instance => instance.isPaused() === false));
+});

--- a/packages/host/test/common-logs-pipe.spec.ts
+++ b/packages/host/test/common-logs-pipe.spec.ts
@@ -6,38 +6,11 @@ import test from "ava";
 
 const lineLength = 20;
 const numberOfLogs = 1e4;
-const highWaterMark = lineLength * numberOfLogs / 4;
-const commonLogsBufferLength = numberOfLogs / 4;
+const highWaterMark = lineLength * numberOfLogs / 1000;
+const commonLogsBufferLength = numberOfLogs / 1000;
 
 test("10k logs pauses instances streams if commonLogsPipe is a PassThrough", async (t) => {
     const commonLogsPipe = { outStream: new PassThrough({ highWaterMark }) };
-
-    const instances = [new PassThrough(), new PassThrough()];
-
-    instances.forEach((instance, _index) => {
-        instance.on("data", (data) => /* consume data */ data);
-        instance.pipe(commonLogsPipe.outStream);
-    });
-
-    await DataStream.from(async function* () {
-        let i = 0;
-
-        while (i < numberOfLogs) {
-            yield ++i;
-        }
-    })
-        .do((index) => {
-            instances.forEach(instance => {
-                instance.write(`Log ${index}`);
-            });
-        })
-        .run();
-
-    t.assert(instances.every(instance => instance.isPaused() === true));
-});
-
-test("10k logs pauses instances streams if commonLogsPipe is a PassThrough", async (t) => {
-    const commonLogsPipe = { outStream: new PassThrough({ highWaterMark: 10, objectMode: true }) };
 
     const instances = [new PassThrough(), new PassThrough()];
 

--- a/packages/host/test/common-logs-pipe.spec.ts
+++ b/packages/host/test/common-logs-pipe.spec.ts
@@ -67,11 +67,12 @@ test("instances streams will automatically resume after a pause", async (t) => {
 
     const instances = [new PassThrough(), new PassThrough()];
 
+    const areStreamsPaused = [false, false];
+
     instances.forEach((instance, index) => {
         instance.on("data", (data) => /* consume data */ data);
-        // THIS NEVER GETS CALLED
-        instance.on("pause", () => console.log(`pause ${index}`));
-        instance.on("resume", () => console.log(`resume ${index}`));
+        instance.on("pause", () => { areStreamsPaused[index] = true; });
+        instance.on("resume", () => { areStreamsPaused[index] = false; });
         commonLogsPipe.addInStream(`${index}-${index}`, instance);
     });
 
@@ -90,4 +91,5 @@ test("instances streams will automatically resume after a pause", async (t) => {
         .run();
 
     t.assert(instances.every(instance => instance.isPaused() === false));
+    t.assert(areStreamsPaused.every(isPaused => isPaused === false));
 });

--- a/packages/host/test/common-logs-pipe.spec.ts
+++ b/packages/host/test/common-logs-pipe.spec.ts
@@ -9,7 +9,7 @@ const numberOfLogs = 1e4;
 const highWaterMark = lineLength * numberOfLogs / 4;
 const commonLogsBufferLength = numberOfLogs / 4;
 
-test("WORKING: 10k logs pauses instances streams if commonLogsPipe is a PassThrough", async (t) => {
+test("10k logs pauses instances streams if commonLogsPipe is a PassThrough", async (t) => {
     const commonLogsPipe = { outStream: new PassThrough({ highWaterMark }) };
 
     const instances = [new PassThrough(), new PassThrough()];
@@ -36,8 +36,8 @@ test("WORKING: 10k logs pauses instances streams if commonLogsPipe is a PassThro
     t.assert(instances.every(instance => instance.isPaused() === true));
 });
 
-test("NOT WORKING: 10k logs pauses instances streams if commonLogsPipe is a PassThrough", async (t) => {
-    const commonLogsPipe = { outStream: new PassThrough({ highWaterMark }) };
+test("10k logs pauses instances streams if commonLogsPipe is a PassThrough", async (t) => {
+    const commonLogsPipe = { outStream: new PassThrough({ highWaterMark: 10, objectMode: true }) };
 
     const instances = [new PassThrough(), new PassThrough()];
 

--- a/packages/model/src/stream-handler.ts
+++ b/packages/model/src/stream-handler.ts
@@ -61,7 +61,7 @@ export class CommunicationHandler implements ICommunicationHandler {
     upstreams?: UpstreamStreamsConfig;
     downstreams?: DownstreamStreamsConfig;
 
-    private loggerPassthough: PassThoughStream<string>;
+    private loggerPassThrough: PassThoughStream<string>;
     private controlPassThrough: DataStream;
     private monitoringPassThrough: DataStream;
 
@@ -76,7 +76,7 @@ export class CommunicationHandler implements ICommunicationHandler {
     constructor() {
         this.controlPassThrough = new DataStream();
         this.monitoringPassThrough = new DataStream();
-        this.loggerPassthough = new PassThrough();
+        this.loggerPassThrough = new PassThrough();
         this.controlHandlerHash = {
             [RunnerMessageCode.FORCE_CONFIRM_ALIVE]: [],
             [RunnerMessageCode.KILL]: [],
@@ -148,7 +148,7 @@ export class CommunicationHandler implements ICommunicationHandler {
             throw new Error("Streams not hooked");
         }
 
-        this.downstreams[CC.LOG].pipe(this.loggerPassthough, { end: false }).pipe(this.upstreams[CC.LOG]);
+        this.downstreams[CC.LOG].pipe(this.loggerPassThrough, { end: false }).pipe(this.upstreams[CC.LOG]);
 
         const monitoringOutput = StringStream.from(this.downstreams[CC.MONITORING] as Readable)
             .JSONParse()
@@ -205,7 +205,7 @@ export class CommunicationHandler implements ICommunicationHandler {
     }
 
     getLogOutput(): LoggerOutput {
-        return { out: this.loggerPassthough, err: this.loggerPassthough };
+        return { out: this.loggerPassThrough, err: this.loggerPassThrough };
     }
 
     pipeStdio(): this {

--- a/packages/types/src/communication-handler.ts
+++ b/packages/types/src/communication-handler.ts
@@ -40,8 +40,7 @@ export interface ICommunicationHandler {
      */
     getMonitorStream(): DataStream;
     /**
-     * @TODO below statement is possibly untrue
-     * Returns a copy of log stream for reading - does not interact with the fifo stream itself
+     * Returns a copy of log stream for writing
      */
     getLogOutput(): LoggerOutput;
 

--- a/packages/types/src/communication-handler.ts
+++ b/packages/types/src/communication-handler.ts
@@ -40,6 +40,7 @@ export interface ICommunicationHandler {
      */
     getMonitorStream(): DataStream;
     /**
+     * @TODO below statement is possibly untrue
      * Returns a copy of log stream for reading - does not interact with the fifo stream itself
      */
     getLogOutput(): LoggerOutput;

--- a/packages/types/src/communication-handler.ts
+++ b/packages/types/src/communication-handler.ts
@@ -40,7 +40,7 @@ export interface ICommunicationHandler {
      */
     getMonitorStream(): DataStream;
     /**
-     * Returns a copy of log stream for writing
+     * Returns log stream for writing
      */
     getLogOutput(): LoggerOutput;
 


### PR DESCRIPTION
Changes include:

- New endpoint '/logs' that streams all instances logs
- Introducing new class `CommonLogsPipe` which encapsulates accumulated logging from all instances
- Small refactor

@TODO remove the todo from the changes in this PR before merging it :wink: 

### Verify
1. Build everything and install cli: `npm install -g dist/cli`
2. Run sth
3. Run `si host logs`
4. Send and start a sequence twice
5. Watch some pretty logs from both instances showing up in your terminal