### PR TITLE
Reenable STH to be run inside a docker container

### DIFF
--- a/packages/adapters/src/docker-instance-adapter.ts
+++ b/packages/adapters/src/docker-instance-adapter.ts
@@ -211,7 +211,7 @@ IComponent {
 
         streams.stderr.on(
             "data",
-            data => this.logger.error("RUNNER DOCKER error", data));
+            data => this.logger.error("RUNNER DOCKER error", data.toString()));
         streams.stdout.pipe(process.stdout);
 
         this.resources.containerId = containerId;

--- a/packages/adapters/src/docker-instance-adapter.ts
+++ b/packages/adapters/src/docker-instance-adapter.ts
@@ -157,7 +157,10 @@ IComponent {
             );
 
             if (!isHostConnected) {
-                await network.connect({ Container: hostname });
+                // @TODO do not connect on instances run, do that before
+                await network.connect({ Container: hostname }).catch((err) => {
+                    this.logger.warn("This STH is probably already connected", err);
+                });
                 this.logger.log("Connecting host");
                 await defer(4000);
                 this.logger.log((await network.inspect()).Containers);

--- a/packages/adapters/src/docker-instance-adapter.ts
+++ b/packages/adapters/src/docker-instance-adapter.ts
@@ -130,16 +130,14 @@ IComponent {
 
         if (isHostSpawnedInDockerContainer) {
             const dockerNetworkName = randomUUID();
-
-            await this.dockerHelper.dockerode.createNetwork({ Name: dockerNetworkName, Driver: "bridge" });
-
-            this.logger.log({ dockerNetworkName });
-
-            this.dockerNetworkName = dockerNetworkName;
-
             const hostname = os.hostname();
 
-            this.logger.log({ hostname });
+            this.logger.log({ dockerNetworkName, hostname });
+            const network = await this.dockerHelper.dockerode.createNetwork({ Name: dockerNetworkName, Driver: "bridge" });
+
+            await network.connect({ Container: hostname });
+
+            this.dockerNetworkName = dockerNetworkName;
 
             return hostname;
         }

--- a/packages/adapters/src/docker-instance-adapter.ts
+++ b/packages/adapters/src/docker-instance-adapter.ts
@@ -19,10 +19,7 @@ import { DockerAdapterResources, DockerAdapterRunPortsConfig, DockerAdapterVolum
 import { FreePortsFinder, defer } from "@scramjet/utility";
 import * as fs from "fs/promises";
 import { randomUUID } from "crypto";
-import * as child_process from "child_process";
-import { promisify } from "util";
-
-const exec = promisify(child_process.exec);
+import { hostname } from "os";
 
 /**
  * Adapter for running Instance by Runner executed in Docker container.
@@ -140,11 +137,7 @@ IComponent {
 
             this.dockerNetworkName = dockerNetworkName;
 
-            const { stdout: hostname } = await exec("hostname");
-
-            this.logger.log({ hostname });
-
-            return hostname;
+            return hostname();
         }
 
         const interfaces = await this.dockerHelper.listNetworks();

--- a/packages/adapters/src/docker-instance-adapter.ts
+++ b/packages/adapters/src/docker-instance-adapter.ts
@@ -208,7 +208,7 @@ IComponent {
             ],
             autoRemove: true,
             maxMem: config.container.maxMem,
-            networkMode: "bridge"
+            networkMode: this.dockerNetworkId ?? "bridge"
         });
 
         this.resources.containerId = containerId;

--- a/packages/adapters/src/docker-instance-adapter.ts
+++ b/packages/adapters/src/docker-instance-adapter.ts
@@ -156,6 +156,9 @@ IComponent {
 
             if (!isHostConnected) {
                 await network.connect({ Container: hostname });
+                this.logger.log("Connecting host");
+
+                this.logger.log(await network.inspect());
             }
 
             this.dockerNetworkName = dockerNetworkName;

--- a/packages/adapters/src/docker-instance-adapter.ts
+++ b/packages/adapters/src/docker-instance-adapter.ts
@@ -253,7 +253,11 @@ IComponent {
         }
 
         if (this.dockerNetworkName) {
-            await this.dockerHelper.dockerode.getNetwork(this.dockerNetworkName).remove();
+            const network = this.dockerHelper.dockerode.getNetwork(this.dockerNetworkName);
+
+            await network.disconnect({ Container: os.hostname() });
+
+            await network.remove();
         }
     }
 

--- a/packages/adapters/src/docker-instance-adapter.ts
+++ b/packages/adapters/src/docker-instance-adapter.ts
@@ -148,17 +148,19 @@ IComponent {
                 });
             }
 
-            this.logger.log(await network.inspect());
+            const containers = (await network.inspect()).Containers;
 
-            const isHostConnected = !!Object.entries((await network.inspect()).Containers).find(
+            this.logger.log({ containers });
+
+            const isHostConnected = !!Object.entries(containers).find(
                 ([id, { Name }]: [string, any]) => id.startsWith(hostname) || Name === hostname
             );
 
             if (!isHostConnected) {
                 await network.connect({ Container: hostname });
                 this.logger.log("Connecting host");
-
-                this.logger.log(await network.inspect());
+                await defer(4000);
+                this.logger.log((await network.inspect()).Containers);
             }
 
             this.dockerNetworkName = dockerNetworkName;

--- a/packages/adapters/src/docker-instance-adapter.ts
+++ b/packages/adapters/src/docker-instance-adapter.ts
@@ -209,7 +209,9 @@ IComponent {
             networkMode: this.dockerNetworkName ?? "bridge"
         });
 
-        streams.stderr.pipe(process.stdout);
+        streams.stderr.on(
+            "data",
+            data => this.logger.error("RUNNER DOCKER error", data));
         streams.stdout.pipe(process.stdout);
 
         this.resources.containerId = containerId;

--- a/packages/adapters/src/docker-instance-adapter.ts
+++ b/packages/adapters/src/docker-instance-adapter.ts
@@ -15,9 +15,8 @@ import {
 } from "@scramjet/types";
 import * as path from "path";
 import { DockerodeDockerHelper } from "./dockerode-docker-helper";
-import { DockerAdapterResources, DockerAdapterRunPortsConfig, DockerAdapterVolumeConfig } from "./types";
+import { DockerAdapterResources, DockerAdapterRunPortsConfig, DockerAdapterVolumeConfig, IDockerHelper } from "./types";
 import { FreePortsFinder, defer } from "@scramjet/utility";
-import * as os from "os";
 import { DOCKER_NETWORK_NAME, isHostSpawnedInDockerContainer, getHostname } from "./docker-networking";
 
 /**
@@ -27,13 +26,11 @@ class DockerInstanceAdapter implements
 ILifeCycleAdapterMain,
 ILifeCycleAdapterRun,
 IComponent {
-    private dockerHelper: DockerodeDockerHelper;
+    private dockerHelper: IDockerHelper;
 
     private resources: DockerAdapterResources = {};
 
     logger: Logger;
-
-    private dockerNetworkName?: string
 
     constructor() {
         this.dockerHelper = new DockerodeDockerHelper();
@@ -245,12 +242,6 @@ IComponent {
             await this.dockerHelper.removeVolume(this.resources.volumeId);
 
             this.logger.log("Volume removed");
-        }
-
-        if (this.dockerNetworkName) {
-            const network = this.dockerHelper.dockerode.getNetwork(this.dockerNetworkName);
-
-            await network.disconnect({ Container: os.hostname() });
         }
     }
 

--- a/packages/adapters/src/docker-networking.ts
+++ b/packages/adapters/src/docker-networking.ts
@@ -1,0 +1,45 @@
+import { DockerodeDockerHelper } from "./dockerode-docker-helper";
+import * as fs from "fs/promises";
+import * as os from "os";
+
+export const isHostSpawnedInDockerContainer = async () => await fs.access("/.dockerenv").then(() => true, () => false);
+
+export const getHostname = () => os.hostname();
+
+export const DOCKER_NETWORK_NAME = "transformhub0";
+
+// @TODO this could be encapsulated into IInstanceAdapter for doing something on Transform Hub launch
+export async function setupDockerNetworking(dockerHelper: DockerodeDockerHelper) {
+    if (await isHostSpawnedInDockerContainer() === false) {
+        return;
+    }
+
+    const network = dockerHelper.dockerode.getNetwork(DOCKER_NETWORK_NAME);
+
+    const networkExists = await network.inspect().then(() => true, () => false);
+
+    if (!networkExists) {
+        await dockerHelper.dockerode.createNetwork({
+            Name: DOCKER_NETWORK_NAME,
+            Driver: "bridge",
+            Options: {
+                "com.docker.network.bridge.host_binding_ipv4":"0.0.0.0",
+                "com.docker.network.bridge.enable_ip_masquerade":"true",
+                "com.docker.network.bridge.enable_icc":"true",
+                "com.docker.network.driver.mtu":"1500"
+            }
+        });
+    }
+
+    const containers = (await network.inspect()).Containers;
+
+    const hostname = getHostname();
+
+    const isHostConnected = !!Object.entries(containers).find(
+        ([id, { Name }]: [string, any]) => id.startsWith(hostname) || Name === hostname
+    );
+
+    if (!isHostConnected) {
+        await network.connect({ Container: hostname });
+    }
+}

--- a/packages/adapters/src/dockerode-docker-helper.ts
+++ b/packages/adapters/src/dockerode-docker-helper.ts
@@ -310,4 +310,8 @@ export class DockerodeDockerHelper implements IDockerHelper {
 
         return { statusCode: containerExitResult.StatusCode };
     }
+
+    async listNetworks(): Promise<Dockerode.NetworkInspectInfo[]> {
+        return this.dockerode.listNetworks();
+    }
 }

--- a/packages/adapters/src/dockerode-docker-helper.ts
+++ b/packages/adapters/src/dockerode-docker-helper.ts
@@ -41,7 +41,7 @@ type DockerodeVolumeMountConfig = {
  * Communicates with Docker using Dockerode library.
  */
 export class DockerodeDockerHelper implements IDockerHelper {
-    dockerode: Dockerode = new Dockerode();
+    public dockerode: Dockerode = new Dockerode();
     logger: Logger = getLogger(this);
 
     /**
@@ -305,7 +305,7 @@ export class DockerodeDockerHelper implements IDockerHelper {
      * @param options Condition to be fullfilled. @see {DockerAdapterWaitOptions}
      * @returns Container exit code.
      */
-    async wait(container: DockerContainer, options: DockerAdapterWaitOptions): Promise<ExitData> {
+    async wait(container: DockerContainer, options: DockerAdapterWaitOptions = {}): Promise<ExitData> {
         const containerExitResult = await this.dockerode.getContainer(container).wait(options);
 
         return { statusCode: containerExitResult.StatusCode };

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -6,3 +6,4 @@ export * from "./types";
 export * from "./get-instance-adapter";
 export * from "./get-sequence-adapter";
 
+export * from "./docker-networking";

--- a/packages/adapters/src/process-instance-adapter.ts
+++ b/packages/adapters/src/process-instance-adapter.ts
@@ -80,7 +80,7 @@ IComponent {
                 PRODUCTION: process.env.PRODUCTION,
                 SEQUENCE_PATH: sequencePath,
                 INSTANCES_SERVER_PORT: instancesServerPort.toString(),
-                INSTANCES_SERVER_IP: "127.0.0.1",
+                INSTANCES_SERVER_HOST: "127.0.0.1",
                 INSTANCE_ID: instanceId,
             }
         });

--- a/packages/adapters/src/types.ts
+++ b/packages/adapters/src/types.ts
@@ -45,6 +45,10 @@ export type DockerAdapterRunPortsConfig = {
     PortBindings: any
 }
 
+export type DockerNetwork = { containers: Record<string, { name: string }> }
+
+export type DockerCreateNetworkConfig = { name: string, driver: string, options: Record<string, string> }
+
 /**
  * Configuration used to run command in container.
  *
@@ -276,6 +280,12 @@ export interface IDockerHelper {
     pullImage(name: string, fetchOnlyIfNotExists?: boolean): Promise<void>
 
     listNetworks(): Promise<NetworkInspectInfo[]>
+
+    inspectNetwork(id: string): Promise<DockerNetwork>
+
+    connectToNetwork(networkid: string, container: string): Promise<void>
+
+    createNetwork(config: DockerCreateNetworkConfig): Promise<void>
 }
 
 export type InstanceAdapterOptions = {

--- a/packages/adapters/src/types.ts
+++ b/packages/adapters/src/types.ts
@@ -1,5 +1,5 @@
 import { ExitCode } from "@scramjet/types";
-import { ContainerStats } from "dockerode";
+import { ContainerStats, NetworkInspectInfo } from "dockerode";
 import { PathLike } from "fs";
 import { Stream, Writable } from "stream";
 
@@ -274,6 +274,8 @@ export interface IDockerHelper {
      * @param fetchOnlyIfNotExists fetch only if not exists (defaults to true)
      */
     pullImage(name: string, fetchOnlyIfNotExists?: boolean): Promise<void>
+
+    listNetworks(): Promise<NetworkInspectInfo[]>
 }
 
 export type InstanceAdapterOptions = {

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -12,11 +12,12 @@ import { CPMConnector } from "./cpm-connector";
 import { CSIController } from "./csi-controller";
 import { CommonLogsPipe } from "./common-logs-pipe";
 import { InstanceStore } from "./instance-store";
-import { getSequenceAdapter } from "@scramjet/adapters";
+import { DockerodeDockerHelper, getSequenceAdapter } from "@scramjet/adapters";
 import { ReasonPhrases } from "http-status-codes";
 import { ServiceDiscovery } from "./sd-adapter";
 import { SocketServer } from "./socket-server";
 import { LoadCheck } from "@scramjet/load-check";
+import { setupDockerNetworking } from "@scramjet/adapters/src/docker-networking";
 
 const version = findPackage(__dirname).next().value?.version || "unknown";
 
@@ -154,6 +155,12 @@ export class Host implements IComponent {
 
         if (identifyExisiting) {
             await this.identifyExistingSequences();
+        }
+
+        if (!this.config.noDocker) {
+            this.logger.log("Setting up Docker networking");
+
+            await setupDockerNetworking(new DockerodeDockerHelper());
         }
 
         await this.socketServer.start();

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -12,12 +12,11 @@ import { CPMConnector } from "./cpm-connector";
 import { CSIController } from "./csi-controller";
 import { CommonLogsPipe } from "./common-logs-pipe";
 import { InstanceStore } from "./instance-store";
-import { DockerodeDockerHelper, getSequenceAdapter } from "@scramjet/adapters";
+import { DockerodeDockerHelper, getSequenceAdapter, setupDockerNetworking } from "@scramjet/adapters";
 import { ReasonPhrases } from "http-status-codes";
 import { ServiceDiscovery } from "./sd-adapter";
 import { SocketServer } from "./socket-server";
 import { LoadCheck } from "@scramjet/load-check";
-import { setupDockerNetworking } from "@scramjet/adapters/src/docker-networking";
 
 const version = findPackage(__dirname).next().value?.version || "unknown";
 

--- a/packages/runner/src/bin/start-runner.ts
+++ b/packages/runner/src/bin/start-runner.ts
@@ -15,9 +15,7 @@ if (!instancesServerPort || instancesServerPort !== parseInt(instancesServerPort
     process.exit(1);
 }
 
-const ipRegex = /^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
-
-if (!instancesServerIp || !instancesServerIp.match(ipRegex)) {
+if (!instancesServerIp) {
     console.error("Incorrect run argument: instancesServerIp");
     process.exit(1);
 }

--- a/packages/runner/src/bin/start-runner.ts
+++ b/packages/runner/src/bin/start-runner.ts
@@ -7,7 +7,7 @@ import { HostClient } from "../host-client";
 
 const sequencePath: string = process.env.SEQUENCE_PATH?.replace(/.js$/, "") + ".js";
 const instancesServerPort = process.env.INSTANCES_SERVER_PORT;
-const instancesServerIp = process.env.INSTANCES_SERVER_IP;
+const instancesServerHost = process.env.INSTANCES_SERVER_HOST;
 const instanceId = process.env.INSTANCE_ID;
 
 if (!instancesServerPort || instancesServerPort !== parseInt(instancesServerPort, 10).toString()) {
@@ -15,8 +15,8 @@ if (!instancesServerPort || instancesServerPort !== parseInt(instancesServerPort
     process.exit(1);
 }
 
-if (!instancesServerIp) {
-    console.error("Incorrect run argument: instancesServerIp");
+if (!instancesServerHost) {
+    console.error("Incorrect run argument: instancesServerHost");
     process.exit(1);
 }
 
@@ -30,7 +30,7 @@ if (!fs.existsSync(sequencePath)) {
     process.exit(1);
 }
 
-const hostClient = new HostClient(+instancesServerPort, instancesServerIp);
+const hostClient = new HostClient(+instancesServerPort, instancesServerHost);
 
 /**
  * Start runner script.

--- a/packages/runner/src/host-client.ts
+++ b/packages/runner/src/host-client.ts
@@ -19,8 +19,7 @@ class HostClient implements IHostClient {
     constructor(private instancesServerPort: number, private instancesServerIp: string) {
         this.logger = getLogger(this);
 
-        // eslint-disable-next-line no-console
-        console.log(`Will connect to ${instancesServerIp}:${instancesServerPort}`);
+        process.stderr.write(`Will connect to ${instancesServerIp}:${instancesServerPort}`);
     }
 
     private get streams(): UpstreamStreamsConfig {

--- a/packages/runner/src/host-client.ts
+++ b/packages/runner/src/host-client.ts
@@ -18,6 +18,9 @@ class HostClient implements IHostClient {
 
     constructor(private instancesServerPort: number, private instancesServerIp: string) {
         this.logger = getLogger(this);
+
+        // eslint-disable-next-line no-console
+        console.log(`Will connect to ${instancesServerIp}:${instancesServerPort}`);
     }
 
     private get streams(): UpstreamStreamsConfig {

--- a/packages/runner/src/host-client.ts
+++ b/packages/runner/src/host-client.ts
@@ -16,10 +16,8 @@ class HostClient implements IHostClient {
 
     logger: Console;
 
-    constructor(private instancesServerPort: number, private instancesServerIp: string) {
+    constructor(private instancesServerPort: number, private instancesServerHost: string) {
         this.logger = getLogger(this);
-
-        process.stderr.write(`Will connect to ${instancesServerIp}:${instancesServerPort}`);
     }
 
     private get streams(): UpstreamStreamsConfig {
@@ -35,7 +33,7 @@ class HostClient implements IHostClient {
             Array.from(Array(8))
                 .map(() => {
                     // Error handling for each connection is process crash for now
-                    const connection = net.createConnection(this.instancesServerPort, this.instancesServerIp);
+                    const connection = net.createConnection(this.instancesServerPort, this.instancesServerHost);
 
                     return new Promise<net.Socket>(res => {
                         connection.on("connect", () => res(connection));


### PR DESCRIPTION
After migrating Runner to TCP from FIFOs we are now more dependent on the network configuration of STH.
To take control of that we create our own Docker bridge network (`transformhub0`) during Host initialization.

Manager works properly too: https://github.com/scramjetorg/scramjet-cpm-dev/pull/135
This should fix #207  
