### PR TITLE
Add last uploaded id alias in cli

### DIFF
--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -198,3 +198,25 @@ Feature: CLI tests
         And I get the second instance output
         Then confirm data named "hello-input-out-10" received
         * stop host
+
+    @ci
+    Scenario: E2E-010 TC-022 Check minus set/remove
+        Given I execute CLI with "seq select abc" arguments
+        And I execute CLI with "inst select def" arguments
+        Then I get the last sequence id from config
+        And I get the last instance id from config
+        And The sequence id equals "abc"
+        And The instance id equals "def"
+
+    @ci
+    Scenario: E2E-010 TC-023 Check minus replacements with a sequence
+        Given host is running
+        When I execute CLI with "pack ../dist/reference-apps/hello-alice-out" arguments
+        And I execute CLI with "seq send -" arguments
+        And I execute CLI with "seq start -" arguments
+        Then I get the last sequence id from config
+        Then I get the last instance id from config
+        And I get instance info
+        And I execute CLI with "inst kill -" arguments
+        And I execute CLI with "seq rm -" arguments
+        And host is still running

--- a/bdd/step-definitions/e2e/cli.ts
+++ b/bdd/step-definitions/e2e/cli.ts
@@ -37,6 +37,10 @@ When("I execute CLI with bash command {string}", { timeout: 30000 }, async funct
 
 When("I execute CLI with {string} arguments", { timeout: 30000 }, async function(args: string) {
     stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, ...args.split(" "), ...connectionFlags()]);
+
+    if (process.env.SCRAMJET_TEST_LOG) {
+        console.error(stdio);
+    }
     assert.equal(stdio[2], 0);
 });
 
@@ -121,6 +125,36 @@ Then("I get array of information about sequences", function() {
     const arr = JSON.parse(stdio[0].replace("\n", ""));
 
     assert.equal(Array.isArray(arr), true);
+});
+
+Then('I get the last instance id from config', async function() {
+    // Write code here that turns the phrase above into concrete actions
+    stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "config", "p", "--format", "json"]);
+    instanceId = JSON.parse(stdio[0]).lastInstanceId;
+
+    assert.ok(typeof instanceId === "string", "instanceId must be defined");
+    assert.ok(instanceId.length > 0, "Instance id is not empty");
+});
+
+Then('I get the last sequence id from config', async function() {
+    // Write code here that turns the phrase above into concrete actions
+    stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "config", "p", "--format", "json"]);
+    if (process.env.SCRAMJET_TEST_LOG) {
+        console.error(stdio);
+    }
+
+    sequenceId = JSON.parse(stdio[0]).lastSequenceId;
+
+    assert.ok(typeof sequenceId === "string", "sequenceId must be defined");
+    assert.ok(sequenceId.length > 0, "Sequence id is not empty");
+});
+
+Then('The sequence id equals {string}', function(str: string) {
+    assert.strictEqual(str, sequenceId);
+});
+
+Then('The instance id equals {string}', function(str: string) {
+    assert.strictEqual(str, instanceId);
 });
 
 Then("I start Sequence", async function() {

--- a/packages/cli/src/lib/commands/config.ts
+++ b/packages/cli/src/lib/commands/config.ts
@@ -1,5 +1,5 @@
 import { CommandDefinition } from "../../types";
-import { getConfig, setConfigValue } from "../config";
+import { delConfigValue, getConfig, setConfigValue } from "../config";
 import { displayObject } from "../output";
 
 /**
@@ -12,7 +12,7 @@ export const config: CommandDefinition = (program) => {
      * Set custom value for config and write it to JSON file.
     */
     const configCmd = program
-        .command("config [command]")
+        .command("config")
         .alias("c")
         .description("configuration file operations");
 
@@ -23,7 +23,7 @@ export const config: CommandDefinition = (program) => {
     */
     configCmd.command("print")
         .alias("p")
-        .description("print out the current config")
+        .description("Print out the current config")
         .action(() => displayObject(program, getConfig()));
 
     /**
@@ -32,7 +32,7 @@ export const config: CommandDefinition = (program) => {
      * Log: configVersion, apiUrl, logLevel, format
      */
     configCmd.command("apiUrl <apiUrl>")
-        .description("set the hub API url")
+        .description("Set the hub API url")
         .action((value) => setConfigValue("apiUrl", value));
 
     /**
@@ -40,6 +40,15 @@ export const config: CommandDefinition = (program) => {
      * Default `format`: {@link defaultConfig.format}
      */
     configCmd.command("logLevel <logLevel>")
-        .description("set the hub API url")
+        .description("Set the hub API url")
         .action((value) => setConfigValue("log", value));
+
+    configCmd.command("set <key> <value>")
+        .description("Set config value")
+        .action((key, value) => setConfigValue(key, value));
+
+    configCmd.command("unset <key>")
+        .alias("del")
+        .description("Unset config value")
+        .action((key) => delConfigValue(key));
 };

--- a/packages/cli/src/lib/commands/instance.ts
+++ b/packages/cli/src/lib/commands/instance.ts
@@ -2,7 +2,7 @@
 import { createReadStream } from "fs";
 import { CommandDefinition } from "../../types";
 import { attachStdio, getHostClient, getInstance, getReadStreamFromFile } from "../common";
-import { getInstanceId } from "../config";
+import { getInstanceId, setConfigValue } from "../config";
 import { displayEntity, displayStream } from "../output";
 
 /**
@@ -58,9 +58,14 @@ export const instance: CommandDefinition = (program) => {
             );
         });
 
+    instanceCmd.command("select")
+        .description("Select an instance id as default")
+        .argument("<id>", "The instance id")
+        .action(async (id) => setConfigValue("lastInstanceId", id));
+
     instanceCmd.command("info")
-        .description("show info about the instance")
-        .argument("<id>", "The instance id to remove or '-' for the last one started.")
+        .description("Display info about the instance")
+        .argument("<id>", "The instance id or '-' for the last one started or selected.")
         .action(async (id) => displayEntity(
             program,
             getHostClient(program).getInstanceInfo(getInstanceId(id))
@@ -69,7 +74,7 @@ export const instance: CommandDefinition = (program) => {
     instanceCmd.command("invokeEvent")
         .alias("emit")
         .description("Sends event with eventName and a JSON formatted event payload")
-        .argument("<id>", "The instance id to remove or '-' for the last one started.")
+        .argument("<id>", "The instance id or '-' for the last one started or selected.")
         .arguments("<eventName> [<payload>]")
         .action(async (id, eventName, message) => {
             const instanceClient = getInstance(program, getInstanceId(id));
@@ -88,7 +93,7 @@ export const instance: CommandDefinition = (program) => {
     instanceCmd.command("event")
         .description("Get the last event occurence (will wait for the first one if not yet retrieved)")
         .alias("on")
-        .argument("<id>", "The instance id to remove or '-' for the last one started.")
+        .argument("<id>", "The instance id or '-' for the last one started or selected.")
         .argument("<eventName>", "The event name")
         .option("-s, --stream", "stream the events (the stream will start with last event)")
         .option("-n, --next", "wait for the next event occurrence")
@@ -113,7 +118,7 @@ export const instance: CommandDefinition = (program) => {
 
     instanceCmd.command("input")
         .description("Sends file to input, if file not given the data will be read from stdin")
-        .argument("<id>", "The instance id to remove or '-' for the last one started.")
+        .argument("<id>", "The instance id or '-' for the last one started or selected.")
         .argument("[<file>]", "The input file (stdin if not given default)")
         .option("-t, --content-type <value>", "Content-Type", "text/plain")
         .action(async (id, filename, { contentType }) => {
@@ -128,21 +133,21 @@ export const instance: CommandDefinition = (program) => {
         });
 
     instanceCmd.command("output")
-        .argument("<id>", "The instance id to remove or '-' for the last one started.")
+        .argument("<id>", "The instance id or '-' for the last one started or selected.")
         .description("Pipe running instance output to stdout")
         .action((id) => {
             return displayStream(program, getInstance(program, getInstanceId(id)).getStream("output"));
         });
 
     instanceCmd.command("log")
-        .argument("<id>", "The instance id to remove or '-' for the last one started.")
+        .argument("<id>", "The instance id or '-' for the last one started or selected.")
         .description("Pipe running instance log to stdout")
         .action((id) => {
             return displayStream(program, getInstance(program, getInstanceId(id)).getStream("log"));
         });
 
     instanceCmd.command("attach")
-        .argument("<id>", "The instance id to remove or '-' for the last one started.")
+        .argument("<id>", "The instance id or '-' for the last one started or selected.")
         .description("Connect to all stdio - stdin, stdout, stderr of a running instance")
         .action(async (id) => {
             const inst = getInstance(program, getInstanceId(id));
@@ -152,7 +157,7 @@ export const instance: CommandDefinition = (program) => {
 
     instanceCmd.command("stdin")
         .description("Send file to stdin, if file not given the data will be read from stdin")
-        .argument("<id>", "The instance id to remove or '-' for the last one started.")
+        .argument("<id>", "The instance id or '-' for the last one started or selected.")
         .argument("[<file>]", "The input file (stdin if not given default)")
         .action((id, stream) => {
             const instanceClient = getInstance(program, getInstanceId(id));
@@ -165,7 +170,7 @@ export const instance: CommandDefinition = (program) => {
 
     instanceCmd.command("stderr")
         .description("Pipe running instances stderr stream to stdout")
-        .argument("<id>", "The instance id to remove or '-' for the last one started.")
+        .argument("<id>", "The instance id or '-' for the last one started or selected.")
         .action((id) => displayStream(
             program,
             getInstance(program, getInstanceId(id)).getStream("stderr")
@@ -173,7 +178,7 @@ export const instance: CommandDefinition = (program) => {
 
     instanceCmd.command("stdout")
         .description("Pipe running instances stdout stream to stdout")
-        .argument("<id>", "The instance id to remove or '-' for the last one started.")
+        .argument("<id>", "The instance id or '-' for the last one started or selected.")
         .action((id) => {
             return displayStream(program, getInstance(program, getInstanceId(id)).getStream("stdout"));
         });

--- a/packages/cli/src/lib/commands/instance.ts
+++ b/packages/cli/src/lib/commands/instance.ts
@@ -2,6 +2,7 @@
 import { createReadStream } from "fs";
 import { CommandDefinition } from "../../types";
 import { attachStdio, getHostClient, getInstance, getReadStreamFromFile } from "../common";
+import { getInstanceId } from "../config";
 import { displayEntity, displayStream } from "../output";
 
 /**
@@ -20,10 +21,11 @@ export const instance: CommandDefinition = (program) => {
         .description("list the instances")
         .action(async () => displayEntity(program, getHostClient(program).listInstances()));
 
-    instanceCmd.command("kill <id>")
-        .description("kill instance without waiting for unfinished tasks")
+    instanceCmd.command("kill")
+        .description("Kill instance immediately without waiting for unfinished tasks")
+        .argument("<id>", "The instance id or '-' for the last one started.")
         .action(async (id) => {
-            return displayEntity(program, getInstance(program, id).kill());
+            return displayEntity(program, getInstance(program, getInstanceId(id)).kill());
         });
 
     /**
@@ -31,35 +33,51 @@ export const instance: CommandDefinition = (program) => {
      * if true instance can prolong its lifetime
      * if false instance will end after timeout
     */
-    instanceCmd.command("stop <id> <timeout>")
-        .description("end instance gracefully waiting for unfinished tasks")
+    instanceCmd.command("stop")
+        .description("End instance gracefully with waiting for unfinished tasks")
+        .argument("<id>", "The instance id or '-' for the last one started.")
+        .argument("<timeout>", "Timeout in milliseconds.")
         .action(async (id, timeout) => {
-            return displayEntity(program, getInstance(program, id).stop(+timeout, true));
+            return displayEntity(program, getInstance(program, getInstanceId(id)).stop(+timeout, true));
         });
 
-    instanceCmd.command("status <id>")
-        .description("status data about the instance")
+    instanceCmd.command("status")
+        .description("Display status data about the instance")
+        .argument("<id>", "The instance id or '-' for the last one started.")
         .action(() => {
             console.log("Not implemented");
         });
 
-    instanceCmd.command("health <id>")
-        .description("show the instance health status")
+    instanceCmd.command("health")
+        .description("Display last instance health status")
+        .argument("<id>", "The instance id or '-' for the last one started.")
         .action((id) => {
-            return displayEntity(program, getInstance(program, id).getHealth());
+            return displayEntity(
+                program,
+                getInstance(program, getInstanceId(id)).getHealth()
+            );
         });
 
-    instanceCmd.command("info <id>")
+    instanceCmd.command("info")
         .description("show info about the instance")
-        .action(async (id) => displayEntity(program, getHostClient(program).getInstanceInfo(id)));
+        .argument("<id>", "The instance id to remove or '-' for the last one started.")
+        .action(async (id) => displayEntity(
+            program,
+            getHostClient(program).getInstanceInfo(getInstanceId(id))
+        ));
 
-    instanceCmd.command("invokeEvent <id> <eventName> [<payload>]")
+    instanceCmd.command("invokeEvent")
         .alias("emit")
-        .description("send event with eventName and a JSON formatted event payload")
+        .description("Sends event with eventName and a JSON formatted event payload")
+        .argument("<id>", "The instance id to remove or '-' for the last one started.")
+        .arguments("<eventName> [<payload>]")
         .action(async (id, eventName, message) => {
-            const instanceClient = getInstance(program, id);
+            const instanceClient = getInstance(program, getInstanceId(id));
 
-            return displayEntity(program, instanceClient.sendEvent(eventName, message));
+            return displayEntity(
+                program,
+                instanceClient.sendEvent(eventName, message)
+            );
         });
 
     /**
@@ -67,25 +85,39 @@ export const instance: CommandDefinition = (program) => {
      * Currently there is no event filtering.
      * Only the last event instance is returned
      */
-    instanceCmd.command("event <id> <event>")
+    instanceCmd.command("event")
+        .description("Get the last event occurence (will wait for the first one if not yet retrieved)")
         .alias("on")
+        .argument("<id>", "The instance id to remove or '-' for the last one started.")
+        .argument("<eventName>", "The event name")
         .option("-s, --stream", "stream the events (the stream will start with last event)")
         .option("-n, --next", "wait for the next event occurrence")
-        .description("get the last event occurence (will wait for the first one if not yet retrieved)")
         .action(async (id, event, { next, stream }) => {
             if (stream)
-                return displayStream(program, getInstance(program, id).getEventStream(event));
-            if (next)
-                return displayEntity(program, getInstance(program, id).getNextEvent(event));
+                return displayStream(
+                    program,
+                    getInstance(program, getInstanceId(id)).getEventStream(event)
+                );
 
-            return displayEntity(program, getInstance(program, id).getEvent(event));
+            if (next)
+                return displayEntity(
+                    program,
+                    getInstance(program, getInstanceId(id)).getNextEvent(event)
+                );
+
+            return displayEntity(
+                program,
+                getInstance(program, getInstanceId(id)).getEvent(event)
+            );
         });
 
-    instanceCmd.command("input <id> [<file>]")
+    instanceCmd.command("input")
+        .description("Sends file to input, if file not given the data will be read from stdin")
+        .argument("<id>", "The instance id to remove or '-' for the last one started.")
+        .argument("[<file>]", "The input file (stdin if not given default)")
         .option("-t, --content-type <value>", "Content-Type", "text/plain")
-        .description("send file to input, if file not given the data will be read from stdin")
         .action(async (id, filename, { contentType }) => {
-            const instanceClient = getInstance(program, id);
+            const instanceClient = getInstance(program, getInstanceId(id));
 
             return displayEntity(program,
                 instanceClient.sendInput(
@@ -95,44 +127,54 @@ export const instance: CommandDefinition = (program) => {
             );
         });
 
-    instanceCmd.command("output <id>")
-        .description("show stream on output")
+    instanceCmd.command("output")
+        .argument("<id>", "The instance id to remove or '-' for the last one started.")
+        .description("Pipe running instance output to stdout")
         .action((id) => {
-            return displayStream(program, getInstance(program, id).getStream("output"));
+            return displayStream(program, getInstance(program, getInstanceId(id)).getStream("output"));
         });
 
-    instanceCmd.command("log <id>")
-        .description("show instance log")
+    instanceCmd.command("log")
+        .argument("<id>", "The instance id to remove or '-' for the last one started.")
+        .description("Pipe running instance log to stdout")
         .action((id) => {
-            return displayStream(program, getInstance(program, id).getStream("log"));
+            return displayStream(program, getInstance(program, getInstanceId(id)).getStream("log"));
         });
 
-    instanceCmd.command("attach <id>")
-        .description("connect to all stdio - stdin, stdout, stderr of a running instance")
+    instanceCmd.command("attach")
+        .argument("<id>", "The instance id to remove or '-' for the last one started.")
+        .description("Connect to all stdio - stdin, stdout, stderr of a running instance")
         .action(async (id) => {
-            const inst = getInstance(program, id);
+            const inst = getInstance(program, getInstanceId(id));
 
             await attachStdio(program, inst);
         });
 
-    instanceCmd.command("stdin <id> [<file>]")
-        .description("send file to stdin, if file not given the data will be read from stdin")
+    instanceCmd.command("stdin")
+        .description("Send file to stdin, if file not given the data will be read from stdin")
+        .argument("<id>", "The instance id to remove or '-' for the last one started.")
+        .argument("[<file>]", "The input file (stdin if not given default)")
         .action((id, stream) => {
-            const instanceClient = getInstance(program, id);
+            const instanceClient = getInstance(program, getInstanceId(id));
 
-            return displayEntity(program,
-                instanceClient.sendStdin(stream ? createReadStream(stream) : process.stdin));
+            return displayEntity(
+                program,
+                instanceClient.sendStdin(stream ? createReadStream(stream) : process.stdin)
+            );
         });
 
-    instanceCmd.command("stderr <id>")
-        .description("show stream on stderr")
-        .action((id) => {
-            return displayStream(program, getInstance(program, id).getStream("stderr"));
-        });
+    instanceCmd.command("stderr")
+        .description("Pipe running instances stderr stream to stdout")
+        .argument("<id>", "The instance id to remove or '-' for the last one started.")
+        .action((id) => displayStream(
+            program,
+            getInstance(program, getInstanceId(id)).getStream("stderr")
+        ));
 
-    instanceCmd.command("stdout <id>")
-        .description("show stream on stdout")
+    instanceCmd.command("stdout")
+        .description("Pipe running instances stdout stream to stdout")
+        .argument("<id>", "The instance id to remove or '-' for the last one started.")
         .action((id) => {
-            return displayStream(program, getInstance(program, id).getStream("stdout"));
+            return displayStream(program, getInstance(program, getInstanceId(id)).getStream("stdout"));
         });
 };

--- a/packages/cli/src/lib/commands/sequence.ts
+++ b/packages/cli/src/lib/commands/sequence.ts
@@ -2,7 +2,12 @@ import { SequenceClient } from "@scramjet/api-client";
 import { readFile } from "fs/promises";
 import { CommandDefinition } from "../../types";
 import { attachStdio, getHostClient, getReadStreamFromFile } from "../common";
+import { getSequenceId, setConfigValue } from "../config";
 import { displayEntity, displayObject } from "../output";
+
+async function resolveConfigJson(configJson: any, config: any): Promise<any> {
+    return configJson || config ? JSON.parse(configJson || await readFile(config, "utf-8")) : {};
+}
 
 /**
  * Initializes `sequence` command.
@@ -13,19 +18,26 @@ export const sequence: CommandDefinition = (program) => {
     const sequenceCmd = program
         .command("sequence [command]")
         .alias("seq")
-        .description("operations on sequence");
+        .description("Performs operations on sequences");
 
     sequenceCmd
-        .command("run [package] [args...]")
+        .command("run")
         .description("Uploads a package and immediately executes it with given arguments")
+        .argument("<package>", "The file to upload or '-' to use the last packed")
+        .argument("[args...]", "Additional args")
         .option("-d, --detached", "Don't attach to stdio")
-        .option("-c, --config <path>", "Appconfig path location")
+        .option("-c, --config <config-path>", "Appconfig path location")
+        .option("-C, --config-json <config-string>", "Appconfig as string")
         .action(async (sequencePackage, args) => {
             const { config: configPath, detached } = sequenceCmd.opts();
             const config = configPath ? JSON.parse(await readFile(configPath, "utf-8")) : {};
             const seq = await getHostClient(program)
                 .sendSequence(sequencePackage ? await getReadStreamFromFile(sequencePackage) : process.stdin);
+
+            setConfigValue("lastSequenceId", seq.id);
             const instance = await seq.start(config, args);
+
+            setConfigValue("lastInstanceId", instance.id);
 
             if (!detached) {
                 await attachStdio(program, instance);
@@ -33,13 +45,18 @@ export const sequence: CommandDefinition = (program) => {
         })
     ;
 
-    sequenceCmd.command("send [<sequencePackage>]")
-        .description("send packed and compressed sequence file")
-        .action(async (sequencePackage) =>
-            displayObject(program, await getHostClient(program).sendSequence(
+    sequenceCmd.command("send")
+        .description("Send packed and compressed sequence file")
+        .argument("[<sequencePackage>]", "The file to upload or '-' to use the last packed. Leave empty for stdin.")
+        .action(async (sequencePackage) => {
+            const seq = await getHostClient(program).sendSequence(
                 sequencePackage ? await getReadStreamFromFile(sequencePackage) : process.stdin
-            ))
-        );
+            );
+
+            setConfigValue("lastSequenceId", seq.id);
+
+            return displayObject(program, seq);
+        });
 
     /**
      * Command `si sequence list`
@@ -47,7 +64,7 @@ export const sequence: CommandDefinition = (program) => {
      */
     sequenceCmd.command("list")
         .alias("ls")
-        .description("list the sequences")
+        .description("Lists available sequences")
         .action(async () => displayEntity(program, getHostClient(program).listSequences()));
 
     /**
@@ -58,16 +75,22 @@ export const sequence: CommandDefinition = (program) => {
     * @returns {Object} with response or error
     */
     sequenceCmd.command("start")
-        .arguments("<id> [args...]")
-        .description("start the sequence")
-        .option("-c, --config <config-path>")
-        .option("-C, --config-json <config-string>")
+        .description("Starts a sequence")
+        .argument("<id>", "The sequence id to start or '-' for the last uploaded.")
+        .argument("[args...]")
+        .option("-c, --config <config-path>", "Appconfig path location")
+        .option("-C, --config-json <config-string>", "Appconfig as string")
         .action(async (id, args) => {
             const { config, configJson } = sequenceCmd.opts();
-            const sequenceClient = SequenceClient.from(id, getHostClient(program));
+            const sequenceClient = SequenceClient.from(
+                getSequenceId(id),
+                getHostClient(program)
+            );
 
-            return displayObject(program,
-                await sequenceClient.start(configJson || config ? JSON.parse(configJson || await readFile(config, "utf-8")) : {}, args));
+            const instance = await sequenceClient.start(await resolveConfigJson(configJson, config), args);
+
+            setConfigValue("lastInstanceId", instance.id);
+            return displayObject(program, instance);
         });
 
     /**
@@ -77,16 +100,27 @@ export const sequence: CommandDefinition = (program) => {
     * @param args for example '[10000, 2000]' | '["tcp"]'
     * @returns {Object} with response or error
     */
-    sequenceCmd.command("get <id>")
-        .description("get data about the sequence")
-        .action(async (id) => displayEntity(program, getHostClient(program).getSequence(id)));
+    sequenceCmd.command("get")
+        .argument("<id>", "The sequence id to start or '-' for the last uploaded.")
+        .description("Obtains basic information about a sequence")
+        .action(async (id) => {
+            return displayEntity(
+                program,
+                getHostClient(program).getSequence(getSequenceId(id))
+            );
+        });
 
     /**
     * Command `si sequence delete`
     * @param id sequence
     */
-    sequenceCmd.command("delete <id>")
+    sequenceCmd.command("delete")
+        .description("Removes the sequence from STH")
+        .argument("<id>", "The sequence id to remove or '-' for the last uploaded.")
         .alias("rm")
-        .description("delete the sequence")
-        .action(async (id) => displayEntity(program, getHostClient(program).deleteSequence(id)));
+        .action(async (id) => {
+            return displayEntity(program, getHostClient(program).deleteSequence(
+                getSequenceId(id)
+            ));
+        });
 };

--- a/packages/cli/src/lib/commands/sequence.ts
+++ b/packages/cli/src/lib/commands/sequence.ts
@@ -68,6 +68,14 @@ export const sequence: CommandDefinition = (program) => {
         .action(async () => displayEntity(program, getHostClient(program).listSequences()));
 
     /**
+     * Command `si sequence select`
+     */
+    sequenceCmd.command("select")
+        .description("Select a sequence id as default")
+        .argument("<id>", "The sequence id")
+        .action(async (id) => setConfigValue("lastSequenceId", id));
+
+    /**
     * Command `si sequence start`
     * @param id sequence
     * @param appConfig

--- a/packages/cli/src/lib/commands/sequence.ts
+++ b/packages/cli/src/lib/commands/sequence.ts
@@ -2,7 +2,7 @@ import { SequenceClient } from "@scramjet/api-client";
 import { readFile } from "fs/promises";
 import { CommandDefinition } from "../../types";
 import { attachStdio, getHostClient, getReadStreamFromFile } from "../common";
-import { getSequenceId, setConfigValue } from "../config";
+import { getPackagePath, getSequenceId, setConfigValue } from "../config";
 import { displayEntity, displayObject } from "../output";
 
 async function resolveConfigJson(configJson: any, config: any): Promise<any> {
@@ -50,7 +50,7 @@ export const sequence: CommandDefinition = (program) => {
         .argument("[<sequencePackage>]", "The file to upload or '-' to use the last packed. Leave empty for stdin.")
         .action(async (sequencePackage) => {
             const seq = await getHostClient(program).sendSequence(
-                sequencePackage ? await getReadStreamFromFile(sequencePackage) : process.stdin
+                sequencePackage ? await getReadStreamFromFile(getPackagePath(sequencePackage)) : process.stdin
             );
 
             setConfigValue("lastSequenceId", seq.id);

--- a/packages/cli/src/lib/common.ts
+++ b/packages/cli/src/lib/common.ts
@@ -8,6 +8,7 @@ import { c } from "tar";
 import { StringStream } from "scramjet";
 import { filter as mmfilter } from "minimatch";
 import { Readable } from "stream";
+import { setConfigValue } from "./config";
 
 const { F_OK, R_OK } = constants;
 
@@ -117,9 +118,13 @@ export const packAction = async (directory: string, { stdout, output }: { stdout
         throw new Error(`${packageLocation} not found.`);
     });
 
+    const ouputPath = output ? resolve(process.cwd(), output) : `${cwd}.tar.gz`;
     const target = stdout
         ? process.stdout
-        : createWriteStream(output ? resolve(process.cwd(), output) : `${cwd}.tar.gz`);
+        : createWriteStream(ouputPath);
+
+    if (!stdout) setConfigValue("lastPackagePath", ouputPath);
+
     const ignoreLocation = resolve(cwd, ".siignore");
     const filter = await getIgnoreFunction(ignoreLocation);
     const out = c(

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -48,6 +48,35 @@ export const getConfig = () => {
 };
 
 /**
+ * Writes config
+ *
+ * @param conf - the config
+ */
+function writeConfig(conf: any) {
+    try {
+        writeFileSync(location, JSON.stringify(conf, null, 2), "utf-8");
+    } catch (e) {
+        // Just log info here.
+        // eslint-disable-next-line no-console
+        console.error("Warning: couldn't write config update");
+    }
+}
+
+export const delConfigValue = (key: keyof Config) => {
+    const conf = getConfig();
+
+    if (
+        Object.prototype.hasOwnProperty.call(defaultConfig, key)
+    ) {
+        delete conf[key];
+    } else {
+        throw new Error(`Unknown config entry: ${key}`);
+    }
+
+    writeConfig(conf);
+};
+
+/**
  * Set custom value for config and write it to JSON file.
  *
  * @param {defaultConfig} key Property to be set.
@@ -70,13 +99,7 @@ export const setConfigValue = (key: keyof Config, value: number | string | boole
         throw new Error(`Unknown config entry: ${key}`);
     }
 
-    try {
-        writeFileSync(location, JSON.stringify(conf, null, 2), "utf-8");
-    } catch (e) {
-        // Just log info here.
-        // eslint-disable-next-line no-console
-        console.error("Warning: couldn't write config update");
-    }
+    writeConfig(conf);
 };
 
 const getDashDefaultValue = (id: string, def: string) => {
@@ -109,4 +132,3 @@ export const getInstanceId = (id: string) => getDashDefaultValue(id, getConfig()
  * @returns the correct id
  */
 export const getPackagePath = (path: string) => getDashDefaultValue(path, getConfig().lastPackagePath);
-

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -9,7 +9,10 @@ const defaultConfig = {
     configVersion: 1,
     apiUrl: "http://127.0.0.1:8000/api/v1",
     log: true,
-    format: "pretty"
+    format: "pretty",
+    lastPackagePath: "",
+    lastInstanceId: "",
+    lastSequenceId: ""
 };
 
 /**
@@ -17,7 +20,7 @@ const defaultConfig = {
  * @returns defaultConfig
  */
 type Config = typeof defaultConfig;
-const location = resolve(homedir(), "sth-cli-rc.json");
+const location = resolve(homedir(), ".sth-cli-rc.json");
 
 let currentConfig: Config;
 
@@ -67,5 +70,43 @@ export const setConfigValue = (key: keyof Config, value: number | string | boole
         throw new Error(`Unknown config entry: ${key}`);
     }
 
-    writeFileSync(location, JSON.stringify(conf, null, 2), "utf-8");
+    try {
+        writeFileSync(location, JSON.stringify(conf, null, 2), "utf-8");
+    } catch (e) {
+        // Just log info here.
+        // eslint-disable-next-line no-console
+        console.error("Warning: couldn't write config update");
+    }
 };
+
+const getDashDefaultValue = (id: string, def: string) => {
+    if (id !== "-") return id;
+
+    if (!def) throw new Error("Previous value isn't said - you can't use '-' to replace it.");
+    return def;
+};
+
+/**
+ * Gets last sequence id if dash is provided, otherwise returns the first argument
+ *
+ * @param id - dash or anything else
+ * @returns the correct id
+ */
+export const getSequenceId = (id: string) => getDashDefaultValue(id, getConfig().lastSequenceId);
+
+/**
+ * Gets last instance id if dash is provided, otherwise returns the first argument
+ *
+ * @param id - dash or anything else
+ * @returns the correct id
+ */
+export const getInstanceId = (id: string) => getDashDefaultValue(id, getConfig().lastSequenceId);
+
+/**
+ * Gets package file path if dash is provided, otherwise returns the first argument
+ *
+ * @param path - dash or anything else
+ * @returns the correct id
+ */
+export const getPackagePath = (path: string) => getDashDefaultValue(path, getConfig().lastPackagePath);
+


### PR DESCRIPTION
This PR adds CLI functionality that replaces `-` argument for the last item the user interacted with or `select`ed.

Adds `-` functionality on all commands - the sequence can be set by running `si seq|inst select <id>` or when uploading, packing or starting sequences.

Test:

`NO_DOCKER=1 yarn test:bdd --name "E2E-010 TC-023"`

A bit more elaborate test from command line:

```sh
yarn build
npm i -g ./dist/cli
si pack dist/reference-apps/hello-alice-out
si seq send -
si seq start -
si seq info -
```

Have fun.