### PR TITLE
Listen and reconnect on VerserClient error in Host to Manager connection

### DIFF
--- a/packages/host/src/lib/cpm-connector.ts
+++ b/packages/host/src/lib/cpm-connector.ts
@@ -343,6 +343,11 @@ export class CPMConnector extends TypedEmitter<Events> {
             this.logger.error("Request error:", error);
             this.reconnect();
         });
+
+        this.verserClient.on("error", (error: any) => {
+            this.logger.error("VerserClient error:", error);
+            this.reconnect();
+        });
     }
 
     /**


### PR DESCRIPTION
As I was already on similar stuff, I've added `VerserClient` error handler as mentioned in #211.

I've tested it through MultiManager - MultiHost, but can be checked with without them too, like:

> Start Manager instance.
> Start Host instance with `cpmUrl` pointing to Manager instance.
> Stop Manager process.

Host should handle error and try to reconnect to Manager. When Manager is available again it should reconnect.

![image](https://user-images.githubusercontent.com/1061942/150147242-2f0aca56-4eb3-4550-8afa-d7938a2c0627.png)

Closes #211.