### PR TITLE
Do not check if file exists when filename has not been provided

### DIFF
--- a/packages/cli/src/lib/commands/instance.ts
+++ b/packages/cli/src/lib/commands/instance.ts
@@ -84,7 +84,7 @@ export const instance: CommandDefinition = (program) => {
 
             return displayEntity(program,
                 instanceClient.sendInput(
-                    await getReadStreamFromFile(filename) || process.stdin,
+                    filename ? await getReadStreamFromFile(filename) : process.stdin,
                     { type: contentType }
                 )
             );

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -306,17 +306,25 @@ export class CSIController extends EventEmitter {
             }
 
             this.router.upstream("/output", this.upStreams[CommunicationChannel.OUT]);
+
+            let inputHeadersSent = false;
+
             this.router.downstream("/input", (req) => {
                 if (this.apiInputEnabled) {
                     const stream = this.downStreams![CommunicationChannel.IN];
                     const contentType = req.headers["content-type"];
 
-                    if (contentType === undefined) {
-                        throw new Error("Content-Type must be defined");
+                    if (!inputHeadersSent) {
+                        if (contentType === undefined) {
+                            throw new Error("Content-Type must be defined");
+                        }
+
+                        stream.write(`Content-Type: ${contentType}\r\n`);
+                        stream.write("\r\n");
+
+                        inputHeadersSent = true;
                     }
 
-                    stream.write(`Content-Type: ${contentType}\r\n`);
-                    stream.write("\r\n");
                     return stream;
                 }
 


### PR DESCRIPTION
 in `si inst input` command

after fixing this I've found another bug when i've tried to send from stdin and then send a file contents

Fixed it in the way that subsequent requests to instance `input` don't send `content-type` to `Runner` which actually doesn't parse headers more than once.
