### PR TITLE
Fix sending logs to CPM

### DIFF
--- a/packages/api-client/src/types/index.ts
+++ b/packages/api-client/src/types/index.ts
@@ -8,7 +8,7 @@ export type Response = {
 };
 
 export type ResponseStream = {
-    data?: Stream;
+    data?: NodeJS.ReadableStream;
     status: number | undefined;
 };
 

--- a/packages/host/src/lib/cpm-connector.ts
+++ b/packages/host/src/lib/cpm-connector.ts
@@ -143,8 +143,7 @@ export class CPMConnector extends EventEmitter {
                         this.emit("connect");
                         this.setLoadCheckMessageSender();
                     } else if (mSocket._chan === 1) {
-                        const logStream = StringStream.from(mSocket)
-                            .catch((err: Error) => this.logger.error(err.message));
+                        const logStream = mSocket.on("error", (err: Error) => this.logger.error(err.message));
 
                         this.emit("log_connect", logStream);
                     } else {


### PR DESCRIPTION
Changes include:
* Adjusting type of data in ReponseStream to be able to read the stream (NodeJS.ReadableStream is actually what fetch returns in body)
* Handling errors on logStream using just error event listener (previous approach with wrapping it in StringStream for some reason was blocking the logStream) 