### PR TITLE
Allow stoping Verser

### DIFF
--- a/packages/verser/src/lib/verser-connection.ts
+++ b/packages/verser/src/lib/verser-connection.ts
@@ -156,8 +156,13 @@ export class VerserConnection {
      * @returns Promise resolving when connection is ended.
      */
     async close() {
+        this.logger.log("Closing VerserConnection...");
+
         return new Promise<void>(res => {
-            this.socket.end(res);
+            this.socket.end(() => {
+                this.logger.log("VerserConnection closed.");
+                res();
+            });
         });
     }
 }

--- a/packages/verser/src/lib/verser-connection.ts
+++ b/packages/verser/src/lib/verser-connection.ts
@@ -149,4 +149,15 @@ export class VerserConnection {
             // TODO: Error handling?
         });
     }
+
+    /**
+     * Closes the connection by sending FIN packet.
+     *
+     * @returns Promise resolving when connection is ended.
+     */
+    async close() {
+        return new Promise<void>(res => {
+            this.socket.end(res);
+        });
+    }
 }

--- a/packages/verser/src/lib/verser.ts
+++ b/packages/verser/src/lib/verser.ts
@@ -30,13 +30,17 @@ export class Verser extends TypedEmitter<Events> {
         });
     }
 
-    async stop() {
+    async disconnect() {
         await Promise.all(this.connections.map(connection => connection.close()));
+
+        this.connections = [];
+    }
+
+    async stop() {
+        await this.disconnect();
 
         await new Promise<void>(res => {
             this.server.once("close", res).close();
         });
-
-        this.connections = [];
     }
 }


### PR DESCRIPTION
This PR introduces mechanism for closing/stoping Verser server. It is used in a `Multi-Manager` when `Manager` instance is to be stopped.

~It first ends all open connections and then stops Verser server~. For now connected Hosts will error due to dropped connection as we decided to cover this in a follow-up. I did one correction, since `server` instance in `Verser` is passed by external resource stopping it may not be the best idea in some cases - thus I had ended up with two methods `disconnect()` (drops all connections) and `stop()` (drops all connections and stops the server) - see https://github.com/scramjetorg/transform-hub/pull/196/commits/741189f6f1998c47ddb189c6642ccda0ccdf6ef6.

For more reference why this PR was introduced please see https://github.com/scramjetorg/scramjet-cpm-dev/pull/130#issue-1094257847.