### PR TITLE
Disable quotes rule in bdd expected responses

### DIFF
--- a/bdd/step-definitions/e2e/expectedResponses.ts
+++ b/bdd/step-definitions/e2e/expectedResponses.ts
@@ -1,3 +1,4 @@
+/* eslint-disable quote-props */
 /* eslint-disable quotes */
 export const expectedResponses: { [key:string]: any} = {
     "endless-names-10": `{"name":"Alice"}\n{"name":"Ada"}\n{"name":"Aga"}\n{"name":"Michał"}\n{"name":"Patryk"}\n{"name":"Rafał"}\n{"name":"Aida"}\n{"name":"Basia"}\n{"name":"Natalia"}\n{"name":"Monika"}\n{"name":"Wojtek"}\n`,


### PR DESCRIPTION
disable warning for 

> Check warning on line 6 in bdd/step-definitions/e2e/expectedResponses.ts

> GitHub Actions
> / Analyze the source code (14.x)
> bdd/step-definitions/e2e/expectedResponses.ts#L6
> Unnecessarily quoted property 'hulkName' found