### PR TITLE
Stop API and socket server when host stopped

### DIFF
--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -519,6 +519,8 @@ export class Host implements IComponent {
         );
 
         this.logger.log("Instances stopped.");
+
+        await this.cleanup();
     }
 
     async cleanup() {
@@ -533,6 +535,17 @@ export class Host implements IComponent {
             this.api.server
                 .once("close", () => {
                     this.logger.log("API server stopped.");
+                    res();
+                })
+                .close();
+        });
+
+        this.logger.log("Stopping socket server...");
+
+        await new Promise<void>((res, _rej) => {
+            this.socketServer.server
+                ?.once("close", () => {
+                    this.logger.log("Socket server stopped.");
                     res();
                 })
                 .close();


### PR DESCRIPTION
At the moment, `STH.stop()` only stops currently running sequences instances. In context of single `STH` it is also not used anywhere AFAIU, because it doesn't make that much sense (since `STH` is a process without any "supervisor").

However, in context of `mSTH`, `.stop()` method is used by `/stop/:sthId` endpoint. And stopping it for now only stopped running instances (and removed `STH` instance from `mSTH` store), however both API and Socket server still run in the background meaning that:

* stopped STH instance API endpoint were still reachable
* it also occupied the port which should be freed (due to API server still running)

I'm not 100% sure, but I think that it makes sense that `STH` instance can cleanup after itself (within itself), instead of relaying on the parent process/object.

There is also no test coverage for now. Should we go with BDD here or maybe something else?