### PR TITLE
CI BDD tests with --no-docker mode

### DIFF
--- a/.github/workflows/sth-build-test.yml
+++ b/.github/workflows/sth-build-test.yml
@@ -365,7 +365,7 @@ jobs:
         run: ls dist*tar.gz |xargs -n1 tar -I pigz -xf
 
       - name: Load Docker images
-        run: ls -1  docker*Img*.tar| while read line; do docker load -i $line; done
+        run: docker load -i dockerSthImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar
 
       - name: Setup Nodejs ${{ matrix.node-version }}
         uses: actions/setup-node@v2

--- a/.github/workflows/sth-build-test.yml
+++ b/.github/workflows/sth-build-test.yml
@@ -409,7 +409,7 @@ jobs:
             name: dockerSthImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
 
         - name: Unzip dockerImg-${{ github.event.pull_request.head.sha }}-${{ matrix.node-version }}.tar.gz artifact
-          run: pigz -d docker*Img*.tar.gz
+          run: pigz -d pigz -d dockerSthImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
 
         - name: Unzip dist-${{ github.event.pull_request.head.sha }}-${{ matrix.node-version }}.tar.gz artifact
           run: ls dist*tar.gz |xargs -n1 tar -I pigz -xf

--- a/.github/workflows/sth-build-test.yml
+++ b/.github/workflows/sth-build-test.yml
@@ -359,7 +359,7 @@ jobs:
           name: dockerSthImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
 
       - name: Unzip dockerImg-${{ github.event.pull_request.head.sha }}-${{ matrix.node-version }}.tar.gz artifact
-        run: pigz -d pigz -d dockerSthImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
+        run: pigz -d dockerSthImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
 
       - name: Unzip dist-${{ github.event.pull_request.head.sha }}-${{ matrix.node-version }}.tar.gz artifact
         run: ls dist*tar.gz |xargs -n1 tar -I pigz -xf
@@ -373,7 +373,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Run BDD for HUB params
-        run: NO_DOCKER=1 SCRAMJET_TEST_LOG=1 yarn test:bdd-ci-no-host
+        run: SCRAMJET_TEST_LOG=1 yarn test:bdd-ci-no-host-no-docker
 
 
   test-bdd-ci-sth-no-docker:
@@ -409,7 +409,7 @@ jobs:
             name: dockerSthImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
 
         - name: Unzip dockerImg-${{ github.event.pull_request.head.sha }}-${{ matrix.node-version }}.tar.gz artifact
-          run: pigz -d pigz -d dockerSthImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
+          run: pigz -d dockerSthImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
 
         - name: Unzip dist-${{ github.event.pull_request.head.sha }}-${{ matrix.node-version }}.tar.gz artifact
           run: ls dist*tar.gz |xargs -n1 tar -I pigz -xf
@@ -423,5 +423,5 @@ jobs:
             node-version: ${{ matrix.node-version }}
 
         - name: Run BDD tests
-          run: NO_DOCKER=1 SCRAMJET_TEST_LOG=1 yarn test:bdd-ci
+          run: SCRAMJET_TEST_LOG=1 yarn test:bdd-ci-no-docker
 

--- a/.github/workflows/sth-build-test.yml
+++ b/.github/workflows/sth-build-test.yml
@@ -359,7 +359,7 @@ jobs:
           name: dockerSthImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
 
       - name: Unzip dockerImg-${{ github.event.pull_request.head.sha }}-${{ matrix.node-version }}.tar.gz artifact
-        run: pigz -d docker*Img*.tar.gz
+        run: pigz -d pigz -d dockerSthImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
 
       - name: Unzip dist-${{ github.event.pull_request.head.sha }}-${{ matrix.node-version }}.tar.gz artifact
         run: ls dist*tar.gz |xargs -n1 tar -I pigz -xf

--- a/.github/workflows/sth-build-test.yml
+++ b/.github/workflows/sth-build-test.yml
@@ -415,7 +415,7 @@ jobs:
           run: ls dist*tar.gz |xargs -n1 tar -I pigz -xf
 
         - name: Load Docker images
-          run: ls -1  docker*Img*.tar| while read line; do docker load -i $line; done
+          run: docker load -i dockerSthImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar
 
         - name: Setup Nodejs ${{ matrix.node-version }}
           uses: actions/setup-node@v2

--- a/.github/workflows/sth-build-test.yml
+++ b/.github/workflows/sth-build-test.yml
@@ -326,3 +326,122 @@ jobs:
       - name: Run BDD tests
         run: SCRAMJET_TEST_LOG=1 yarn test:bdd-ci
 
+  test-bdd-ci-no-host-no-docker-sth:
+    name: Test bdd-ci-no-host-no-docker STH (Nodejs ${{ matrix.node-version }})
+    needs: [analyze-code, build-sth, build-refapps, build-docker-sth-image, build-docker-runner-image, build-docker-pre-runner-image]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    strategy:
+      fail-fast: true
+      matrix:
+        node-version: [14.x, 16.x]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --silent
+
+      - name: Download dist-sth-${{ github.event.pull_request.head.sha }}-${{ matrix.node-version }}.tar.gz artifact 
+        uses: actions/download-artifact@v2
+        with:
+          name: dist-sth-${{ github.event.pull_request.head.sha }}-${{ matrix.node-version }}.tar.gz
+
+      - name: Download dist-refapps-${{ github.event.pull_request.head.sha }}-${{ matrix.node-version }}.tar.gz artifact 
+        uses: actions/download-artifact@v2
+        with:
+          name: dist-refapps-${{ github.event.pull_request.head.sha }}-${{ matrix.node-version }}.tar.gz
+
+      - name: Download dockerSthImg artifact 
+        uses: actions/download-artifact@v2
+        with:
+          name: dockerSthImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
+
+      - name: Download dockerImg artifact 
+        uses: actions/download-artifact@v2
+        with:
+          name: dockerRunnerImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
+
+      - name: Download dockerPreRunnerImg artifact 
+        uses: actions/download-artifact@v2
+        with:
+          name: dockerPreRunnerImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
+
+      - name: Unzip dockerImg-${{ github.event.pull_request.head.sha }}-${{ matrix.node-version }}.tar.gz artifact
+        run: pigz -d docker*Img*.tar.gz
+
+      - name: Unzip dist-${{ github.event.pull_request.head.sha }}-${{ matrix.node-version }}.tar.gz artifact
+        run: ls dist*tar.gz |xargs -n1 tar -I pigz -xf
+
+      - name: Load Docker images
+        run: ls -1  docker*Img*.tar| while read line; do docker load -i $line; done
+
+      - name: Setup Nodejs ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Run BDD for HUB params
+        run: NO_DOCKER=1 SCRAMJET_TEST_LOG=1 yarn test:bdd-ci-no-host
+
+
+  test-bdd-ci-sth-no-docker:
+      name: Test bdd-ci-no-docker STH (Nodejs ${{ matrix.node-version }})
+      needs: [analyze-code, build-sth, build-refapps, build-docker-sth-image, build-docker-runner-image, build-docker-pre-runner-image]
+      runs-on: ubuntu-latest
+      timeout-minutes: 20
+
+      strategy:
+        fail-fast: true
+        matrix:
+          node-version: [14.x, 16.x]
+
+      steps:
+        - uses: actions/checkout@v2
+
+        - name: Install dependencies
+          run: yarn install --frozen-lockfile --silent
+
+        - name: Download dist-sth-${{ github.event.pull_request.head.sha }}-${{ matrix.node-version }}.tar.gz artifact 
+          uses: actions/download-artifact@v2
+          with:
+            name: dist-sth-${{ github.event.pull_request.head.sha }}-${{ matrix.node-version }}.tar.gz
+
+        - name: Download dist-refapps-${{ github.event.pull_request.head.sha }}-${{ matrix.node-version }}.tar.gz artifact 
+          uses: actions/download-artifact@v2
+          with:
+            name: dist-refapps-${{ github.event.pull_request.head.sha }}-${{ matrix.node-version }}.tar.gz
+
+        - name: Download dockerSthImg artifact 
+          uses: actions/download-artifact@v2
+          with:
+            name: dockerSthImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
+
+        - name: Download dockerImg artifact 
+          uses: actions/download-artifact@v2
+          with:
+            name: dockerRunnerImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
+
+        - name: Download dockerPreRunnerImg artifact 
+          uses: actions/download-artifact@v2
+          with:
+            name: dockerPreRunnerImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
+
+        - name: Unzip dockerImg-${{ github.event.pull_request.head.sha }}-${{ matrix.node-version }}.tar.gz artifact
+          run: pigz -d docker*Img*.tar.gz
+
+        - name: Unzip dist-${{ github.event.pull_request.head.sha }}-${{ matrix.node-version }}.tar.gz artifact
+          run: ls dist*tar.gz |xargs -n1 tar -I pigz -xf
+
+        - name: Load Docker images
+          run: ls -1  docker*Img*.tar| while read line; do docker load -i $line; done
+
+        - name: Setup Nodejs ${{ matrix.node-version }}
+          uses: actions/setup-node@v2
+          with:
+            node-version: ${{ matrix.node-version }}
+
+        - name: Run BDD tests
+          run: NO_DOCKER=1 SCRAMJET_TEST_LOG=1 yarn test:bdd-ci
+

--- a/.github/workflows/sth-build-test.yml
+++ b/.github/workflows/sth-build-test.yml
@@ -328,7 +328,7 @@ jobs:
 
   test-bdd-ci-no-host-no-docker-sth:
     name: Test bdd-ci-no-host-no-docker STH (Nodejs ${{ matrix.node-version }})
-    needs: [analyze-code, build-sth, build-refapps, build-docker-sth-image, build-docker-runner-image, build-docker-pre-runner-image]
+    needs: [analyze-code, build-sth, build-refapps, build-docker-sth-image]
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -358,16 +358,6 @@ jobs:
         with:
           name: dockerSthImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
 
-      - name: Download dockerImg artifact 
-        uses: actions/download-artifact@v2
-        with:
-          name: dockerRunnerImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
-
-      - name: Download dockerPreRunnerImg artifact 
-        uses: actions/download-artifact@v2
-        with:
-          name: dockerPreRunnerImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
-
       - name: Unzip dockerImg-${{ github.event.pull_request.head.sha }}-${{ matrix.node-version }}.tar.gz artifact
         run: pigz -d docker*Img*.tar.gz
 
@@ -388,7 +378,7 @@ jobs:
 
   test-bdd-ci-sth-no-docker:
       name: Test bdd-ci-no-docker STH (Nodejs ${{ matrix.node-version }})
-      needs: [analyze-code, build-sth, build-refapps, build-docker-sth-image, build-docker-runner-image, build-docker-pre-runner-image]
+      needs: [analyze-code, build-sth, build-refapps, build-docker-sth-image]
       runs-on: ubuntu-latest
       timeout-minutes: 20
 
@@ -417,16 +407,6 @@ jobs:
           uses: actions/download-artifact@v2
           with:
             name: dockerSthImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
-
-        - name: Download dockerImg artifact 
-          uses: actions/download-artifact@v2
-          with:
-            name: dockerRunnerImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
-
-        - name: Download dockerPreRunnerImg artifact 
-          uses: actions/download-artifact@v2
-          with:
-            name: dockerPreRunnerImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
 
         - name: Unzip dockerImg-${{ github.event.pull_request.head.sha }}-${{ matrix.node-version }}.tar.gz artifact
           run: pigz -d docker*Img*.tar.gz

--- a/.github/workflows/sth-build-test.yml
+++ b/.github/workflows/sth-build-test.yml
@@ -359,13 +359,13 @@ jobs:
           name: dockerSthImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
 
       - name: Unzip dockerImg-${{ github.event.pull_request.head.sha }}-${{ matrix.node-version }}.tar.gz artifact
-        run: pigz -d dockerSthImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
+        run: pigz -d dockerSthImg-scramjetorg_sth-$(jq -r .version package.json)-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
 
       - name: Unzip dist-${{ github.event.pull_request.head.sha }}-${{ matrix.node-version }}.tar.gz artifact
         run: ls dist*tar.gz |xargs -n1 tar -I pigz -xf
 
       - name: Load Docker images
-        run: docker load -i dockerSthImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar
+        run: docker load -i dockerSthImg-scramjetorg_sth-$(jq -r .version package.json)-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar
 
       - name: Setup Nodejs ${{ matrix.node-version }}
         uses: actions/setup-node@v2
@@ -409,13 +409,13 @@ jobs:
             name: dockerSthImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
 
         - name: Unzip dockerImg-${{ github.event.pull_request.head.sha }}-${{ matrix.node-version }}.tar.gz artifact
-          run: pigz -d dockerSthImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
+          run: pigz -d dockerSthImg-scramjetorg_sth-$(jq -r .version package.json)-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
 
         - name: Unzip dist-${{ github.event.pull_request.head.sha }}-${{ matrix.node-version }}.tar.gz artifact
           run: ls dist*tar.gz |xargs -n1 tar -I pigz -xf
 
         - name: Load Docker images
-          run: docker load -i dockerSthImg-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar
+          run: docker load -i dockerSthImg-scramjetorg_sth-$(jq -r .version package.json)-${{ matrix.node-version }}-${{ github.event.pull_request.head.sha }}.tar
 
         - name: Setup Nodejs ${{ matrix.node-version }}
           uses: actions/setup-node@v2

--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -38,6 +38,10 @@ Should host not be spawned
 `CSI_COREDUMP_VOLUME: string`
 Required in some performance tests. Path to a file.
 
+---
+`NO_DOCKER: boolean (default: false)`
+Run host with '--no-docker' option. 
+
 ### Runner
 
 ---

--- a/bdd/features/e2e/E2E-001-samples.feature
+++ b/bdd/features/e2e/E2E-001-samples.feature
@@ -6,25 +6,25 @@ Feature: Sample e2e tests
         And instance started with arguments "/package/data.json"
         And get "output" in background with instanceId
         And wait for instance healthy is "true"
-        And get containerId
+        And get runner PID
         When response in every line contains "Hello " followed by name from file "data.json" finished by "!"
-        And container is closed
+        And runner has ended execution
         Then host is still running
 
     @ci
     Scenario: E2E-001 TC-002 API test - Get instance output
         Given host is running
         When sequence "../packages/reference-apps/hello-alice-out.tar.gz" loaded
-        And instance started with arguments "/package/data.json"
+        And instance started
         And get "output" in background with instanceId
         And wait for instance healthy is "true"
-        And get containerId
+        And get runner PID
         When response in every line contains "Hello " followed by name from file "data.json" finished by "!"
         And send kill message to instance
         And wait for "2000" ms
         And delete sequence and volumes
         And confirm that sequence and volumes are removed
-        Then container is closed
+        Then runner has ended execution
         And host is still running
 
     Scenario: E2E-001 TC-003 - KM5_Cloud Server Instance Component
@@ -33,11 +33,11 @@ Feature: Sample e2e tests
         And instance started with arguments "/package/data.json"
         And get "output" in background with instanceId
         And wait for instance healthy is "true"
-        And get containerId
+        And get runner PID
         When response in every line contains "Hello " followed by name from file "data.json" finished by "!"
         And send kill message to instance
         And wait for "2000" ms
         And delete sequence and volumes
         And confirm that sequence and volumes are removed
-        And container is closed
+        And runner has ended execution
         Then host is still running

--- a/bdd/features/e2e/E2E-001-samples.feature
+++ b/bdd/features/e2e/E2E-001-samples.feature
@@ -3,7 +3,7 @@ Feature: Sample e2e tests
     Scenario: E2E-001 TC-001 Execute hello-alice-out example for host
         Given host is running
         When sequence "../packages/reference-apps/hello-alice-out.tar.gz" loaded
-        And instance started with arguments "/package/data.json"
+        And instance started
         And get "output" in background with instanceId
         And wait for instance healthy is "true"
         And get runner PID
@@ -30,7 +30,7 @@ Feature: Sample e2e tests
     Scenario: E2E-001 TC-003 - KM5_Cloud Server Instance Component
         Given host is running
         When sequence "../packages/reference-apps/hello-alice-out.tar.gz" loaded
-        And instance started with arguments "/package/data.json"
+        And instance started
         And get "output" in background with instanceId
         And wait for instance healthy is "true"
         And get runner PID

--- a/bdd/features/e2e/E2E-002-stop.feature
+++ b/bdd/features/e2e/E2E-002-stop.feature
@@ -6,13 +6,13 @@ Feature: Stop e2e tests
         When sequence "../packages/reference-apps/can-keep-alive.tar.gz" loaded
         And instance started with arguments "SEND_KEEPALIVE"
         And wait for instance healthy is "true"
-        And get containerId
+        And get runner PID
         And send stop message to instance with arguments timeout 5000 and canCallKeepAlive "true"
         And wait for instance healthy is "true"
         And send stop message to instance with arguments timeout 5000 and canCallKeepAlive "true"
         And wait for instance healthy is "true"
         And send stop message to instance with arguments timeout 0 and canCallKeepAlive "false"
-        And container is closed
+        And runner has ended execution
         Then host is still running
 
     @ci
@@ -21,9 +21,9 @@ Feature: Stop e2e tests
         When sequence "../packages/reference-apps/can-keep-alive.tar.gz" loaded
         And instance started with arguments ""
         And wait for instance healthy is "true"
-        And get containerId
+        And get runner PID
         And send stop message to instance with arguments timeout 2000 and canCallKeepAlive "true"
-        And container is closed
+        And runner has ended execution
         Then host is still running
 
     @ci
@@ -32,7 +32,7 @@ Feature: Stop e2e tests
         When sequence "../packages/reference-apps/can-keep-alive.tar.gz" loaded
         And instance started with arguments "SEND_KEEPALIVE"
         And wait for instance healthy is "true"
-        And get containerId
+        And get runner PID
         And send stop message to instance with arguments timeout 0 and canCallKeepAlive "false"
-        And container is closed
+        And runner has ended execution
         Then host is still running

--- a/bdd/features/e2e/E2E-003-kill.feature
+++ b/bdd/features/e2e/E2E-003-kill.feature
@@ -6,9 +6,9 @@ Feature: Kill e2e tests
         When sequence "../packages/reference-apps/hello-alice-out.tar.gz" loaded
         And instance started with arguments "/package/data.json"
         And wait for instance healthy is "true"
-        And get containerId
+        And get runner PID
         And send kill message to instance
-        And container is closed
+        And runner has ended execution
         Then host is still running
 
     # This is a potential edge case so it's currently ignored.
@@ -18,9 +18,9 @@ Feature: Kill e2e tests
         When sequence "../packages/reference-apps/sequence-20s-kill-handler.tar.gz" loaded
         And instance started with arguments "/package/data.json"
         And wait for instance healthy is "true"
-        And get containerId
+        And get runner PID
         Then get event "kill-handler-called" from instance
         When send kill message to instance
         Then instance response body is "{\"eventName\":\"kill-handler-called\",\"message\":\"\"}"
-        And container is closed
+        And runner has ended execution
         Then host is still running

--- a/bdd/features/e2e/E2E-003-kill.feature
+++ b/bdd/features/e2e/E2E-003-kill.feature
@@ -4,7 +4,7 @@ Feature: Kill e2e tests
     Scenario: E2E-003 TC-001 API test - Kill instance
         Given host is running
         When sequence "../packages/reference-apps/hello-alice-out.tar.gz" loaded
-        And instance started with arguments "/package/data.json"
+        And instance started
         And wait for instance healthy is "true"
         And get runner PID
         And send kill message to instance
@@ -16,7 +16,7 @@ Feature: Kill e2e tests
     Scenario: E2E-003 TC-002 Kill sequence - kill handler should emit event when executed
         Given host is running
         When sequence "../packages/reference-apps/sequence-20s-kill-handler.tar.gz" loaded
-        And instance started with arguments "/package/data.json"
+        And instance started
         And wait for instance healthy is "true"
         And get runner PID
         Then get event "kill-handler-called" from instance

--- a/bdd/features/e2e/E2E-004-event.feature
+++ b/bdd/features/e2e/E2E-004-event.feature
@@ -6,11 +6,11 @@ Feature: Event e2e tests
         When sequence "../packages/reference-apps/event-sequence-v2.tar.gz" loaded
         And instance started
         And wait for instance healthy is "true"
-        And get containerId
+        And get runner PID
         And send event "test-event" to instance with message "test message"
         Then wait for event "test-event-response" from instance
         Then instance response body is "{\"eventName\":\"test-event-response\",\"message\":\"message from sequence\"}"
-        And container is closed
+        And runner has ended execution
         Then host is still running
 
     @ci
@@ -19,8 +19,8 @@ Feature: Event e2e tests
         When sequence "../packages/reference-apps/event-sequence-2.tar.gz" loaded
         And instance started
         And wait for instance healthy is "true"
-        And get containerId
+        And get runner PID
         Then get event "new-test-event" from instance
         Then instance response body is "{\"eventName\":\"new-test-event\",\"message\":\"event sent between functions in one sequence\"}"
-        And container is closed
+        And runner has ended execution
         Then host is still running

--- a/bdd/features/e2e/E2E-005-monitoring.feature
+++ b/bdd/features/e2e/E2E-005-monitoring.feature
@@ -3,7 +3,7 @@ Feature: Monitoring e2e tests
     Scenario: E2E-005 TC-001 API test - Get monitoring from sequence where new handler method is added and returning: healthy false
         Given host is running
         When sequence "../packages/reference-apps/unhealthy-sequence.tar.gz" loaded
-        And instance started with arguments "/package/data.json"
+        And instance started
         And wait for instance healthy is "true"
         And get runner PID
         And wait for instance healthy is "false"
@@ -13,7 +13,7 @@ Feature: Monitoring e2e tests
     Scenario: E2E-005 TC-002 Get monitoring from sequence, should return default monitoring value: healthy true
         Given host is running
         When sequence "../packages/reference-apps/healthy-sequence.tar.gz" loaded
-        And instance started with arguments "/package/data.json"
+        And instance started
         And wait for instance healthy is "true"
         And get runner PID
         And runner has ended execution

--- a/bdd/features/e2e/E2E-005-monitoring.feature
+++ b/bdd/features/e2e/E2E-005-monitoring.feature
@@ -5,9 +5,9 @@ Feature: Monitoring e2e tests
         When sequence "../packages/reference-apps/unhealthy-sequence.tar.gz" loaded
         And instance started with arguments "/package/data.json"
         And wait for instance healthy is "true"
-        And get containerId
+        And get runner PID
         And wait for instance healthy is "false"
-        And container is closed
+        And runner has ended execution
         Then host is still running
 
     Scenario: E2E-005 TC-002 Get monitoring from sequence, should return default monitoring value: healthy true
@@ -15,6 +15,6 @@ Feature: Monitoring e2e tests
         When sequence "../packages/reference-apps/healthy-sequence.tar.gz" loaded
         And instance started with arguments "/package/data.json"
         And wait for instance healthy is "true"
-        And get containerId
-        And container is closed
+        And get runner PID
+        And runner has ended execution
         Then host is still running

--- a/bdd/features/e2e/E2E-006-stdio.feature
+++ b/bdd/features/e2e/E2E-006-stdio.feature
@@ -7,10 +7,10 @@ Feature: Stdio e2e tests
         And instance started
         And keep instance streams "stdout,stderr"
         And wait for instance healthy is "true"
-        And get containerId
+        And get runner PID
         When send stdin to instance with contents of file "../packages/reference-apps/stdio-sequence/numbers.txt"
         When send kill message to instance
-        And container is closed
+        And runner has ended execution
         Then host is still running
         And kept instance stream "stdout" should be "1\n3\n5\n7\n9\n11\n13\n15\n17\n19\n"
         And kept instance stream "stderr" should be "2\n4\n6\n8\n10\n12\n14\n16\n18\n20\n"

--- a/bdd/features/e2e/E2E-009-data-persist.feature
+++ b/bdd/features/e2e/E2E-009-data-persist.feature
@@ -7,9 +7,9 @@ Feature: Output streams persisting data E2E test
         And instance started with arguments "1000"
         And keep instance streams "stdout,stderr,output"
         And wait for instance healthy is "true"
-        And get containerId
+        And get runner PID
         When send kill message to instance
-        And container is closed
+        And runner has ended execution
         Then host is running
         And kept instance stream "stdout" should store 1000 items divided by ","
         And kept instance stream "stderr" should store 1000 items divided by ","

--- a/bdd/features/e2e/E2E-012-stream-flooding-test.feature
+++ b/bdd/features/e2e/E2E-012-stream-flooding-test.feature
@@ -6,13 +6,13 @@ Feature: Stream flooding tests. Ensure that even if a large amount of data is se
         When sequence "../packages/reference-apps/event-sequence-v2.tar.gz" loaded
         And instance started with arguments "500"
         And wait for instance healthy is "true"
-        And get containerId
+        And get runner PID
         When flood the stdin stream with 11000 kilobytes
         And wait for "3000" ms
         And send event "test-event" to instance with message "test message"
         Then get event "test-event-response" from instance
         Then instance response body is "{\"eventName\":\"test-event-response\",\"message\":\"message from sequence\"}"
-        And container is closed
+        And runner has ended execution
         Then host is still running
 
     @ci
@@ -21,11 +21,11 @@ Feature: Stream flooding tests. Ensure that even if a large amount of data is se
         When sequence "../packages/reference-apps/flood-stdout-sequence.tar.gz" loaded
         And instance started with arguments "2000 10000"
         And wait for instance healthy is "true"
-        And get containerId
+        And get runner PID
         Then get event "test-event-response" from instance
         When wait for "1000" ms
         Then instance response body is "{\"eventName\":\"test-event-response\",\"message\":\"message from sequence\"}"
         And send kill message to instance
-        And container is closed
+        And runner has ended execution
         Then host is still running
 

--- a/bdd/features/e2e/hub/HUB-001-host-config.feature
+++ b/bdd/features/e2e/hub/HUB-001-host-config.feature
@@ -51,7 +51,7 @@ Feature: Host configuration
     Scenario: HUB-001 TC-009  Set runner image (--runner-image)
         When hub process is started with parameters "--runner-image repo.int.scp.ovh/scramjet/runner:0.10.0-pre.7"
         And sequence "../packages/reference-apps/inert-function.tar.gz" is loaded
-        And instance started with arguments "/package/data.json"
+        And instance started
         And get runner container information
         Then container uses "repo.int.scp.ovh/scramjet/runner:0.10.0-pre.7" image
         * exit hub process
@@ -60,7 +60,7 @@ Feature: Host configuration
     Scenario: HUB-001 TC-010  Default runner image
         When hub process is started with parameters "''"
         And sequence "../packages/reference-apps/inert-function.tar.gz" is loaded
-        And instance started with arguments "/package/data.json"
+        And instance started
         And wait for "2000" ms
         And get runner container information
         Then container uses image defined in sth-config
@@ -70,7 +70,7 @@ Feature: Host configuration
     Scenario: HUB-001 TC-011  Set runner memory limit (--runner-max-mem)
         When hub process is started with parameters "--runner-max-mem 128"
         And sequence "../packages/reference-apps/hello-alice-out.tar.gz" is loaded
-        And instance started with arguments "/package/data.json"
+        And instance started
         And wait for "2000" ms
         And get runner container information
         Then container memory limit is 128

--- a/bdd/features/e2e/hub/HUB-001-host-config.feature
+++ b/bdd/features/e2e/hub/HUB-001-host-config.feature
@@ -56,7 +56,7 @@ Feature: Host configuration
         Then container uses "repo.int.scp.ovh/scramjet/runner:0.10.0-pre.7" image
         * exit hub process
 
-    @ci @starts-host
+    @ci @starts-host @docker-specific
     Scenario: HUB-001 TC-010  Default runner image
         When hub process is started with parameters "''"
         And sequence "../packages/reference-apps/inert-function.tar.gz" is loaded
@@ -66,7 +66,7 @@ Feature: Host configuration
         Then container uses image defined in sth-config
         * exit hub process
 
-    @ci @starts-host
+    @ci @starts-host @docker-specific
     Scenario: HUB-001 TC-011  Set runner memory limit (--runner-max-mem)
         When hub process is started with parameters "--runner-max-mem 128"
         And sequence "../packages/reference-apps/hello-alice-out.tar.gz" is loaded
@@ -86,7 +86,7 @@ Feature: Host configuration
         And end fake stream
         * exit hub process
 
-    @ci @starts-host
+    @ci @starts-host @docker-specific
     Scenario: HUB-001 TC-013  Set prerunner memory limit (--prerunner-max-mem)
         When hub process is started with parameters "--prerunner-max-mem 64"
         And get all containers

--- a/bdd/features/performance-tests/PT-002-function-call-delay.feature
+++ b/bdd/features/performance-tests/PT-002-function-call-delay.feature
@@ -5,33 +5,33 @@ Feature: Maintain efficiency within a host
         Given host is running
         When sequence "../packages/reference-apps/inert-sequence-2-with-delay.tar.gz" loaded
         And instance started with arguments "4000 2000" and write stream to "delay-test-result.txt" and timeout after 30 seconds
-        And get containerId
+        And get runner PID
         Then file "delay-test-result.txt" is generated
         When calculate average delay time from "delay-test-result.txt" of first "2000" function calls starting "2000"
         When calculated avereage delay time is lower than 0.1 ms
-        And container is closed
+        And runner has ended execution
         Then host is still running
 
     Scenario: PT-002 TC-002 Maintain efficiency
         Given host is running
         When sequence "../packages/reference-apps/inert-sequence-2-with-delay.tar.gz" loaded
         And instance started with arguments "12000 2000" and write stream to "delay-test-result.txt" and timeout after 120 seconds
-        And get containerId
+        And get runner PID
         Then file "delay-test-result.txt" is generated
         When calculate average delay time from "delay-test-result.txt" of first "10000" function calls starting "2000"
         When calculated avereage delay time is lower than 0.1 ms
-        And container is closed
+        And runner has ended execution
         Then host is still running
 
     Scenario: PT-002 TC-003 Maintain efficiency test with core dump
         Given host is running
         When sequence "../packages/reference-apps/inert-sequence-2-with-delay.tar.gz" loaded
         And instance started with arguments "12000 2000 1" and write stream to "delay-test-result.txt" and timeout after 120 seconds
-        And get containerId
+        And get runner PID
         Then file "delay-test-result.txt" is generated
         When calculate average delay time from "delay-test-result.txt" of first "10000" function calls starting "2000"
         When calculated avereage delay time is lower than 0.1 ms
-        When container is closed
+        When runner has ended execution
         And memory dump file "core.node.1" was created
         And search word "scramjetTest" and find 0 occurences in location "core.node.1" file
         And search word scramjetTest and find more than 1 occurences in location "core.node.1" file

--- a/bdd/features/performance-tests/PT-003-process-large-file.feature
+++ b/bdd/features/performance-tests/PT-003-process-large-file.feature
@@ -15,9 +15,9 @@ Feature: Process large file test
         When sequence "../packages/reference-apps/big-file-sequence.tar.gz" loaded
         And instance started with url from assets argument "scp-store/example512M.json.gz"
         And wait for instance healthy is "true"
-        And get containerId
+        And get runner PID
         And get "output" in background with instanceId
-        And container is closed
+        And runner has ended execution
         When response data is equal "39996113"
         Then host is still running
 
@@ -27,8 +27,8 @@ Feature: Process large file test
         When sequence "../packages/reference-apps/big-file-sequence.tar.gz" loaded
         And instance started with url from assets argument "scp-store/example10G.json.gz"
         And wait for instance healthy is "true"
-        And get containerId
+        And get runner PID
         And get "output" in background with instanceId
-        And container is closed
+        And runner has ended execution
         When response data is equal "781174082"
         Then host is still running

--- a/bdd/features/performance-tests/PT-004-checksum.feature
+++ b/bdd/features/performance-tests/PT-004-checksum.feature
@@ -7,8 +7,8 @@ Feature: Verify the checksums of payloads are correct
         When sequence "../packages/reference-apps/checksum-sequence.tar.gz" loaded
         And instance started
         When wait for instance healthy is "true"
-        And get containerId
+        And get runner PID
         And compare checksums of content sent from file "../dist/reference-apps/checksum-sequence/data.json"
-        When container is closed
+        When runner has ended execution
         Then host is still running
 

--- a/bdd/features/performance-tests/PT-005-ports.feature
+++ b/bdd/features/performance-tests/PT-005-ports.feature
@@ -6,14 +6,14 @@ Feature: Ports e2e tests
         And instance started with arguments "tcp"
         And get instance info
         And wait for instance healthy is "true"
-        And get containerId
+        And get runner PID
         And start reading "log" stream
         And connect to instance on port 17006 using "tcp" server
         And send "testMessage" to "tcp" server
         And wait for "3000" ms
         And check stream for message sent
         And send "null" to "tcp" server
-        And container is closed
+        And runner has ended execution
         Then host is still running
 
     Scenario: PT-005 TC-002 UDP Connection
@@ -22,12 +22,12 @@ Feature: Ports e2e tests
         And instance started with arguments "udp"
         And get instance info
         And wait for instance healthy is "true"
-        And get containerId
+        And get runner PID
         And start reading "log" stream
         And connect to instance on port 17008 using "udp" server
         And send "testMessage" to "udp" server
         And wait for "3000" ms
         And check stream for message sent
         And send "null" to "udp" server
-        And container is closed
+        And runner has ended execution
         Then host is still running

--- a/bdd/lib/host-utils.ts
+++ b/bdd/lib/host-utils.ts
@@ -66,6 +66,7 @@ export class HostUtils {
             if (process.env.LOCAL_HOST_PORT) command.push("-P", process.env.LOCAL_HOST_PORT);
             if (process.env.LOCAL_HOST_SOCKET_PATH) command.push("-S", process.env.LOCAL_HOST_SOCKET_PATH);
             if (process.env.CPM_URL) command.push("-C", process.env.CPM_URL);
+            if (process.env.NO_DOCKER) command.push("--no-docker");
             if (process.env.SCRAMJET_TEST_LOG) {
                 // eslint-disable-next-line no-console
                 console.log("Spawning with command:", ...command);

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "test:bdd-ci": "yarn --cwd=./bdd run test:bdd --format=@cucumber/pretty-formatter --tags=@ci --tags=\"not @starts-host\"",
     "test:bdd-ci-no-host": "NO_HOST=true yarn --cwd=./bdd run test:bdd --format=@cucumber/pretty-formatter --tags=@ci --tags=\"@starts-host\"",
     "test:bdd": "yarn --cwd=./bdd run test:bdd --fail-fast",
+    "test:bdd-ci-no-docker": "NO_DOCKER=1 yarn test:bdd-ci --tags=\"not @docker-specific\"",
+    "test:bdd-ci-no-host-no-docker": "NO_DOCKER=1 yarn test:bdd-ci-no-host --tags=\"not @docker-specific\"",
     "prebump:packages": "NEXT_VER=$(npx semver -i ${VERSION_LEVEL:-prerelease} $(jq -r .version < package.json)) && git diff --exit-code --quiet && yarn bump:images && lerna version -y --force-publish --no-git-tag-version ${NEXT_VER} && git add .",
     "bump:packages": "NEXT_VER=$(npx semver -i ${VERSION_LEVEL:-prerelease} $(jq -r .version < package.json)) && yarn version --new-version ${NEXT_VER}",
     "bump:images": "./scripts/bump_docker_images.sh",

--- a/packages/adapters/src/process-instance-adapter.ts
+++ b/packages/adapters/src/process-instance-adapter.ts
@@ -126,7 +126,10 @@ IComponent {
             return msg;
         }
 
-        return msg;
+        return {
+            ...msg,
+            processId: this.runnerProcess?.pid
+        };
     }
 
     hookCommunicationHandler(communicationHandler: ICommunicationHandler): void {
@@ -178,8 +181,7 @@ IComponent {
         this.logger.log("Starting Runner...", config.id);
 
         const sequencePath = path.join(
-            config.sequencesDir,
-            config.id,
+            config.sequenceDir,
             config.entrypointPath
         );
 
@@ -215,7 +217,9 @@ IComponent {
         this.logger.log("Process exited.");
 
         if (statusCode === null) {
-            throw new Error(`Runner was killed by a signal ${signal}, and didn't return a status code`);
+            this.logger.warn(`Runner was killed by a signal ${signal}, and didn't return a status code`);
+            // Probably SIGKLL
+            return 137;
         }
 
         if (statusCode > 0) {

--- a/packages/adapters/src/process-instance-adapter.ts
+++ b/packages/adapters/src/process-instance-adapter.ts
@@ -218,7 +218,7 @@ IComponent {
 
         if (statusCode === null) {
             this.logger.warn(`Runner was killed by a signal ${signal}, and didn't return a status code`);
-            // Probably SIGKLL
+            // Probably SIGIKLL
             return 137;
         }
 

--- a/packages/adapters/src/process-sequence-adapter.ts
+++ b/packages/adapters/src/process-sequence-adapter.ts
@@ -14,8 +14,8 @@ import { exec } from "child_process";
 import { isDefined, readStreamedJSON } from "@scramjet/utility";
 import { isValidSequencePackageJSON } from "./validate-sequence-package-json";
 
-async function getRunnerConfigForStoredSequence(sequencesDir: string, id: string): Promise<ProcessSequenceConfig> {
-    const packageJsonPath = path.join(sequencesDir, id, "package.json");
+async function getRunnerConfigForStoredSequence(sequenceDir: string, id: string): Promise<ProcessSequenceConfig> {
+    const packageJsonPath = path.join(sequenceDir, "package.json");
     const packageJson = await readStreamedJSON(createReadStream(packageJsonPath));
 
     if (!isValidSequencePackageJSON(packageJson)) {
@@ -28,7 +28,7 @@ async function getRunnerConfigForStoredSequence(sequencesDir: string, id: string
         version: packageJson.version ?? "",
         name: packageJson.name ?? "",
         id,
-        sequencesDir
+        sequenceDir
     };
 }
 

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -331,7 +331,7 @@ export class CSIController extends EventEmitter {
             );
 
             this.communicationHandler.addMonitoringHandler(RunnerMessageCode.EVENT, (data) => {
-                const event = data[1] as unknown as EventMessageData;
+                const event = data[1];
 
                 if (!event.eventName) return;
                 localEmitter.lastEvents[event.eventName] = event;

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -4,7 +4,6 @@ import {
     CSIConfig,
     DownstreamStreamsConfig,
     EncodedMessage,
-    EventMessageData,
     ExitCode,
     HandshakeAcknowledgeMessage,
     ICommunicationHandler,

--- a/packages/reference-apps/event-sequence-v2/index.ts
+++ b/packages/reference-apps/event-sequence-v2/index.ts
@@ -10,6 +10,7 @@ import { InertApp } from "@scramjet/types";
 export = async function() {
     await new Promise<void>(resolve => {
         this.on("test-event", async () => {
+            await new Promise(res => setTimeout(res, 3000));
             this.emit("test-event-response", "message from sequence");
             await new Promise(res => setTimeout(res, 1000));
             resolve();

--- a/packages/sth/src/bin/hub.ts
+++ b/packages/sth/src/bin/hub.ts
@@ -46,7 +46,7 @@ configService.update({
         hostname: options.hostname,
         id: options.id
     },
-    noDocker: options.noDocker,
+    noDocker: !options.docker,
     sequencesDir: options.sequencesDir
 });
 

--- a/packages/types/src/messages/monitoring.ts
+++ b/packages/types/src/messages/monitoring.ts
@@ -31,6 +31,9 @@ export type MonitoringMessageData = MonitoringMessageFromRunnerData & {
     networkTx?: number;
 
     containerId?: string;
+
+    /** PID of Runner If STH is run with --no-docker option */
+    processId?: number;
 }
 
 /**

--- a/packages/types/src/runner-config.ts
+++ b/packages/types/src/runner-config.ts
@@ -27,7 +27,7 @@ export type DockerSequenceConfig = CommonSequenceConfig & {
 
 export type ProcessSequenceConfig = CommonSequenceConfig & {
     type: "process",
-    sequencesDir: string
+    sequenceDir: string
 }
 
 export type SequenceConfig = DockerSequenceConfig | ProcessSequenceConfig


### PR DESCRIPTION
Parametrizing BDD tests so it's possible to run them in NO_DOCKER mode.
One sequence required adding one sleep bc in --no-docker mode it was ending too fast.