### PR TITLE
[Bug] Service Discovery blocking Instance API input endpoint

### DIFF
--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -219,11 +219,14 @@ export class CSIController extends EventEmitter {
         this.communicationHandler.addMonitoringHandler(RunnerMessageCode.PANG, async (message) => {
             const pangData = message[1];
 
-            this.provides ||= pangData.provides;
-            this.requires ||= pangData.requires;
-
-            this.apiInputEnabled = pangData.requires === "";
-
+            if (pangData.provides) {
+                this.provides ||= pangData.provides;
+            } else if (pangData.requires) {
+                this.requires ||= pangData.requires;
+                if (pangData.requires !== "") {
+                    this.apiInputEnabled = false;
+                }
+            }
             this.emit("pang", message[1]);
         });
 


### PR DESCRIPTION
The PANG message carrying topic "provides" information sent from Runner overrides the API enabled variable in CSI Controller: 
https://github.com/scramjetorg/transform-hub/blob/release/0.12/packages/host/src/lib/csi-controller.ts#L225

The result is that despite the BDD tests passing on transform-hub, the Service Discovery blocks Instance API input endpoints and e.g. the samples in scramjet-cloud-docs do not work. The BDD tests pass because the input endpoint is by default enabled and it is disabled only after the second PANG message arrives in CSI Controller. During the time the input endpoint is enabled the tests manage to send the data to Instances, thus making the tests pass.
