### PR TITLE
Enable starting runner with ts-node in --no-docker mode

### DIFF
--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -22,7 +22,8 @@
     "@scramjet/utility": "^0.12.2",
     "dockerode": "^3.3.0",
     "scramjet": "^4.36.0",
-    "shell-escape": "^0.2.0"
+    "shell-escape": "^0.2.0",
+    "ts.data.json": "^2.1.0"
   },
   "devDependencies": {
     "@scramjet/types": "^0.12.2",

--- a/packages/adapters/src/docker-sequence-adapter.ts
+++ b/packages/adapters/src/docker-sequence-adapter.ts
@@ -138,7 +138,7 @@ class DockerSequenceAdapter implements ISequenceAdapter {
             wait
         ]);
 
-        const validPackageJson = await sequencePackageJSONDecoder.decodeToPromise(packageJson)
+        const validPackageJson = await sequencePackageJSONDecoder.decodeToPromise(packageJson);
 
         const engines = validPackageJson.engines ? { ...validPackageJson.engines } : {};
         const config = validPackageJson.scramjet?.config ? { ...validPackageJson.scramjet.config } : {};

--- a/packages/adapters/src/process-instance-adapter.ts
+++ b/packages/adapters/src/process-instance-adapter.ts
@@ -200,6 +200,8 @@ IComponent {
         const runnerProcess = spawn(runnerCommand[0], runnerCommand.slice(1), {
             env: {
                 PATH: process.env.PATH,
+                DEVELOPMENT: process.env.DEVELOPMENT,
+                PRODUCTION: process.env.PRODUCTION,
                 FIFOS_DIR: this.fifosDir,
                 SEQUENCE_PATH: sequencePath
             }

--- a/packages/adapters/src/process-instance-adapter.ts
+++ b/packages/adapters/src/process-instance-adapter.ts
@@ -199,7 +199,7 @@ IComponent {
         // @TODO support running by ts-node
         const runnerProcess = spawn(runnerCommand[0], runnerCommand.slice(1), {
             env: {
-                ...process.env,
+                PATH: process.env.PATH,
                 FIFOS_DIR: this.fifosDir,
                 SEQUENCE_PATH: sequencePath
             }

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -137,6 +137,8 @@ export class CSIController extends EventEmitter {
         this.superVisorProcess = spawn(executable, command, {
             env: {
                 PATH: process.env.PATH,
+                DEVELOPMENT: process.env.DEVELOPMENT,
+                PRODUCTION: process.env.PRODUCTION,
                 NO_DOCKER: this.config.noDocker.toString()
             }
         });

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -122,7 +122,6 @@ export class CSIController extends EventEmitter {
     }
 
     startSupervisor() {
-        // eslint-disable-next-line no-extra-parens
         const isTSNode = !!(process as any)[Symbol.for("ts-node.register.instance")];
         const supervisorPath = require.resolve("@scramjet/supervisor");
 
@@ -137,6 +136,7 @@ export class CSIController extends EventEmitter {
 
         this.superVisorProcess = spawn(executable, command, {
             env: {
+                ...process.env,
                 NO_DOCKER: this.config.noDocker.toString()
             }
         });

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -136,7 +136,7 @@ export class CSIController extends EventEmitter {
 
         this.superVisorProcess = spawn(executable, command, {
             env: {
-                ...process.env,
+                PATH: process.env.PATH,
                 NO_DOCKER: this.config.noDocker.toString()
             }
         });

--- a/packages/sth-config/src/config-service.ts
+++ b/packages/sth-config/src/config-service.ts
@@ -34,7 +34,7 @@ const _defaultConfig: STHConfiguration = {
     safeOperationLimit: 512,
     instanceAdapterExitDelay: 9000,
     noDocker: false,
-    sequencesDir: path.join(require("os").homedir(), ".scramjet_sequences")
+    sequencesRoot: path.join(require("os").homedir(), ".scramjet_sequences")
 };
 
 merge(_defaultConfig, {

--- a/packages/sth/src/bin/hub.ts
+++ b/packages/sth/src/bin/hub.ts
@@ -20,7 +20,7 @@ const options = program
     .option("--prerunner-max-mem <mb>", "Maximum mem used by prerunner")
     .option("--expose-host-ip <ip>", "Host IP address that the Runner container's port is mapped to.")
     .option("--no-docker", "Run all the instances on the host machine instead of in docker containers. UNSAFE FOR RUNNING ARBITRARY CODE.", false)
-    .option("--sequences-dir", "Only works with --no-docker option. Where should ProcessSequenceAdapter save new sequences")
+    .option("--sequences-root", "Only works with --no-docker option. Where should ProcessSequenceAdapter save new sequences")
     .parse(process.argv)
     .opts();
 
@@ -47,7 +47,7 @@ configService.update({
         id: options.id
     },
     noDocker: !options.docker,
-    sequencesDir: options.sequencesDir
+    sequencesRoot: options.sequencesRoot
 });
 
 // before here we actually load the host and we have the config imported elsewhere

--- a/packages/types/src/runner-config.ts
+++ b/packages/types/src/runner-config.ts
@@ -1,5 +1,6 @@
 // TODO: Rename. it is not a runner config but response from Pre-runner. - valid!!!
 
+import { PortConfig } from "./sequence-package-json";
 import { RunnerContainerConfiguration } from "./sth-configuration";
 
 type CommonSequenceConfig = {
@@ -16,12 +17,9 @@ type CommonSequenceConfig = {
 export type DockerSequenceConfig = CommonSequenceConfig & {
     type: "docker",
     container: RunnerContainerConfiguration;
-    engines: {
-        [key: string]: string;
-    };
+    engines: Record<string, string>,
     config?: {
-        image?: string,
-        ports?: `${number}/${"tcp" | "udp"}`[]
+        ports?: PortConfig[] | null
     };
 };
 

--- a/packages/types/src/sequence-package-json.ts
+++ b/packages/types/src/sequence-package-json.ts
@@ -5,7 +5,6 @@ export type SequencePackageJSONScramjetConfig = {
 }
 
 export type SequencePackageJSONScramjetSection = {
-    // @TODO it's not used anywhere, we're using runtime config images instead
     config?: SequencePackageJSONScramjetConfig | null
 }
 

--- a/packages/types/src/sequence-package-json.ts
+++ b/packages/types/src/sequence-package-json.ts
@@ -1,13 +1,18 @@
+export type PortConfig = `${number}/${"tcp" | "udp"}`
+
+export type SequencePackageJSONScramjetConfig = {
+    ports?: PortConfig[] | null
+}
+
+export type SequencePackageJSONScramjetSection = {
+    // @TODO it's not used anywhere, we're using runtime config images instead
+    config?: SequencePackageJSONScramjetConfig | null
+}
 
 export type SequencePackageJSON = {
     name?: string | null
     version?: string | null
     main: string,
     engines?: Record<string, string> | null
-    scramjet?: {
-        // @TODO it's not used anywhere, we're using runtime config images instead
-        config?: {
-            ports: `${number}/${"tcp" | "udp"}`[]
-          } | null
-    } | null
+    scramjet?: SequencePackageJSONScramjetSection | null
 }

--- a/packages/types/src/sth-configuration.ts
+++ b/packages/types/src/sth-configuration.ts
@@ -140,5 +140,5 @@ export type STHConfiguration = {
      * Only used when `noDocker` is true
      * Where should ProcessSequenceAdapter save new sequences
      */
-    sequencesDir: string
+    sequencesRoot: string
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7238,6 +7238,11 @@ ts-node@^10.0.0:
     make-error "^1.1.1"
     yn "3.1.1"
 
+ts.data.json@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ts.data.json/-/ts.data.json-2.1.0.tgz#0ed5a1306ba440102d18175b2634270515dc5cc9"
+  integrity sha512-Y9eSZH1W/V9F7Mx91kV0DAfhn0q30luUglCgCJDCknRsNcB2isfcqmKMb3Dmgib+/XX9F7lsx5nUOQqMWYf0sw==
+
 tsconfig-paths@^3.11.0:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz#954c1fe973da6339c78e06b03ce2e48810b65f36"


### PR DESCRIPTION
Other than that I've refactored some things that didn't get into the original PR.

One change worth noting is choice of JSON decoding library.
[ts.data.json](https://github.com/joanllenas/ts.data.json)

I've had it battle tested in my previous work and it works like a charm. I've had a chance to play with similar libraries and this one is imho the most intuitive and robust solution. 

### Verify
To verify we can just run any BDD test with `SCRAMJET_SPAWN_TS=1 NO_DOCKER=1` e.g.
```
SCRAMJET_SPAWN_TS=true NO_DOCKER=true SCRAMJET_TEST_LOG=true DEVELOPMENT=true yarn test:bdd --name="PT-004 TC-001 Checksum of JSON payload"
```
and verify in logs that both `supervisor` and `runner` were run using TS source code
```
2021-12-01T18:18:59.941Z info (object:CSIController:40ea8abe-4e6c-4835-857b-33aa33f8d0cd) Spawning supervisor with command: [
  '/home/kpietrzak/Projects/scramjet-cpm-dev/sth/packages/supervisor/src/bin/supervisor.ts',
  '40ea8abe-4e6c-4835-857b-33aa33f8d0cd',
  '/tmp/scramjet-socket-server-path-34947'
]

(...)

2021-12-01T18:19:02.805Z log (object:ProcessInstanceAdapter) Spawning Runner process with command [
  'ts-node',
  '/home/kpietrzak/Projects/scramjet-cpm-dev/sth/packages/runner/src/bin/start-runner.ts'
] and envs:  {
  FIFOS_DIR: '/tmp/fifosAukCK0',
  SEQUENCE_PATH: '/home/kpietrzak/.scramjet_sequences/535eeaa8-6349-4f64-a0d8-9992a14e6509/index.js'
}
```