### PR TITLE
Fix: CLI last id memory

### DIFF
--- a/packages/adapters/src/docker-instance-adapter.ts
+++ b/packages/adapters/src/docker-instance-adapter.ts
@@ -44,12 +44,12 @@ IComponent {
     /**
      * Finds free port for every port requested in Sequence configuration and returns map of assigned ports.
      *
-     * @param {string[]} declaredPorts Ports declared in sequence config.
-     * @param {ContainerConfiguration & ContainerConfigurationWithExposedPorts} containerConfig Container configuration
+     * @param declaredPorts - Ports declared in sequence config.
+     * @param containerConfig Container configuration
      * extended with configuration for ports exposing.
-     * @param {boolean} [exposed=false] Defines configuration output type. Exposed ports when true or port bindings.
+     * @param exposed - Defines configuration output type. Exposed ports when true or port bindings.
      *
-     * @returns {Promise<{[ key: string ]: string }>} Promise resolving with map of ports mapping.
+     * @returns Promise resolving with map of ports mapping.
      */
     private async preparePortBindingsConfig(
         declaredPorts: string[],
@@ -139,7 +139,7 @@ IComponent {
                 host: hostname,
             };
         }
-        // otherwise STH runs on Host OS so we Runner can just connect to the Gateway 
+        // otherwise STH runs on Host OS so we Runner can just connect to the Gateway
         const sthNetworkGateway = sthDockerNetwork?.IPAM?.Config?.[0]?.Gateway;
 
         if (!sthNetworkGateway) {

--- a/packages/cli/src/lib/commands/config.ts
+++ b/packages/cli/src/lib/commands/config.ts
@@ -47,6 +47,12 @@ export const config: CommandDefinition = (program) => {
         .description("Set config value")
         .action((key, value) => setConfigValue(key, value));
 
+    configCmd.command("get <key>")
+        .description("Get config value")
+        .action((key: keyof ReturnType<typeof getConfig>) => {
+            console.log(getConfig()[key]);
+        });
+
     configCmd.command("unset <key>")
         .alias("del")
         .description("Unset config value")

--- a/packages/cli/src/lib/commands/config.ts
+++ b/packages/cli/src/lib/commands/config.ts
@@ -50,7 +50,7 @@ export const config: CommandDefinition = (program) => {
     configCmd.command("get <key>")
         .description("Get config value")
         .action((key: keyof ReturnType<typeof getConfig>) => {
-            console.log(getConfig()[key]);
+            return displayObject(program, getConfig()[key]);
         });
 
     configCmd.command("unset <key>")

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -123,7 +123,7 @@ export const getSequenceId = (id: string) => getDashDefaultValue(id, getConfig()
  * @param id - dash or anything else
  * @returns the correct id
  */
-export const getInstanceId = (id: string) => getDashDefaultValue(id, getConfig().lastSequenceId);
+export const getInstanceId = (id: string) => getDashDefaultValue(id, getConfig().lastInstanceId);
 
 /**
  * Gets package file path if dash is provided, otherwise returns the first argument


### PR DESCRIPTION
This is a bugfix for the id replacement in CLI.

CLI currently wrongly supplies `sequence id` for `instance` endpoints. This small fix corrects it.