### PR TITLE
Reduce size of Common Logs Pipe buffer

### DIFF
--- a/packages/host/src/lib/common-logs-pipe.ts
+++ b/packages/host/src/lib/common-logs-pipe.ts
@@ -6,7 +6,7 @@ import { StringStream } from "scramjet";
 export class CommonLogsPipe {
     private pipe: ReReadable;
 
-    constructor(bufferLength = 1e6) {
+    constructor(bufferLength = 1e5) {
         this.pipe = new ReReadable({ length: bufferLength });
         // drain the outStream so that it never pauses the participating inStreams from instances
         this.pipe.rewind().resume();


### PR DESCRIPTION
Change default buffer length to prevent memory overload.