### PR TITLE
Fix version: unknown

### DIFF
--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -23,7 +23,7 @@ import { configService } from "@scramjet/sth-config";
 import { constants } from "fs";
 import { loadCheck } from "@scramjet/load-check";
 
-const version = findPackage().next().value?.version || "unknown";
+const version = findPackage(__dirname).next().value?.version || "unknown";
 const exists = (dir: string) => access(dir, constants.F_OK).then(() => true, () => false);
 
 export type HostOptions = Partial<{


### PR DESCRIPTION
Resolves following
Starting STH with ```sth``` command from outside it's module directory caused looking for package.json in wrong place on fs.

```curl localhost:8000/api/v1/version```

before fix
```{"version":"unknown"}```

with this change:
```{"version":"0.12.2"}```

