### PR TITLE
Move dependencies

### DIFF
--- a/bdd/package.json
+++ b/bdd/package.json
@@ -4,8 +4,6 @@
   "description": "",
   "main": "_cucumber.js",
   "dependencies": {
-    "@cucumber/cucumber": "^7.1.0",
-    "@cucumber/pretty-formatter": "^1.0.0-alpha.0",
     "@scramjet/api-client": "^0.13.2",
     "@scramjet/logger": "^0.13.2",
     "@scramjet/sth-config": "^0.13.2",
@@ -14,6 +12,11 @@
     "freeport": "^1.0.5",
     "n-readlines": "^1.0.1",
     "scramjet": "^4.36.0"
+  },
+  "devDependencies": {
+    "@cucumber/cucumber": "^7.1.0",
+    "@cucumber/pretty-formatter": "^1.0.0-alpha.0"
+
   },
   "scripts": {
     "build:bdd": "tsc -p tsconfig.json",

--- a/packages/sth/package.json
+++ b/packages/sth/package.json
@@ -23,12 +23,19 @@
     "@scramjet/host": "^0.13.2",
     "@scramjet/logger": "^0.13.2",
     "@scramjet/sth-config": "^0.13.2",
+    "commander": "^8.1.0"
+  },
+  "devDependencies": {
+    "@scramjet/types": "^0.13.2",
+    "@types/node": "15.12.5",
+    "ava": "^3.15.0",
+    "ts-node": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^4.27.0",
     "@typescript-eslint/parser": "^4.27.0",
-    "commander": "^8.1.0",
     "eslint-plugin-import": "^2.23.3",
     "ts-loader": "^9.2.3",
-    "ts-node": "^10.0.0",
+    "typedoc": "^0.22.5",
+    "typedoc-plugin-markdown": "^3.11.2",
     "typescript": "^4.3.4"
   },
   "readme": "README.md",
@@ -45,15 +52,6 @@
       "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=7F7V65C43EBMW"
     }
   ],
-  "devDependencies": {
-    "@scramjet/types": "^0.13.2",
-    "@types/node": "15.12.5",
-    "ava": "^3.15.0",
-    "ts-node": "^10.0.0",
-    "typedoc": "^0.22.5",
-    "typedoc-plugin-markdown": "^3.11.2",
-    "typescript": "^4.3.4"
-  },
   "ava": {
     "extensions": [
       "ts"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -15,11 +15,11 @@
   "author": "Scramjet <open-source@scramjet.org>",
   "license": "AGPL-3.0",
   "dependencies": {
-    "@scramjet/symbols": "^0.13.2"
+    "@scramjet/symbols": "^0.13.2",
+    "http-status-codes": "^2.1.4"
   },
   "devDependencies": {
     "@types/node": "15.12.5",
-    "http-status-codes": "^2.1.4",
     "scramjet": "^4.36.0",
     "typedoc": "0.21.2",
     "typedoc-plugin-markdown": "3.10.2",


### PR DESCRIPTION
This is how all dependencies look like after changes:
```json
{
  "name": "@scramjet/all-deps",
  "version": "^0.13.2",
  "dependencies": {
    "0http": "^3.1.0",
    "JSONStream": "^1.3.5",
    "bpmux": "^8.1.3",
    "commander": "^8.1.0",
    "dockerode": "^3.3.0",
    "find-package-json": "^1.2.0",
    "freeport": "^1.0.5",
    "http-status-codes": "^2.1.4",
    "minimatch": "^3.0.4",
    "minimist": "^1.2.5",
    "n-readlines": "^1.0.1",
    "node-fetch": "^2.6.1",
    "rereadable-stream": "^1.4.12",
    "scramjet": "^4.36.0",
    "shell-escape": "^0.2.0",
    "systeminformation": "^5.7.10",
    "tar": "^6.1.0",
    "ts.data.json": "^2.1.0",
    "uuid": "^8.3.2"
  },
  "devDependencies": {
    "@cucumber/cucumber": "^7.1.0",
    "@cucumber/pretty-formatter": "^1.0.0-alpha.0",
    "@types/dockerode": "^3.2.2",
    "@types/find-package-json": "^1.2.1",
    "@types/minimatch": "^3.0.4",
    "@types/node": "15.12.5",
    "@types/node-fetch": "^2.5.11",
    "@types/proxyquire": "^1.3.28",
    "@types/shell-escape": "^0.2.0",
    "@types/sinon": "^10.0.2",
    "@types/tar": "^4.0.4",
    "@types/trouter": "^3.1.0",
    "@types/uuid": "^8.3.1",
    "@typescript-eslint/eslint-plugin": "^4.27.0",
    "@typescript-eslint/parser": "^4.27.0",
    "ava": "^3.15.0",
    "build-if-changed": "^1.5.5",
    "cloc": "^2.8.0",
    "eslint": "^7.29.0",
    "eslint-plugin-import": "^2.23.3",
    "eslint-to-editorconfig": "^2.0.0",
    "fs-extra": "^9.1.0",
    "glob": "^7.1.7",
    "globrex": "^0.1.2",
    "husky": "^6.0.0",
    "lerna": "^4.0.0",
    "nyc": "^15.1.0",
    "proxyquire": "^2.1.3",
    "semver": "^7.3.5",
    "sinon": "^11.1.1",
    "syncpack": "^5.7.11",
    "toposort": "^2.0.2",
    "trouter": "^3.2.0",
    "ts-loader": "^9.2.3",
    "ts-node": "^10.0.0",
    "typedoc": "^0.22.10",
    "typedoc-plugin-markdown": "^3.11.7",
    "typescript": "^4.3.4"
  },
  "peerDependencies": {},
  "optiopnalDependencies": {}
}
```