### PR TITLE
Python runner part2

### DIFF
--- a/python/reference-apps/python-alice/alice.py
+++ b/python/reference-apps/python-alice/alice.py
@@ -6,7 +6,7 @@ async def delayed_hello(person):
     await asyncio.sleep(0.25)
     return f"Hello {person['name'].strip()}!"
 
-def run(input):
+def run(context, input):
     source = open('data.json')
     data = Stream.read_from(source, chunk_size=1024, max_parallel=1)
     return data.flatmap(json.loads).map(delayed_hello).each(print)

--- a/python/reference-apps/python-s3-demo/christmas.py
+++ b/python/reference-apps/python-s3-demo/christmas.py
@@ -30,7 +30,7 @@ async def do_stuff(stream):
         stream.write(random.choice('🎄🎁🎀🐍🚀'))
 
 
-async def run(input):
+async def run(context, input):
     stream = Stream()
     asyncio.create_task(do_stuff(stream))
     return stream.map(lambda s: s+'\n')

--- a/python/reference-apps/python-s5-demo/demo_s5.py
+++ b/python/reference-apps/python-s5-demo/demo_s5.py
@@ -1,0 +1,42 @@
+import sys
+import asyncio
+import re
+from collections import Counter
+from scramjet.streams import Stream
+
+
+class shared:
+    letters = "abc"
+
+class WrongInputError(Exception):
+    pass
+
+async def watch_stdin(logger):
+    async for data in sys.stdin:
+        if letters := data.rstrip():
+            shared.letters = letters
+            logger.info(f"Letter set changed to {repr(shared.letters)}")
+        else:
+            raise WrongInputError
+
+
+async def run(ctx, input, only_letters=True):
+    ctx.logger.info(f"Letter set: {repr(shared.letters)}")
+    asyncio.create_task(watch_stdin(ctx.logger))
+
+    def preprocess(text):
+        return re.sub("[^a-zA-Z ]", "", text) if bool(only_letters) else text
+
+    def select_counts(counter):
+        return {letter: counter[letter] for letter in shared.letters}
+
+    return (
+        Stream.read_from(input, max_parallel=1)
+            .each(lambda x: asyncio.sleep(2))
+            .map(preprocess)
+            .each(print)
+            .map(Counter)
+            .map(select_counts)
+    )
+
+output_type = "application/x-ndjson"

--- a/python/reference-apps/python-s5-demo/package.json
+++ b/python/reference-apps/python-s5-demo/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@scramjet/python-runner-demo-sprint-5",
+  "version": "0.1",
+  "lang": "python",
+  "main": "./demo_s5.py",
+  "author": "Jan Warchoł <open-source@scramjet.org>",
+  "license": "GPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scramjetorg/transform-hub.git"
+  }
+}

--- a/python/reference-apps/python-s5-demo/scramjet
+++ b/python/reference-apps/python-s5-demo/scramjet
@@ -1,0 +1,1 @@
+../../scramjet-framework/scramjet/

--- a/python/runner/logging_setup.py
+++ b/python/runner/logging_setup.py
@@ -1,0 +1,77 @@
+import logging
+from logging.handlers import MemoryHandler
+from time import gmtime
+import sys
+
+
+class LoggingSetup():
+    def __init__(self, temp_log_path, min_loglevel=logging.DEBUG) -> None:
+        self._temp_logfile = open(temp_log_path, 'a+')
+        self._temp_logfile.write('\n')
+        sys.stdout = self._temp_logfile
+        sys.stderr = self._temp_logfile
+
+        self.configure_loglevels()
+        self.logger = logging.getLogger('PythonRunner')
+        self.logger.setLevel(min_loglevel)
+        self.create_handlers(min_loglevel)
+
+
+    def configure_loglevels(self):
+        class Colors:
+            red="\033[31m"
+            green="\033[32m"
+            yellow="\033[33m"
+            blue="\033[34m"
+            magenta="\033[35m"
+            cyan="\033[36m"
+            grey="\033[37m"
+
+            bold="\033[1m"
+            reset="\033[0m"
+
+        def customize_name(level, text):
+            colors = {
+                logging.ERROR: Colors.red,
+                logging.WARN:  Colors.magenta,
+                logging.INFO:  Colors.cyan,
+                logging.DEBUG: Colors.yellow,
+            }
+            logging.addLevelName(level, colors[level] + text + Colors.reset)
+
+        customize_name(logging.ERROR, "error")
+        customize_name(logging.WARN, "warn")
+        customize_name(logging.INFO, "info")
+        customize_name(logging.DEBUG, "debug")
+
+
+    def get_formatter(self):
+        logging.Formatter.converter = gmtime  # use UTC time
+        date_format = "%Y-%m-%dT%H:%M:%S"  # ISO 8601 format (excl. miliseconds)
+        log_format = '{asctime}.{msecs:03.0f}Z {levelname} ({name}) {message}'
+
+        return logging.Formatter(fmt=log_format, datefmt=date_format, style='{')
+
+
+    def create_handlers(self, min_loglevel):
+        formatter = self.get_formatter()
+
+        self._main_handler = logging.StreamHandler(self._temp_logfile)
+        self._main_handler.setLevel(min_loglevel)
+        self._main_handler.setFormatter(formatter)
+        self.logger.addHandler(self._main_handler)
+
+        self._temp_handler = MemoryHandler(1000)
+        self._temp_handler.setLevel(logging.INFO)
+        self._temp_handler.setFormatter(formatter)
+        self.logger.addHandler(self._temp_handler)
+
+
+    def switch_to(self, target):
+        self._main_handler.setStream(target)
+        self._temp_logfile.close()
+
+
+    def flush_temp_handler(self):
+        self._temp_handler.setTarget(self._main_handler)
+        self._temp_handler.close()

--- a/python/runner/runner.py
+++ b/python/runner/runner.py
@@ -4,12 +4,12 @@ import os
 import codecs
 import importlib.util
 from scramjet.streams import Stream
+from logging_setup import LoggingSetup
 from hardcoded_magic_values import CommunicationChannels as CC
 from hardcoded_magic_values import RunnerMessageCodes as msg_codes
 from magic_utils import send_encoded_msg, read_and_decode
 
 STARTUP_LOGFILE = './python-runner-startup.log'
-DEBUG = 'DEVELOPMENT' in os.environ
 
 sequence_path = os.getenv('SEQUENCE_PATH')
 server_port = os.getenv('INSTANCES_SERVER_PORT')
@@ -17,34 +17,37 @@ instance_id = os.getenv('INSTANCE_ID')
 
 
 class Runner:
-    def __init__(self, instance_id, sequence_path) -> None:
+    def __init__(self, instance_id, sequence_path, log_setup) -> None:
         self.instance_id = instance_id
         self.seq_path = sequence_path
+        self._logging_setup = log_setup
+        self.logger = log_setup.logger
 
 
     async def main(self, server_host, server_port):
-        print("Connecting to host...")
+        self.logger.info("Connecting to host...")
         await self.init_connections(server_host, server_port)
 
         # Do this early to have access to any thrown exceptions and logs.
         self.connect_stdio()
+        self.connect_log_stream()
 
         config, args = await self.handshake()
-        print("Communication established.")
+        self.logger.info("Communication established.")
 
         await self.run_instance(args)
 
 
     async def init_connections(self, host, port):
         async def connect(channel):
-            print(f"Connecting to {host}:{port}...")
+            self.logger.debug(f"Connecting to {host}:{port}...")
             reader, writer = await asyncio.open_connection(host, port)
-            print("Connected.")
+            self.logger.debug("Connected.")
 
             writer.write(self.instance_id.encode())
             writer.write(channel.value.encode())
             await writer.drain()
-            print(f"Sent ID {self.instance_id} on {channel.name}.")
+            self.logger.debug(f"Sent ID {self.instance_id} on {channel.name}.")
 
             return (channel, reader, writer)
 
@@ -70,50 +73,63 @@ class Runner:
         sys.stderr.flush = lambda: True
 
 
+    def connect_log_stream(self):
+        self.logger.info("Switching to main log stream...")
+        target = codecs.getwriter("utf-8")(self.streams[CC.LOG])
+        self._logging_setup.switch_to(target)
+        self._logging_setup.flush_temp_handler()
+        self.logger.info("Log stream connected.")
+
+
     async def handshake(self):
         monitoring = self.streams[CC.MONITORING]
         control = self.streams[CC.CONTROL]
 
-        print(f"Sending PING")
+        self.logger.info(f"Sending PING")
         send_encoded_msg(monitoring, msg_codes.PING)
 
         code, data = await read_and_decode(control)
         if code == msg_codes.PONG.value:
-            print(f"Got configuration: {data}")
+            self.logger.info(f"Got configuration: {data}")
             return data['appConfig'], data['args']
 
 
     async def run_instance(self, args):
-        print(f"Loading sequence from {self.seq_path}...")
+        self.logger.debug(f"Loading sequence from {self.seq_path}...")
         spec = importlib.util.spec_from_file_location("sequence", self.seq_path)
         self.sequence = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(self.sequence)
         # switch to sequence dir so that relative paths will work
         os.chdir(os.path.dirname(self.seq_path))
 
+        context = AppContext(self)
         input = Stream.read_from(self.streams[CC.IN]).decode("utf-8")
-        print("Running instance...")
-        result = self.sequence.run(input, *args)
+
+        self.logger.info("Running instance...")
+        result = self.sequence.run(context, input, *args)
         if asyncio.iscoroutine(result):
             result = await result
         output = result.map(lambda s: s.encode())
         await output.write_to(self.streams[CC.OUT])
 
-        print('Finished.')
+        self.logger.info('Finished.')
 
 
-with open(STARTUP_LOGFILE, 'a+') as temp_logfile:
-    sys.stdout = temp_logfile
-    sys.stderr = temp_logfile
+class AppContext:
+    def __init__(self, runner) -> None:
+        self.logger = runner.logger
 
-    print("Starting up...")
-    print(f"server_port: {server_port}")
-    print(f"instance_id: {instance_id}")
-    print(f"sequence_path: {sequence_path}")
 
-    if not sequence_path or not server_port or not instance_id:
-        print("Undefined config variable! <blows raspberry>")
-        sys.exit(2)
+log_setup = LoggingSetup(STARTUP_LOGFILE)
 
-    runner = Runner(instance_id, sequence_path)
-    asyncio.run(runner.main('localhost', server_port))
+log_setup.logger.info("Starting up...")
+log_setup.logger.debug(f"server_port: {server_port}")
+log_setup.logger.debug(f"instance_id: {instance_id}")
+log_setup.logger.debug(f"sequence_path: {sequence_path}")
+
+if not sequence_path or not server_port or not instance_id:
+    log_setup.logger.error("Undefined config variable! <blows raspberry>")
+    sys.exit(2)
+
+runner = Runner(instance_id, sequence_path, log_setup)
+asyncio.run(runner.main('localhost', server_port))


### PR DESCRIPTION
* Add content-type handling to python runner

  - wait for headers before forwarding input stream to the instance
  - handle encoding output and converting it to json if the sequence has
    output_type set

* Add heartbeat and support kill in python runner

* Add logging support to python runner

  Use standard python logging module, but with customized formatting and
  colored levels.
  
  Also, use two handlers for logging output:
  - main handler, which is initially connected to startup logfile and
    switches target as soon as logging channel is connected to the runner
  - temporary handler, which is used to copy some messages that were
    logged during startup to the main log channel (only with level INFO
    and above)
  
  Provide the instance with context object that has the logger attached.
