### PR TITLE
Support rapid building for development using esbuild

### DIFF
--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -8,6 +8,10 @@
 
 `SCRAMJET_DEVELOPMENT: boolean`
 
+---
+`ESBUILD: boolean`
+After STH is built with esbuild it should run with this flag
+
 ### BDD tests
 
 `SCRAMJET_SPAWN_JS: boolean (default: false)`

--- a/bdd/lib/utils.ts
+++ b/bdd/lib/utils.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-loop-func */
-import * as fs from "fs";
+import fs from "fs";
 import { strict as assert } from "assert";
 import { promisify } from "util";
 import { exec, spawn } from "child_process";

--- a/bdd/step-definitions/e2e/cli.ts
+++ b/bdd/step-definitions/e2e/cli.ts
@@ -3,7 +3,7 @@
 /* eslint-disable no-console */
 import { Then, When } from "@cucumber/cucumber";
 import { strict as assert } from "assert";
-import * as fs from "fs";
+import fs from "fs";
 import { getStreamsFromSpawn } from "../../lib/utils";
 import { expectedResponses } from "./expectedResponses";
 

--- a/bdd/step-definitions/e2e/host-steps.ts
+++ b/bdd/step-definitions/e2e/host-steps.ts
@@ -4,17 +4,16 @@
 import { Given, When, Then, Before, BeforeAll, AfterAll } from "@cucumber/cucumber";
 import { strict as assert } from "assert";
 import { removeBoundaryQuotes, defer } from "../../lib/utils";
-import * as fs from "fs";
-import { createReadStream } from "fs";
+import fs, { createReadStream } from "fs";
 import { HostClient, InstanceOutputStream, Response } from "@scramjet/api-client";
 import { HostUtils } from "../../lib/host-utils";
 import { PassThrough, Readable, Stream } from "stream";
-import * as crypto from "crypto";
+import crypto from "crypto";
 import { promisify } from "util";
-import * as Dockerode from "dockerode";
+import Dockerode from "dockerode";
 import { CustomWorld } from "../world";
 
-import * as findPackage from "find-package-json";
+import findPackage from "find-package-json";
 import { readFile } from "fs/promises";
 import { BufferStream } from "scramjet";
 import { expectedResponses } from "./expectedResponses";

--- a/bdd/step-definitions/performance-tests/durability-tcp.ts
+++ b/bdd/step-definitions/performance-tests/durability-tcp.ts
@@ -3,8 +3,8 @@ import { Then } from "@cucumber/cucumber";
 import { CustomWorld } from "../world";
 
 import { strict as assert } from "assert";
-import * as crypto from "crypto";
-import * as net from "net";
+import crypto from "crypto";
+import net from "net";
 import { stdout } from "process";
 
 import { InstanceClient } from "@scramjet/api-client";

--- a/bdd/step-definitions/performance-tests/durability.ts
+++ b/bdd/step-definitions/performance-tests/durability.ts
@@ -3,7 +3,7 @@ import { HostClient, InstanceClient } from "@scramjet/api-client";
 import { When, Then } from "@cucumber/cucumber";
 import { strict as assert } from "assert";
 
-import * as crypto from "crypto";
+import crypto from "crypto";
 
 import { createReadStream } from "fs";
 import { CustomWorld } from "../world";

--- a/bdd/step-definitions/performance-tests/ports.ts
+++ b/bdd/step-definitions/performance-tests/ports.ts
@@ -1,10 +1,10 @@
 /* eslint-disable no-console */
 import { When } from "@cucumber/cucumber";
 import { InstanceOutputStream } from "@scramjet/api-client";
-import * as net from "net";
+import net from "net";
 import { strict as assert } from "assert";
 import { PassThrough, Stream } from "stream";
-import * as dgram from "dgram";
+import dgram from "dgram";
 import { CustomWorld } from "../world";
 import { URL } from "url";
 

--- a/bdd/step-definitions/runner/runner-steps.ts
+++ b/bdd/step-definitions/runner/runner-steps.ts
@@ -1,7 +1,7 @@
 import { Given, Then } from "@cucumber/cucumber";
 import { strict as assert } from "assert";
 import { exec } from "child_process";
-import * as fs from "fs";
+import fs from "fs";
 
 const localRunnerExecutableFilePath = "../dist/runner/bin/start-runner-local.js";
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "lint": "eslint . --ext .ts --cache --cache-strategy=content --cache-location=/tmp/.eslintcache_scramjet-csi",
     "lint:uncached": "rm /tmp/.eslintcache_scramjet-csi && yarn lint",
     "lint:dedupe": "scripts/dedupe.js",
-    "lint:packages-only":  "eslint ./packages --ext .ts --cache --cache-strategy=content --cache-location=/tmp/.eslintcache_scramjet-csi",
     "start": "node dist/sth/bin/hub.js",
     "start:dev": "ts-node packages/sth/src/bin/hub.ts",
     "install:clean": "yarn clean && yarn clean:modules && yarn install",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "build": "yarn build:all-packages",
+    "build:packages-esbuild": "lerna run build:esbuild",
     "build:all": "yarn build:packages && yarn build:refapps && yarn build:docker",
     "build:refapps": "LOCAL_PACKAGES=true lerna run build:refapps",
     "build:packages": "LOCAL_PACKAGES=true lerna run build",
@@ -74,6 +75,7 @@
     "@typescript-eslint/parser": "^4.27.0",
     "build-if-changed": "^1.5.5",
     "cloc": "^2.8.0",
+    "esbuild": "^0.14.13",
     "eslint": "^7.29.0",
     "eslint-plugin-import": "^2.23.3",
     "eslint-to-editorconfig": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lint": "eslint . --ext .ts --cache --cache-strategy=content --cache-location=/tmp/.eslintcache_scramjet-csi",
     "lint:uncached": "rm /tmp/.eslintcache_scramjet-csi && yarn lint",
     "lint:dedupe": "scripts/dedupe.js",
+    "lint:packages-only":  "eslint ./packages --ext .ts --cache --cache-strategy=content --cache-location=/tmp/.eslintcache_scramjet-csi",
     "start": "node dist/sth/bin/hub.js",
     "start:dev": "ts-node packages/sth/src/bin/hub.ts",
     "install:clean": "yarn clean && yarn clean:modules && yarn install",

--- a/packages/adapters/src/docker-instance-adapter.ts
+++ b/packages/adapters/src/docker-instance-adapter.ts
@@ -13,7 +13,7 @@ import {
     SequenceConfig,
     RunnerContainerConfiguration,
 } from "@scramjet/types";
-import * as path from "path";
+import path from "path";
 import { DockerodeDockerHelper } from "./dockerode-docker-helper";
 import { DockerAdapterResources, DockerAdapterRunPortsConfig, DockerAdapterVolumeConfig, IDockerHelper } from "./types";
 import { FreePortsFinder, defer } from "@scramjet/utility";

--- a/packages/adapters/src/docker-networking.ts
+++ b/packages/adapters/src/docker-networking.ts
@@ -1,5 +1,5 @@
-import * as fs from "fs/promises";
-import * as os from "os";
+import fs from "fs/promises";
+import os from "os";
 import { IDockerHelper } from "./types";
 
 export const isHostSpawnedInDockerContainer = async () => await fs.access("/.dockerenv").then(() => true, () => false);

--- a/packages/adapters/src/dockerode-docker-helper.ts
+++ b/packages/adapters/src/dockerode-docker-helper.ts
@@ -1,4 +1,4 @@
-import * as Dockerode from "dockerode";
+import Dockerode from "dockerode";
 import { PassThrough } from "stream";
 import { getLogger } from "@scramjet/logger";
 import { Logger } from "@scramjet/types";

--- a/packages/adapters/src/process-instance-adapter.ts
+++ b/packages/adapters/src/process-instance-adapter.ts
@@ -10,7 +10,7 @@ import {
 } from "@scramjet/types";
 import { ChildProcess, spawn } from "child_process";
 
-import * as path from "path";
+import path from "path";
 
 const isTSNode = !!(process as any)[Symbol.for("ts-node.register.instance")];
 const gotPython = "\n                              _ \n __      _____  _ __  ___ ___| |\n \\ \\ /\\ / / _ \\| '_ \\/ __|_  / |\n  \\ V  V / (_) | | | \\__ \\/ /|_|\n   \\_/\\_/ \\___/|_| |_|___/___(_)  🐍\n";
@@ -57,7 +57,7 @@ IComponent {
         }
         return [
             isTSNode ? "ts-node" : process.execPath,
-            path.resolve(__dirname, require.resolve("@scramjet/runner"))
+            path.resolve(__dirname, "../../../runner/src/bin/start-runner.js")
         ];
     }
 

--- a/packages/adapters/src/process-instance-adapter.ts
+++ b/packages/adapters/src/process-instance-adapter.ts
@@ -57,7 +57,11 @@ IComponent {
         }
         return [
             isTSNode ? "ts-node" : process.execPath,
-            path.resolve(__dirname, "../../../runner/src/bin/start-runner.js")
+            path.resolve(__dirname,
+                process.env.ESBUILD
+                    ? "../../runner/bin/start-runner.js"
+                    : require.resolve("@scramjet/runner")
+            )
         ];
     }
 

--- a/packages/adapters/src/process-sequence-adapter.ts
+++ b/packages/adapters/src/process-sequence-adapter.ts
@@ -8,8 +8,8 @@ import {
 } from "@scramjet/types";
 import { Readable } from "stream";
 import { createReadStream } from "fs";
-import * as fs from "fs/promises";
-import * as path from "path";
+import fs from "fs/promises";
+import path from "path";
 import { exec } from "child_process";
 import { isDefined, readStreamedJSON } from "@scramjet/utility";
 import { sequencePackageJSONDecoder } from "./validate-sequence-package-json";

--- a/packages/api-server/test/0http.spec.ts
+++ b/packages/api-server/test/0http.spec.ts
@@ -1,6 +1,6 @@
 import test, { after, beforeEach } from "ava";
-import * as sinon from "sinon";
-import * as http from "http";
+import sinon from "sinon";
+import http from "http";
 
 /* eslint-disable-next-line import/no-extraneous-dependencies */
 import { cero, sequentialRouter } from "@scramjet/api-server";

--- a/packages/api-server/test/rest-methods.spec.ts
+++ b/packages/api-server/test/rest-methods.spec.ts
@@ -3,7 +3,7 @@ import { APIExpose } from "@scramjet/types";
 import { RunnerMessageCode } from "@scramjet/symbols";
 
 import test, { after, before, beforeEach, skip } from "ava";
-import * as sinon from "sinon";
+import sinon from "sinon";
 import { getCommunicationHandler } from "./lib/get-communcation-handler";
 import { mockRequestResponse, mockServer, ServerWithPlayMethods } from "./lib/server-mock";
 import { routerMock } from "./lib/trouter-mock";

--- a/packages/api-server/test/server.spec.ts
+++ b/packages/api-server/test/server.spec.ts
@@ -2,7 +2,7 @@ import { RunnerMessageCode } from "@scramjet/symbols";
 import test, { after, beforeEach } from "ava";
 import { Writable, Readable } from "stream";
 import { DataStream } from "scramjet";
-import * as sinon from "sinon";
+import sinon from "sinon";
 import { getCommunicationHandler } from "./lib/get-communcation-handler";
 import { mockServer } from "./lib/server-mock";
 import { routerMock } from "./lib/trouter-mock";

--- a/packages/api-server/test/stream-methods.spec.ts
+++ b/packages/api-server/test/stream-methods.spec.ts
@@ -2,7 +2,7 @@ import { APIExpose } from "@scramjet/types";
 import test, { after, before, beforeEach } from "ava";
 import { Readable, Writable } from "stream";
 import { StringStream } from "scramjet";
-import * as sinon from "sinon";
+import sinon from "sinon";
 import { mockRequestResponse, mockServer, ServerWithPlayMethods } from "./lib/server-mock";
 import { routerMock } from "./lib/trouter-mock";
 

--- a/packages/host/src/lib/cpm-connector.ts
+++ b/packages/host/src/lib/cpm-connector.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs";
+import fs from "fs";
 
 import { Agent, ClientRequest, IncomingMessage, Server, request } from "http";
 import { CPMMessageCode, InstanceMessageCode, SequenceMessageCode } from "@scramjet/symbols";

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -1,4 +1,4 @@
-import * as findPackage from "find-package-json";
+import findPackage from "find-package-json";
 
 import { APIExpose, AppConfig, CSIConfig, IComponent, Logger, NextCallback, ParsedMessage, SequenceInfo, STHConfiguration, STHRestAPI } from "@scramjet/types";
 import { CommunicationHandler, HostError, IDProvider } from "@scramjet/model";

--- a/packages/host/src/lib/socket-server.ts
+++ b/packages/host/src/lib/socket-server.ts
@@ -1,6 +1,6 @@
 import { IComponent, Logger, DownstreamStreamsConfig } from "@scramjet/types";
 import { getLogger } from "@scramjet/logger";
-import * as net from "net";
+import net from "net";
 import { isDefined, TypedEmitter } from "@scramjet/utility";
 
 type MaybeSocket = net.Socket | null

--- a/packages/load-check/src/load-check.ts
+++ b/packages/load-check/src/load-check.ts
@@ -2,7 +2,7 @@ import { getLogger } from "@scramjet/logger";
 import { IComponent, Logger, LoadCheckStat, LoadCheckConfig, LoadCheckContstants } from "@scramjet/types";
 import { defer } from "@scramjet/utility";
 
-import * as sysinfo from "systeminformation";
+import sysinfo from "systeminformation";
 import { DataStream, StringStream } from "scramjet";
 
 const MB = 1024 * 1024;

--- a/packages/reference-apps/durability-preservation-event/index.ts
+++ b/packages/reference-apps/durability-preservation-event/index.ts
@@ -1,4 +1,4 @@
-import * as https from "https";
+import https from "https";
 
 import { AppContext } from "@scramjet/types";
 import { IncomingMessage } from "http";

--- a/packages/reference-apps/durability-preservation-tcp/index.ts
+++ b/packages/reference-apps/durability-preservation-tcp/index.ts
@@ -1,9 +1,9 @@
-import * as https from "https";
+import https from "https";
 import { IncomingMessage } from "http";
 import { PassThrough } from "stream";
 import { Logger, ReadableApp } from "@scramjet/types";
 import { StringStream } from "scramjet";
-import * as net from "net";
+import net from "net";
 
 const mockResponse = () => {
     const fakeData = new PassThrough();

--- a/packages/reference-apps/durability-preservation/index.ts
+++ b/packages/reference-apps/durability-preservation/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console, no-extra-parens */
-import * as http from "https";
+import http from "https";
 import { IncomingMessage } from "http";
 import { PassThrough } from "stream";
 import { ReadableApp } from "@scramjet/types";

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -12,7 +12,9 @@
     "clean": "rm -rf ./dist .bic_cache",
     "clean:docker": "docker rm -f runner; docker volume rm prerunner-$(git rev-parse --short HEAD)",
     "postbuild": "yarn prepack",
-    "prepack": "node ../../scripts/publish.js"
+    "prepack": "node ../../scripts/publish.js",
+    "build:esbuild": "esbuild src/**/*.ts --tsconfig=tsconfig.build.json --outdir=dist --bundle --platform=node --external:@scramjet/runner --external:ssh2 --external:cpu-features",
+    "postbuild:esbuild": "mkdir -p ../../dist/runner && cp -r dist/** ../../dist/runner && cp package.json ../../dist/runner"
   },
   "author": "Scramjet <opensource@scramjet.org>",
   "license": "MIT",

--- a/packages/runner/src/bin/start-runner.ts
+++ b/packages/runner/src/bin/start-runner.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { Runner } from "../runner";
-import * as fs from "fs";
+import fs from "fs";
 import { AppConfig } from "@scramjet/types";
 import { HostClient } from "../host-client";
 

--- a/packages/runner/src/host-client.ts
+++ b/packages/runner/src/host-client.ts
@@ -2,7 +2,7 @@
 import { IHostClient, UpstreamStreamsConfig, } from "@scramjet/types";
 import { getLogger } from "@scramjet/logger";
 import { CommunicationChannel as CC } from "@scramjet/symbols";
-import * as net from "net";
+import net from "net";
 
 type HostOpenConnections = [
     net.Socket, net.Socket, net.Socket, net.Socket, net.Socket, net.Socket, net.Socket, net.Socket

--- a/packages/sth-config/src/config-service.ts
+++ b/packages/sth-config/src/config-service.ts
@@ -1,6 +1,6 @@
 import { DeepPartial, STHConfiguration } from "@scramjet/types";
 import { merge } from "@scramjet/utility";
-import * as path from "path";
+import path from "path";
 
 const imageConfig = require("./image-config.json");
 

--- a/packages/sth/package.json
+++ b/packages/sth/package.json
@@ -11,6 +11,8 @@
     "start": "ts-node ./src/index",
     "build": "tsc -p tsconfig.build.json",
     "build:docker": "docker build -t scramjetorg/sth:$npm_package_version -f Dockerfile ../../",
+    "build:esbuild": "esbuild src/**/*.ts --tsconfig=tsconfig.build.json --outdir=dist/ --bundle --platform=node --external:@scramjet/runner --external:ssh2 --external:cpu-features",
+    "postbuild:esbuild": "mkdir -p ../../dist/sth && cp -r dist/** ../../dist/sth  && cp package.json ../../dist/sth",
     "clean": "rm -rf ./dist .bic_cache",
     "test": "echo no tests yet -- # npm run test:ava",
     "test:ava": "ava",

--- a/packages/utility/src/free-ports-finder.ts
+++ b/packages/utility/src/free-ports-finder.ts
@@ -1,5 +1,5 @@
-import * as net from "net";
-import * as dgram from "dgram";
+import net from "net";
+import dgram from "dgram";
 
 /**
  * Provides methods to find free tcp/udp ports.

--- a/scripts/dev/sd.ts
+++ b/scripts/dev/sd.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs";
+import fs from "fs";
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { ChildProcess, spawn } from "child_process";

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,7 +15,8 @@
     "lib": ["es2019", "es2020.promise", "es2020.bigint", "es2020.string"],
     "strict": true,
     "resolveJsonModule": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true
   },
   "typeAcquisition": {
     "include": ["node"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3030,6 +3030,120 @@ es6-symbol@^3.1.1, es6-symbol@~3.1.3:
     d "^1.0.1"
     ext "^1.1.2"
 
+esbuild-android-arm64@0.14.13:
+  version "0.14.13"
+  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.13.tgz#a5c8cb275dc6dcaf2390abb639791ffc4aa6ead1"
+  integrity sha512-rhtwl+KJ3BzzXkK09N3/YbEF1i5WhriysJEStoeWNBzchx9hlmzyWmDGQQhu56HF78ua3JrVPyLOsdLGvtMvxQ==
+
+esbuild-darwin-64@0.14.13:
+  version "0.14.13"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.13.tgz#51ad2fbf8c9d73c1d40e5f9ab6122ffa95f5b494"
+  integrity sha512-Fl47xIt5RMu50WIgMU93kwmUUJb+BPuL8R895n/aBNQqavS+KUMpLPoqKGABBV4myfx/fnAD/97X8Gt1C1YW6w==
+
+esbuild-darwin-arm64@0.14.13:
+  version "0.14.13"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.13.tgz#7ff177193cffbba518a59dfa4666a2fbb3345330"
+  integrity sha512-UttqKRFXsWvuivcyAbFmo54vdkC9Me1ZYQNuoz/uBYDbkb2MgqKYG2+xoVKPBhLvhT0CKM5QGKD81flMH5BE6A==
+
+esbuild-freebsd-64@0.14.13:
+  version "0.14.13"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.13.tgz#648357ff0ca399ce65f7e7ebfff701cf105c70f3"
+  integrity sha512-dlIhPFSp29Yq2TPh7Cm3/4M0uKjlfvOylHVNCRvRNiOvDbBol6/NZ3kLisczms+Yra0rxVapBPN1oMbSMuts9g==
+
+esbuild-freebsd-arm64@0.14.13:
+  version "0.14.13"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.13.tgz#7cb0016dd64fd116624c56dcfe58b27fac8ceaee"
+  integrity sha512-bNOHLu7Oq6RwaAMnwPbJ40DVGPl9GlAOnfH/dFZ792f8hFEbopkbtVzo1SU1jjfY3TGLWOgqHNWxPxx1N7Au+g==
+
+esbuild-linux-32@0.14.13:
+  version "0.14.13"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.13.tgz#50b197f6831e824660ab80d011b656505a0aae32"
+  integrity sha512-WzXyBx6zx16adGi7wPBvH2lRCBzYMcqnBRrJ8ciLIqYyruGvprZocX1nFWfiexjLcFxIElWnMNPX6LG7ULqyXA==
+
+esbuild-linux-64@0.14.13:
+  version "0.14.13"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.13.tgz#d2ee4d780e3cadd129ab8988c7c75ca4bd636f3a"
+  integrity sha512-P6OFAfcoUvE7g9h/0UKm3qagvTovwqpCF1wbFLWe/BcCY8BS1bR/+SxUjCeKX2BcpIsg4/43ezHDE/ntg/iOpw==
+
+esbuild-linux-arm64@0.14.13:
+  version "0.14.13"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.13.tgz#9151963c55cd42968c97f2fd354cd6ff9b3cb476"
+  integrity sha512-k/uIvmkm4mc7vyMvJVwILgGxi2F+FuvLdmESIIWoHrnxEfEekC5AWpI/R6GQ2OMfp8snebSQLs8KL05QPnt1zA==
+
+esbuild-linux-arm@0.14.13:
+  version "0.14.13"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.13.tgz#80e94cd8920607dc0addb97bac7ff5988d0fc28f"
+  integrity sha512-4jmm0UySCg3Wi6FEBS7jpiPb1IyckI5um5kzYRwulHxPzkiokd6cgpcsTakR4/Y84UEicS8LnFAghHhXHZhbFg==
+
+esbuild-linux-mips64le@0.14.13:
+  version "0.14.13"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.13.tgz#8e7eeef567b0895f2ecc4d66b1f1e5a542f1ce5b"
+  integrity sha512-vwYtgjQ1TRlUGL88km9wH9TjXsdZyZ/Xht1ASptg5XGRlqGquVjLGH11PfLLunoMdkQ0YTXR68b4l5gRfjVbyg==
+
+esbuild-linux-ppc64le@0.14.13:
+  version "0.14.13"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.13.tgz#ffbe9915a1d8080f9810a9c5938f453003c6de98"
+  integrity sha512-0KqDSIkZaYugtcdpFCd3eQ38Fg6TzhxmOpkhDIKNTwD/W2RoXeiS+Z4y5yQ3oysb/ySDOxWkwNqTdXS4sz2LdQ==
+
+esbuild-linux-s390x@0.14.13:
+  version "0.14.13"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.13.tgz#e27274d12f198580892432115fc0de432431d33d"
+  integrity sha512-bG20i7d0CN97fwPN9LaLe64E2IrI0fPZWEcoiff9hzzsvo/fQCx0YjMbPC2T3gqQ48QZRltdU9hQilTjHk3geQ==
+
+esbuild-netbsd-64@0.14.13:
+  version "0.14.13"
+  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.13.tgz#78199fa57d5794e6ac6c33993dd0588fba22b353"
+  integrity sha512-jz96PQb0ltqyqLggPpcRbWxzLvWHvrZBHZQyjcOzKRDqg1fR/R1y10b1Cuv84xoIbdAf+ceNUJkMN21FfR9G2g==
+
+esbuild-openbsd-64@0.14.13:
+  version "0.14.13"
+  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.13.tgz#5394336b602e1db15583bbef7d827a2b9648e373"
+  integrity sha512-bp6zSo3kDCXKPM5MmVUg6DEpt+yXDx37iDGzNTn3Kf9xh6d0cdITxUC4Bx6S3Di79GVYubWs+wNjSRVFIJpryw==
+
+esbuild-sunos-64@0.14.13:
+  version "0.14.13"
+  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.13.tgz#4afcddcece51f943149fa07274bd58f64e0913a8"
+  integrity sha512-08Fne1T9QHYxUnu55sV9V4i/yECADOaI1zMGET2YUa8SRkib10i80hc89U7U/G02DxpN/KUJMWEGq2wKTn0QFQ==
+
+esbuild-windows-32@0.14.13:
+  version "0.14.13"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.13.tgz#cb06267f270bbf7ea6631cc78b8f6e3647975c44"
+  integrity sha512-MW3BMIi9+fzTyDdljH0ftfT/qlD3t+aVzle1O+zZ2MgHRMQD20JwWgyqoJXhe6uDVyunrAUbcjH3qTIEZN3isg==
+
+esbuild-windows-64@0.14.13:
+  version "0.14.13"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.13.tgz#3bbfba58e0185121280bd47ccd073b6c1849fd27"
+  integrity sha512-d7+0N+EOgBKdi/nMxlQ8QA5xHBlpcLtSrYnHsA+Xp4yZk28dYfRw1+embsHf5uN5/1iPvrJwPrcpgDH1xyy4JA==
+
+esbuild-windows-arm64@0.14.13:
+  version "0.14.13"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.13.tgz#9203d40d915d809c50bc91af5a8373e5f5abfc4c"
+  integrity sha512-oX5hmgXk9yNKbb5AxThzRQm/E9kiHyDll7JJeyeT1fuGENTifv33f0INCpjBQ+Ty5ChKc84++ZQTEBwLCA12Kw==
+
+esbuild@^0.14.13:
+  version "0.14.13"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.13.tgz#ce3fc7c45a6b8a40caad43daa39cdb9c1e84930a"
+  integrity sha512-FIxvAdj3i2oHA6ex+E67bG7zlSTO+slt8kU2ogHDgGtrQLy2HNChv3PYjiFTYkt8hZbEAniZCXVeHn+FrHt7dA==
+  optionalDependencies:
+    esbuild-android-arm64 "0.14.13"
+    esbuild-darwin-64 "0.14.13"
+    esbuild-darwin-arm64 "0.14.13"
+    esbuild-freebsd-64 "0.14.13"
+    esbuild-freebsd-arm64 "0.14.13"
+    esbuild-linux-32 "0.14.13"
+    esbuild-linux-64 "0.14.13"
+    esbuild-linux-arm "0.14.13"
+    esbuild-linux-arm64 "0.14.13"
+    esbuild-linux-mips64le "0.14.13"
+    esbuild-linux-ppc64le "0.14.13"
+    esbuild-linux-s390x "0.14.13"
+    esbuild-netbsd-64 "0.14.13"
+    esbuild-openbsd-64 "0.14.13"
+    esbuild-sunos-64 "0.14.13"
+    esbuild-windows-32 "0.14.13"
+    esbuild-windows-64 "0.14.13"
+    esbuild-windows-arm64 "0.14.13"
+
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz"


### PR DESCRIPTION
Implemented development building with `esbuild`.
We are able to build `sth` and `runner` JS bundles and use them in BDD tests, blazingly fast :rocket: 
The only inconvenience is that we have to spawn runner with `ESBUILD=1` env var to point on different Runner package.
(This could probably be easily improved, though it requires time for debugging that I don't want to spend right now :wink:) 
I also had to migrate our typescript source code to use `--esModuleInterop` (`import fs as 'fs'` instead of `import * as fs from 'fs'`) since this what esbuild requires. (This is something that we would have to probably do in near future, since some dependencies do not support any other option)

### Verify 
```bash
git clean -xdf
yarn install && yarn build:refapps && yarn packseq 
yarn build:packages-esbuild
ESBUILD=1 NO_DOCKER=1 yarn test:bdd --name="PT-004 TC-001"
```

### What's next?
Guided by the 80/20 principle I would say the rapid local iterations is the most important leverage of this technology.
However I investigated what should we do if we wanted to tottally migrate for esbuild and it includes:

* [ ] Adjusting Dockerfile builds to new bundle-based build structure
* [ ] Supporting npm package installation (`main` and `bin` entries in package.json would have to change probably)
* [ ] Probably ditching support for `ts-node` since it would be faster just to build
* [ ] Adjusting CI build and start scripts to use new build structure
* [ ] Adjusting BDD tests to spawn using new structure
* [ ] Building types separately for npm release using `tsc --emitDeclarationOnly`
* [ ] Build types on CI using `tsc --noEmit`
* [ ] Implement scripts in each package for building/watching types correctness `tsc --noEmit --watch` while developing

We might want to come back to these, when we would like to focus on decreasing CI execution time. 