### PR TITLE
Release 0.15.0 ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ Prominent
 - 23b6baaf - Host now communicates with Manager using a Verser module
 - 986b9793 - Improved Host logging
 - ea5211dc - Runner connects with Host via TCP
+- 51310043 - STH CLI extended with a new functionality that replaces the ID number of the last item the user interacted with "-" alias
+- 1c4ce2f2 - Reenable STH to be run inside a docker container
+- 3f0b4494 - Listen and reconnect on VerserClient error in Host to Manager connection
+- d0f7bdc4 - Python runner work in progress
 
 New features:
 
@@ -34,6 +38,8 @@ New features:
 - **Verser module** - New module for reverse server functionality
 - **Comments** - Improved code documentation
 - **TCP Runner** - Connection between Runner and Host is replaced from socket to TCP
+- **CLI extension** - Last uploaded/added sequence can now be referenced when starting etc. This will massively improve the CLI experience, as there's no longer need to parse the previous command line if we want to do quick deployment of a sequence
+- **Python runner WIP** - Running STH without docker can now spawn sequences written in python
 
 Bugfixes:
 
@@ -52,7 +58,9 @@ Bugfixes:
 - Fix for CLI when input is provided from command line
 - Fix for log duplication
 - Fix process.stdin ending
+- Fix STH to be able to run from within a docker container (bugged since 0.13 and TCP Runner)
+- STH is able to reconnect to Scramjet Cloud Platform automatically
 
-## @scramjet/transform Hub - v0.14.0
+## @scramjet/transform Hub - v0.15.0
 
 This is the last release in changelog.

--- a/docs/host/classes/CPMConnector.md
+++ b/docs/host/classes/CPMConnector.md
@@ -463,7 +463,7 @@ Promise<LoadCheckStatMessage> Promise resolving to LoadCheckStatMessage object.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:435](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L435)
+[packages/host/src/lib/cpm-connector.ts:440](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L440)
 
 ___
 
@@ -499,7 +499,7 @@ Promise resolving to NetworkInfo object.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:402](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L402)
+[packages/host/src/lib/cpm-connector.ts:407](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L407)
 
 ___
 
@@ -523,7 +523,7 @@ Promise resolving to `ReadableStream<any>` with topic data.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:548](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L548)
+[packages/host/src/lib/cpm-connector.ts:553](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L553)
 
 ___
 
@@ -540,7 +540,7 @@ Tries to reconnect.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:352](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L352)
+[packages/host/src/lib/cpm-connector.ts:357](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L357)
 
 ___
 
@@ -835,7 +835,7 @@ Reconnects to Manager if maximum number of connection attempts is not reached.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:370](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L370)
+[packages/host/src/lib/cpm-connector.ts:375](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L375)
 
 ___
 
@@ -937,7 +937,7 @@ Sends instance information to Manager via communication channel.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:498](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L498)
+[packages/host/src/lib/cpm-connector.ts:503](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L503)
 
 ___
 
@@ -959,7 +959,7 @@ Sends list of sequence to Manager via communication channel.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:468](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L468)
+[packages/host/src/lib/cpm-connector.ts:473](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L473)
 
 ___
 
@@ -982,7 +982,7 @@ Sends sequence status to Manager via communication channel.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:484](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L484)
+[packages/host/src/lib/cpm-connector.ts:489](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L489)
 
 ___
 
@@ -1004,7 +1004,7 @@ Sends list of sequence to Manager via communication channel.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:453](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L453)
+[packages/host/src/lib/cpm-connector.ts:458](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L458)
 
 ___
 
@@ -1031,7 +1031,7 @@ Makes a POST request to Manager with topic data.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:525](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L525)
+[packages/host/src/lib/cpm-connector.ts:530](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L530)
 
 ___
 
@@ -1057,7 +1057,7 @@ Topic information is send via communication channel.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:512](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L512)
+[packages/host/src/lib/cpm-connector.ts:517](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L517)
 
 ___
 
@@ -1095,7 +1095,7 @@ Sets up a method sending load check data and to be called with interval
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:419](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L419)
+[packages/host/src/lib/cpm-connector.ts:424](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L424)
 
 ___
 


### PR DESCRIPTION
### Added to CHANGELOG.md:

Scramjet Transform Hub Changelog
This is the changelog for Scramjet Transform Hub. It holds only notable commits, others are grouped without commit info.

**Prominent**

- 51310043 - STH CLI extended with new functionality that replaces the ID number of the last item the user interacted with "-" alias
- 1c4ce2f2 - Reenable STH to be run inside a docker container
- 3f0b4494 - Listen and reconnect on VerserClient error in Host to Manager connection

**New features:**
- CLI extension - Last uploaded/added sequence can now be referenced when starting etc. This will massively improve the CLI experience, as there's no longer need to parse the previous command line if we want to do quick deployment of a sequence
- Python runner WIP - Running STH without docker can now spawn sequences written in python

**Bugfixes:**
- Fix STH to be able to run from within a docker container (bugged since 0.13 and TCP Runner)
- STH is able to reconnect to the Scramjet Cloud Platform automatically