### PR TITLE
Add instance adapter exit delay to sth config

### DIFF
--- a/packages/adapters/src/instance-adapter.ts
+++ b/packages/adapters/src/instance-adapter.ts
@@ -1,4 +1,4 @@
-import { development } from "@scramjet/sth-config";
+import { development, configService } from "@scramjet/sth-config";
 import { getLogger } from "@scramjet/logger";
 import { DelayedStream, SupervisorError } from "@scramjet/model";
 import {
@@ -293,7 +293,7 @@ IComponent {
 
             this.logger.log("Container exited.");
 
-            await defer(10000);
+            await defer(configService.getConfig().instanceAdapterExitDelay);
 
             if (statusCode > 0) {
                 throw new SupervisorError("RUNNER_NON_ZERO_EXITCODE", { statusCode });
@@ -331,13 +331,13 @@ IComponent {
 
     // returns url identifier of made snapshot
     // @ts-ignore
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     snapshot(): MaybePromise<string> {
+        /** ignore */
     }
 
     // @ts-ignore
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    monitorRate(rps: number): this {
+    monitorRate(_rps: number): this {
+        /** ignore */
     }
 
     async remove() {

--- a/packages/sth-config/src/config-service.ts
+++ b/packages/sth-config/src/config-service.ts
@@ -29,7 +29,8 @@ const defaultConfig: STHConfiguration = {
         cpuLoad: 10,
         freeSpace: 128
     },
-    safeOperationLimit: 512
+    safeOperationLimit: 512,
+    instanceAdapterExitDelay: 9000
 };
 
 class ConfigService {

--- a/packages/types/src/sth-configuration.ts
+++ b/packages/types/src/sth-configuration.ts
@@ -3,8 +3,9 @@ export type ContainerConfiguration = {
      * Docker image to use.
      */
     image: string;
+
     /**
-     * Maximum memory container can allocate (megabytes)
+     * Maximum memory container can allocate (megabytes).
      */
     maxMem: number;
 }
@@ -21,9 +22,19 @@ export type ContainerConfigurationWithExposedPorts = {
     exposePortsRange: [number, number]
 }
 
+/**
+ * PreRunner container configuraion.
+ */
 export type PreRunnerContainerConfiguration = ContainerConfiguration;
+
+/**
+ * Runner container configuration.
+ */
 export type RunnerContainerConfiguration = ContainerConfiguration & ContainerConfigurationWithExposedPorts;
 
+/**
+ * Host process configuration.
+ */
 export type HostConfig = {
     /**
      * Hostname.
@@ -57,13 +68,23 @@ export type HostConfig = {
 }
 
 export type STHConfiguration = {
+    /**
+     * CPM url.
+     */
     cpmUrl: string;
 
     /**
      * Docker related configuration.
      */
     docker: {
+        /**
+         * PreRunner container configuration.
+         */
         prerunner: PreRunnerContainerConfiguration,
+
+        /**
+         * Runner container configuration.
+         */
         runner: RunnerContainerConfiguration,
     },
 
@@ -72,15 +93,20 @@ export type STHConfiguration = {
      */
     host: HostConfig;
 
+    /**
+     * Minimum requirements to start new instance.
+     */
     instanceRequirements: {
         /**
          * Free memory required to start instance. In megabytes.
          */
         freeMem: number;
+
         /**
          * Required free CPU. In percentage.
          */
         cpuLoad: number;
+
         /**
          * Free disk space required to start instance. In megabytes.
          */
@@ -93,7 +119,13 @@ export type STHConfiguration = {
     safeOperationLimit: number;
 
     /**
-     * Should we identify existing sequences
+     * Should we identify existing sequences.
      */
     identifyExisting: boolean;
+
+    /**
+     * Time to wait after Runner container exit.
+     * In this additional time instance API is still available.
+     */
+    instanceAdapterExitDelay: number;
 }


### PR DESCRIPTION
Delay between docker runner container exit and  docker instance adapter exit. Allows to connect to instance api after instance end within this time. 

Hardcoded value moved to sth-config