### PR TITLE
Improve logger outputs handling

### DIFF
--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -555,6 +555,7 @@ export class Host implements IComponent {
         this.logger.log("Detaching log pipes...");
 
         removeLoggerOutput(this.commonLogsPipe.getIn());
+        removeLoggerOutput(process.stdout, process.stdout, false);
 
         this.logger.log("Cleanup done.");
     }

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -6,7 +6,7 @@ import { Duplex, Readable, Writable } from "stream";
 import { IncomingMessage, ServerResponse } from "http";
 import { InstanceMessageCode, RunnerMessageCode, SequenceMessageCode } from "@scramjet/symbols";
 import { access, unlink } from "fs/promises";
-import { addLoggerOutput, getLogger } from "@scramjet/logger";
+import { addLoggerOutput, removeLoggerOutput, getLogger } from "@scramjet/logger";
 
 import { AddressInfo } from "net";
 import { CPMConnector } from "./cpm-connector";
@@ -551,6 +551,10 @@ export class Host implements IComponent {
                 })
                 .close();
         });
+
+        this.logger.log("Detaching log pipes...");
+
+        removeLoggerOutput(this.commonLogsPipe.getIn());
 
         this.logger.log("Cleanup done.");
     }

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -166,7 +166,7 @@ const addLoggerStream = (stream: WritableStream<any>, dest: LoggerOutputStream<a
 
     dest.push(outputStream);
 };
-const removeLoggerStream = (stream: WritableStream<any>, dest: LoggerOutputStream<any>[]) => {
+const removeLoggerStream = (stream: WritableStream<any>, dest: LoggerOutputStream<any>[], end: boolean) => {
     const loggerIndex = dest.findIndex(src => src.origin === stream || src.output === stream);
 
     if (loggerIndex !== -1) {
@@ -176,7 +176,10 @@ const removeLoggerStream = (stream: WritableStream<any>, dest: LoggerOutputStrea
 
         if (loggerOutput.count === 0) {
             dest.splice(loggerIndex, 1);
-            loggerOutput.output.end();
+
+            if (end) {
+                loggerOutput.output.end();
+            }
         }
     }
 };
@@ -203,10 +206,11 @@ export function addLoggerOutput(out: WritableStream<any>, err: WritableStream<an
  *
  * @param out - stream for stdout logging
  * @param err - stream for stderr logging
+ * @param end - if true, closes the stream after removing it
  */
-export function removeLoggerOutput(out: WritableStream<any>, err: WritableStream<any> = out) {
-    removeLoggerStream(out, loggerOutputs.out);
-    removeLoggerStream(err, loggerOutputs.err);
+export function removeLoggerOutput(out: WritableStream<any>, err: WritableStream<any> = out, end: boolean = true) {
+    removeLoggerStream(out, loggerOutputs.out, end);
+    removeLoggerStream(err, loggerOutputs.err, end);
 }
 
 /**


### PR DESCRIPTION
This PR introduces two changes to how `loggerOutputs` in `Logger` class could be added and removed. It solves two issue:

* Log duplication (as described in https://app.clickup.com/t/24308805/SCP-2172).
* Memory leaks (by duplicated and/or not cleaned up log streams, as described in https://github.com/scramjetorg/scramjet-cpm-dev/issues/123#issuecomment-1002536428).

## Prevent from adding the same output to logger multiple times

There was an issue when multiple instances of any class using logger (e.g. `STH`) will [call `.addLoggerOutput(process.stdout);` which will "register" `process.stdout`](https://github.com/scramjetorg/transform-hub/blob/82accab74a0ef1450fc4f13c6e074b4e03316ef6/packages/host/src/lib/host.ts#L90) multiple times as logger output leading to log duplication. It also resulted in increased (unnecessary) memory allocation.

This has been fix by introducing mechanism which checks if given logger `dest` has specific log stream already added/registered in https://github.com/scramjetorg/transform-hub/pull/181/commits/06223bdbe43a7f731e63bcce90376c062b97665f.

## Allow removing/closing `loggerOutputs` streams

This is strictly related to memory leaks - if any instance registers it's custom output stream (for example [`STH`s `CommonLogsPipe`](https://github.com/scramjetorg/transform-hub/blob/82accab74a0ef1450fc4f13c6e074b4e03316ef6/packages/host/src/lib/host.ts#L91)), when this instance is stopped / removed / its lifecycle ends, the output stream should be removed from the logger too. If it's not, it's left there causing memory leak. This was fixed for `STH` (only) in this PR in https://github.com/scramjetorg/transform-hub/pull/181/commits/e555620f66d37ba7508b29b3ec224712d57c20af and https://github.com/scramjetorg/transform-hub/pull/181/commits/06ae70cb0daa9eeefaa8f28ab74632aad0d19ae2.

---

I have also added a small mechanism which glues both things mentioned above which counts how many times specific stream was requested to be added/removed from logger. It prevents one instance from removing output stream which is shared by multiple instances. The mechanism is a bit naive (relying on counting add/remove calls with a given stream instance) but it seems to do the job.