### PR TITLE
Change default STH host from localhost to 0.0.0.0

### DIFF
--- a/packages/sth-config/src/config-service.ts
+++ b/packages/sth-config/src/config-service.ts
@@ -20,7 +20,7 @@ const _defaultConfig: STHConfiguration = {
     },
     identifyExisting: false,
     host: {
-        hostname: "localhost",
+        hostname: "0.0.0.0",
         port: 8000,
         apiBase: "/api/v1",
         socketPath: "/tmp/scramjet-socket-server-path",


### PR DESCRIPTION
A really minor change but useful when testing. With STH default hostname set to `0.0.0.0`, it will be available as `localhost`/`127.0.0.1` as before but also can be reached from another machine via external/public IP.