### PR TITLE
Release 0.15.1 ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Prominent
 - 1c4ce2f2 - Reenable STH to be run inside a docker container
 - 3f0b4494 - Listen and reconnect on VerserClient error in Host to Manager connection
 - d0f7bdc4 - Python runner work in progress
+- f0963d02 - Logger upgrade, now it operates on objects not strings
+- e89113b2 - CLI: fix for saving instance id in config
+- 5217044e - Introduce a new, faster building for development using esbuild
+- fe364b1a - Add support for complex packages in python apps
 
 New features:
 
@@ -60,7 +64,8 @@ Bugfixes:
 - Fix process.stdin ending
 - Fix STH to be able to run from within a docker container (bugged since 0.13 and TCP Runner)
 - STH is able to reconnect to Scramjet Cloud Platform automatically
+- Fix for the id replacement in CLI.
 
-## @scramjet/transform Hub - v0.15.0
+## @scramjet/transform Hub - v0.15.1
 
 This is the last release in changelog.

--- a/docs/adapters/classes/dockerinstanceadapter.md
+++ b/docs/adapters/classes/dockerinstanceadapter.md
@@ -53,7 +53,7 @@ ILifeCycleAdapterMain.cleanup
 
 #### Defined in
 
-[docker-instance-adapter.ts:245](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-instance-adapter.ts#L245)
+[docker-instance-adapter.ts:251](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-instance-adapter.ts#L251)
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 #### Defined in
 
-[docker-instance-adapter.ts:121](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-instance-adapter.ts#L121)
+[docker-instance-adapter.ts:123](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-instance-adapter.ts#L123)
 
 ___
 
@@ -92,7 +92,7 @@ Configuration for exposing and binding ports in Docker container.
 
 #### Defined in
 
-[docker-instance-adapter.ts:85](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-instance-adapter.ts#L85)
+[docker-instance-adapter.ts:87](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-instance-adapter.ts#L87)
 
 ___
 
@@ -110,7 +110,7 @@ ILifeCycleAdapterMain.init
 
 #### Defined in
 
-[docker-instance-adapter.ts:41](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-instance-adapter.ts#L41)
+[docker-instance-adapter.ts:42](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-instance-adapter.ts#L42)
 
 ___
 
@@ -134,7 +134,7 @@ ILifeCycleAdapterRun.monitorRate
 
 #### Defined in
 
-[docker-instance-adapter.ts:257](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-instance-adapter.ts#L257)
+[docker-instance-adapter.ts:263](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-instance-adapter.ts#L263)
 
 ___
 
@@ -156,11 +156,11 @@ Finds free port for every port requested in Sequence configuration and returns m
 
 `Promise`<`Object`\>
 
->} Promise resolving with map of ports mapping.
+Promise resolving with map of ports mapping.
 
 #### Defined in
 
-[docker-instance-adapter.ts:54](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-instance-adapter.ts#L54)
+[docker-instance-adapter.ts:56](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-instance-adapter.ts#L56)
 
 ___
 
@@ -180,7 +180,7 @@ ILifeCycleAdapterMain.remove
 
 #### Defined in
 
-[docker-instance-adapter.ts:264](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-instance-adapter.ts#L264)
+[docker-instance-adapter.ts:270](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-instance-adapter.ts#L270)
 
 ___
 
@@ -206,7 +206,7 @@ ILifeCycleAdapterRun.run
 
 #### Defined in
 
-[docker-instance-adapter.ts:158](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-instance-adapter.ts#L158)
+[docker-instance-adapter.ts:161](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-instance-adapter.ts#L161)
 
 ___
 
@@ -234,7 +234,7 @@ ILifeCycleAdapterRun.stats
 
 #### Defined in
 
-[docker-instance-adapter.ts:102](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-instance-adapter.ts#L102)
+[docker-instance-adapter.ts:104](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-instance-adapter.ts#L104)
 
 ## Constructors
 
@@ -260,11 +260,11 @@ ___
 
 ### logger
 
-• **logger**: `Console`
+• **logger**: `IObjectLogger`
 
 #### Implementation of
 
-IComponent.logger
+ILifeCycleAdapterMain.logger
 
 #### Defined in
 

--- a/docs/adapters/classes/dockerodedockerhelper.md
+++ b/docs/adapters/classes/dockerodedockerhelper.md
@@ -528,13 +528,17 @@ Container exit code.
 
 #### Defined in
 
-[dockerode-docker-helper.ts:45](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L45)
+[dockerode-docker-helper.ts:44](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L44)
 
 ___
 
 ### logger
 
-• **logger**: `Console`
+• **logger**: `ObjLogger`
+
+#### Implementation of
+
+[IDockerHelper](../interfaces/idockerhelper.md).[logger](../interfaces/idockerhelper.md#logger)
 
 #### Defined in
 

--- a/docs/adapters/classes/dockersequenceadapter.md
+++ b/docs/adapters/classes/dockersequenceadapter.md
@@ -29,6 +29,7 @@ Adapter for preparing Sequence to be run in Docker container.
 
 - [dockerHelper](dockersequenceadapter.md#dockerhelper)
 - [logger](dockersequenceadapter.md#logger)
+- [name](dockersequenceadapter.md#name)
 - [resources](dockersequenceadapter.md#resources)
 
 ## Constructors
@@ -45,7 +46,7 @@ Adapter for preparing Sequence to be run in Docker container.
 
 #### Defined in
 
-[docker-sequence-adapter.ts:23](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L23)
+[docker-sequence-adapter.ts:28](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L28)
 
 ## Methods
 
@@ -69,7 +70,7 @@ Created volume.
 
 #### Defined in
 
-[docker-sequence-adapter.ts:161](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L161)
+[docker-sequence-adapter.ts:175](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L175)
 
 ___
 
@@ -91,7 +92,7 @@ Pulls image from registry.
 
 #### Defined in
 
-[docker-sequence-adapter.ts:46](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L46)
+[docker-sequence-adapter.ts:54](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L54)
 
 ___
 
@@ -123,7 +124,7 @@ ISequenceAdapter.identify
 
 #### Defined in
 
-[docker-sequence-adapter.ts:115](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L115)
+[docker-sequence-adapter.ts:126](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L126)
 
 ___
 
@@ -147,7 +148,7 @@ Sequence configuration or undefined if sequence cannot be identified.
 
 #### Defined in
 
-[docker-sequence-adapter.ts:74](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L74)
+[docker-sequence-adapter.ts:84](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L84)
 
 ___
 
@@ -167,7 +168,7 @@ ISequenceAdapter.init
 
 #### Defined in
 
-[docker-sequence-adapter.ts:33](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L33)
+[docker-sequence-adapter.ts:41](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L41)
 
 ___
 
@@ -189,7 +190,7 @@ ISequenceAdapter.list
 
 #### Defined in
 
-[docker-sequence-adapter.ts:55](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L55)
+[docker-sequence-adapter.ts:63](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L63)
 
 ___
 
@@ -215,7 +216,7 @@ Promise resolving to sequence configuration.
 
 #### Defined in
 
-[docker-sequence-adapter.ts:177](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L177)
+[docker-sequence-adapter.ts:193](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L193)
 
 ___
 
@@ -241,7 +242,7 @@ ISequenceAdapter.remove
 
 #### Defined in
 
-[docker-sequence-adapter.ts:209](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L209)
+[docker-sequence-adapter.ts:225](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L225)
 
 ## Properties
 
@@ -257,7 +258,27 @@ ___
 
 ### logger
 
-• `Private` **logger**: `Console`
+• **logger**: `IObjectLogger`
+
+Instance of class providing logging utilities.
+
+#### Implementation of
+
+ISequenceAdapter.logger
+
+#### Defined in
+
+[docker-sequence-adapter.ts:28](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L28)
+
+___
+
+### name
+
+• **name**: `string` = `"DockerSequenceAdapter"`
+
+#### Implementation of
+
+ISequenceAdapter.name
 
 #### Defined in
 

--- a/docs/adapters/interfaces/idockerhelper.md
+++ b/docs/adapters/interfaces/idockerhelper.md
@@ -22,6 +22,7 @@
 - [createContainer](idockerhelper.md#createcontainer)
 - [createVolume](idockerhelper.md#createvolume)
 - [listVolumes](idockerhelper.md#listvolumes)
+- [logger](idockerhelper.md#logger)
 - [removeContainer](idockerhelper.md#removecontainer)
 - [removeVolume](idockerhelper.md#removevolume)
 - [run](idockerhelper.md#run)
@@ -49,7 +50,7 @@
 
 #### Defined in
 
-[types.ts:286](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L286)
+[types.ts:288](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L288)
 
 ___
 
@@ -69,7 +70,7 @@ ___
 
 #### Defined in
 
-[types.ts:288](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L288)
+[types.ts:290](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L290)
 
 ___
 
@@ -89,7 +90,7 @@ ___
 
 #### Defined in
 
-[types.ts:284](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L284)
+[types.ts:286](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L286)
 
 ___
 
@@ -103,7 +104,7 @@ ___
 
 #### Defined in
 
-[types.ts:282](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L282)
+[types.ts:284](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L284)
 
 ___
 
@@ -126,7 +127,7 @@ Fetches the image from repo
 
 #### Defined in
 
-[types.ts:280](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L280)
+[types.ts:282](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L282)
 
 ___
 
@@ -149,7 +150,7 @@ Waits until containter exits
 
 #### Defined in
 
-[types.ts:272](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L272)
+[types.ts:274](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L274)
 
 ## Properties
 
@@ -187,7 +188,7 @@ Created container.
 
 #### Defined in
 
-[types.ts:186](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L186)
+[types.ts:188](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L188)
 
 ___
 
@@ -215,7 +216,7 @@ Created volume.
 
 #### Defined in
 
-[types.ts:245](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L245)
+[types.ts:247](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L247)
 
 ___
 
@@ -237,7 +238,17 @@ List of existing volumes
 
 #### Defined in
 
-[types.ts:236](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L236)
+[types.ts:238](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L238)
+
+___
+
+### logger
+
+• **logger**: `IObjectLogger`
+
+#### Defined in
+
+[types.ts:166](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L166)
 
 ___
 
@@ -263,7 +274,7 @@ Removes container.
 
 #### Defined in
 
-[types.ts:229](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L229)
+[types.ts:231](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L231)
 
 ___
 
@@ -289,7 +300,7 @@ Removes volume.
 
 #### Defined in
 
-[types.ts:254](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L254)
+[types.ts:256](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L256)
 
 ___
 
@@ -315,7 +326,7 @@ Executes command in container.
 
 #### Defined in
 
-[types.ts:263](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L263)
+[types.ts:265](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L265)
 
 ___
 
@@ -341,7 +352,7 @@ Starts container.
 
 #### Defined in
 
-[types.ts:210](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L210)
+[types.ts:212](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L212)
 
 ___
 
@@ -365,7 +376,7 @@ ___
 
 #### Defined in
 
-[types.ts:221](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L221)
+[types.ts:223](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L223)
 
 ___
 
@@ -391,7 +402,7 @@ Stops container.
 
 #### Defined in
 
-[types.ts:219](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L219)
+[types.ts:221](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L221)
 
 ___
 
@@ -419,4 +430,4 @@ DockerHelper volume configuration.
 
 #### Defined in
 
-[types.ts:173](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L173)
+[types.ts:175](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L175)

--- a/docs/adapters/modules.md
+++ b/docs/adapters/modules.md
@@ -275,7 +275,7 @@ ___
 
 #### Defined in
 
-[types.ts:291](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L291)
+[types.ts:293](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L293)
 
 ## Variables
 

--- a/docs/host/classes/CPMConnector.md
+++ b/docs/host/classes/CPMConnector.md
@@ -274,9 +274,9 @@ ___
 
 ### logger
 
-• **logger**: `Console`
+• **logger**: `IObjectLogger`
 
-Logger instance.
+Logger.
 
 #### Defined in
 
@@ -357,7 +357,7 @@ Sets up server to handle incoming requests.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:249](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L249)
+[packages/host/src/lib/cpm-connector.ts:254](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L254)
 
 ___
 
@@ -378,7 +378,7 @@ Promise that resolves when connection is established.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:313](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L313)
+[packages/host/src/lib/cpm-connector.ts:321](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L321)
 
 ___
 
@@ -445,7 +445,7 @@ Host id.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:202](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L202)
+[packages/host/src/lib/cpm-connector.ts:205](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L205)
 
 ___
 
@@ -463,7 +463,7 @@ Promise<LoadCheckStatMessage> Promise resolving to LoadCheckStatMessage object.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:440](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L440)
+[packages/host/src/lib/cpm-connector.ts:453](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L453)
 
 ___
 
@@ -499,7 +499,7 @@ Promise resolving to NetworkInfo object.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:407](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L407)
+[packages/host/src/lib/cpm-connector.ts:420](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L420)
 
 ___
 
@@ -523,7 +523,7 @@ Promise resolving to `ReadableStream<any>` with topic data.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:553](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L553)
+[packages/host/src/lib/cpm-connector.ts:570](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L570)
 
 ___
 
@@ -540,7 +540,7 @@ Tries to reconnect.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:357](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L357)
+[packages/host/src/lib/cpm-connector.ts:368](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L368)
 
 ___
 
@@ -556,7 +556,7 @@ Initializes connector.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:209](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L209)
+[packages/host/src/lib/cpm-connector.ts:212](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L212)
 
 ___
 
@@ -819,7 +819,7 @@ Configuration object.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:226](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L226)
+[packages/host/src/lib/cpm-connector.ts:229](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L229)
 
 ___
 
@@ -835,7 +835,7 @@ Reconnects to Manager if maximum number of connection attempts is not reached.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:375](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L375)
+[packages/host/src/lib/cpm-connector.ts:387](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L387)
 
 ___
 
@@ -853,7 +853,7 @@ Channel 1 is reserved for log stream sent to Manager.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:259](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L259)
+[packages/host/src/lib/cpm-connector.ts:264](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L264)
 
 ___
 
@@ -937,7 +937,7 @@ Sends instance information to Manager via communication channel.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:503](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L503)
+[packages/host/src/lib/cpm-connector.ts:518](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L518)
 
 ___
 
@@ -959,7 +959,7 @@ Sends list of sequence to Manager via communication channel.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:473](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L473)
+[packages/host/src/lib/cpm-connector.ts:486](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L486)
 
 ___
 
@@ -982,7 +982,7 @@ Sends sequence status to Manager via communication channel.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:489](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L489)
+[packages/host/src/lib/cpm-connector.ts:502](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L502)
 
 ___
 
@@ -1004,7 +1004,7 @@ Sends list of sequence to Manager via communication channel.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:458](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L458)
+[packages/host/src/lib/cpm-connector.ts:471](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L471)
 
 ___
 
@@ -1031,7 +1031,7 @@ Makes a POST request to Manager with topic data.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:530](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L530)
+[packages/host/src/lib/cpm-connector.ts:547](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L547)
 
 ___
 
@@ -1057,7 +1057,7 @@ Topic information is send via communication channel.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:517](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L517)
+[packages/host/src/lib/cpm-connector.ts:534](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L534)
 
 ___
 
@@ -1079,7 +1079,7 @@ Sets up load check object to be used to get load check data.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:193](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L193)
+[packages/host/src/lib/cpm-connector.ts:196](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L196)
 
 ___
 
@@ -1095,7 +1095,7 @@ Sets up a method sending load check data and to be called with interval
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:424](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L424)
+[packages/host/src/lib/cpm-connector.ts:437](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L437)
 
 ___
 

--- a/docs/host/classes/CSIController.md
+++ b/docs/host/classes/CSIController.md
@@ -2,7 +2,7 @@
 
 # Class: CSIController
 
-Handles all Instance lifecycle, exposes instance's HTTP API
+Handles all Instance lifecycle, exposes instance's HTTP API.
 
 ## Hierarchy
 
@@ -85,7 +85,7 @@ Handles all Instance lifecycle, exposes instance's HTTP API
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:89](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L89)
+[packages/host/src/lib/csi-controller.ts:94](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L94)
 
 ___
 
@@ -95,7 +95,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:77](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L77)
+[packages/host/src/lib/csi-controller.ts:75](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L75)
 
 ___
 
@@ -105,7 +105,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:76](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L76)
+[packages/host/src/lib/csi-controller.ts:74](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L74)
 
 ___
 
@@ -115,7 +115,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:60](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L60)
+[packages/host/src/lib/csi-controller.ts:58](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L58)
 
 ___
 
@@ -125,7 +125,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:109](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L109)
+[packages/host/src/lib/csi-controller.ts:114](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L114)
 
 ___
 
@@ -135,7 +135,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:58](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L58)
+[packages/host/src/lib/csi-controller.ts:56](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L56)
 
 ___
 
@@ -145,7 +145,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:63](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L63)
+[packages/host/src/lib/csi-controller.ts:61](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L61)
 
 ___
 
@@ -173,7 +173,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:65](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L65)
+[packages/host/src/lib/csi-controller.ts:63](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L63)
 
 ___
 
@@ -190,7 +190,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:72](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L72)
+[packages/host/src/lib/csi-controller.ts:70](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L70)
 
 ___
 
@@ -200,17 +200,19 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:61](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L61)
+[packages/host/src/lib/csi-controller.ts:59](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L59)
 
 ___
 
 ### logger
 
-• **logger**: `Console`
+• **logger**: `IObjectLogger`
+
+Logger.
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:55](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L55)
+[packages/host/src/lib/csi-controller.ts:82](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L82)
 
 ___
 
@@ -220,7 +222,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:70](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L70)
+[packages/host/src/lib/csi-controller.ts:68](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L68)
 
 ___
 
@@ -230,7 +232,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:71](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L71)
+[packages/host/src/lib/csi-controller.ts:69](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L69)
 
 ___
 
@@ -240,7 +242,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:64](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L64)
+[packages/host/src/lib/csi-controller.ts:62](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L62)
 
 ___
 
@@ -250,7 +252,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:59](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L59)
+[packages/host/src/lib/csi-controller.ts:57](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L57)
 
 ___
 
@@ -260,7 +262,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:62](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L62)
+[packages/host/src/lib/csi-controller.ts:60](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L60)
 
 ___
 
@@ -270,7 +272,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:74](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L74)
+[packages/host/src/lib/csi-controller.ts:72](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L72)
 
 ___
 
@@ -287,7 +289,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:73](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L73)
+[packages/host/src/lib/csi-controller.ts:71](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L71)
 
 ## Methods
 
@@ -332,7 +334,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:468](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L468)
+[packages/host/src/lib/csi-controller.ts:492](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L492)
 
 ___
 
@@ -346,7 +348,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:331](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L331)
+[packages/host/src/lib/csi-controller.ts:351](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L351)
 
 ___
 
@@ -409,7 +411,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:445](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L445)
+[packages/host/src/lib/csi-controller.ts:469](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L469)
 
 ___
 
@@ -423,7 +425,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:460](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L460)
+[packages/host/src/lib/csi-controller.ts:484](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L484)
 
 ___
 
@@ -437,7 +439,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:464](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L464)
+[packages/host/src/lib/csi-controller.ts:488](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L488)
 
 ___
 
@@ -469,7 +471,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:456](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L456)
+[packages/host/src/lib/csi-controller.ts:480](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L480)
 
 ___
 
@@ -489,7 +491,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:294](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L294)
+[packages/host/src/lib/csi-controller.ts:313](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L313)
 
 ___
 
@@ -509,7 +511,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:320](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L320)
+[packages/host/src/lib/csi-controller.ts:340](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L340)
 
 ___
 
@@ -529,7 +531,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:520](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L520)
+[packages/host/src/lib/csi-controller.ts:551](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L551)
 
 ___
 
@@ -549,7 +551,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:475](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L475)
+[packages/host/src/lib/csi-controller.ts:499](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L499)
 
 ___
 
@@ -569,7 +571,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:496](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L496)
+[packages/host/src/lib/csi-controller.ts:523](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L523)
 
 ___
 
@@ -589,7 +591,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:209](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L209)
+[packages/host/src/lib/csi-controller.ts:227](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L227)
 
 ___
 
@@ -603,7 +605,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:203](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L203)
+[packages/host/src/lib/csi-controller.ts:219](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L219)
 
 ___
 
@@ -677,7 +679,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:149](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L149)
+[packages/host/src/lib/csi-controller.ts:157](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L157)
 
 ___
 
@@ -961,7 +963,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:136](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L136)
+[packages/host/src/lib/csi-controller.ts:144](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L144)
 
 ___
 
@@ -975,7 +977,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:165](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L165)
+[packages/host/src/lib/csi-controller.ts:174](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L174)
 
 ## Constructors
 
@@ -1000,7 +1002,7 @@ TypedEmitter&lt;Events\&gt;.constructor
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:111](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L111)
+[packages/host/src/lib/csi-controller.ts:116](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L116)
 
 ## Accessors
 
@@ -1014,7 +1016,7 @@ TypedEmitter&lt;Events\&gt;.constructor
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:91](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L91)
+[packages/host/src/lib/csi-controller.ts:96](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L96)
 
 • `set` **endOfSequence**(`prm`): `void`
 
@@ -1030,7 +1032,7 @@ TypedEmitter&lt;Events\&gt;.constructor
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:99](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L99)
+[packages/host/src/lib/csi-controller.ts:104](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L104)
 
 ___
 
@@ -1044,4 +1046,4 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:81](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L81)
+[packages/host/src/lib/csi-controller.ts:86](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L86)

--- a/docs/host/classes/Host.md
+++ b/docs/host/classes/Host.md
@@ -59,7 +59,7 @@ The Host's API Server.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:41](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L41)
+[packages/host/src/lib/host.ts:45](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L45)
 
 ___
 
@@ -71,7 +71,7 @@ Api path prefix based on initial configuration.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:46](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L46)
+[packages/host/src/lib/host.ts:50](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L50)
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:85](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L85)
+[packages/host/src/lib/host.ts:89](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L89)
 
 ___
 
@@ -93,7 +93,7 @@ Configuration.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:36](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L36)
+[packages/host/src/lib/host.ts:40](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L40)
 
 ___
 
@@ -105,7 +105,7 @@ Instance of CPMConnector used to communicate with Manager.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:58](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L58)
+[packages/host/src/lib/host.ts:62](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L62)
 
 ___
 
@@ -117,7 +117,7 @@ Instance path prefix.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:51](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L51)
+[packages/host/src/lib/host.ts:55](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L55)
 
 ___
 
@@ -133,7 +133,7 @@ Object to store CSIControllers.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:63](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L63)
+[packages/host/src/lib/host.ts:67](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L67)
 
 ___
 
@@ -145,13 +145,13 @@ Instance of class providing load check.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:78](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L78)
+[packages/host/src/lib/host.ts:82](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L82)
 
 ___
 
 ### logger
 
-• **logger**: `Console`
+• **logger**: `IObjectLogger`
 
 Instance of class providing logging utilities.
 
@@ -161,7 +161,7 @@ IComponent.logger
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:73](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L73)
+[packages/host/src/lib/host.ts:77](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L77)
 
 ___
 
@@ -173,7 +173,7 @@ Sequences store.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:68](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L68)
+[packages/host/src/lib/host.ts:72](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L72)
 
 ___
 
@@ -185,7 +185,7 @@ Service to handle topics.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:83](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L83)
+[packages/host/src/lib/host.ts:87](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L87)
 
 ___
 
@@ -195,7 +195,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:53](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L53)
+[packages/host/src/lib/host.ts:57](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L57)
 
 ## Methods
 
@@ -217,7 +217,7 @@ Setting up handlers for general Host API endpoints:
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:212](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L212)
+[packages/host/src/lib/host.ts:230](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L230)
 
 ___
 
@@ -233,7 +233,7 @@ Stops running servers.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:661](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L661)
+[packages/host/src/lib/host.ts:678](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L678)
 
 ___
 
@@ -249,7 +249,7 @@ Initializes connector and connects to Manager.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:191](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L191)
+[packages/host/src/lib/host.ts:209](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L209)
 
 ___
 
@@ -267,7 +267,7 @@ List of instances.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:580](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L580)
+[packages/host/src/lib/host.ts:597](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L597)
 
 ___
 
@@ -291,7 +291,7 @@ Sequence info object.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:595](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L595)
+[packages/host/src/lib/host.ts:612](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L612)
 
 ___
 
@@ -315,7 +315,7 @@ List of instances.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:629](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L629)
+[packages/host/src/lib/host.ts:646](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L646)
 
 ___
 
@@ -333,7 +333,7 @@ List of sequences.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:614](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L614)
+[packages/host/src/lib/host.ts:631](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L631)
 
 ___
 
@@ -360,7 +360,7 @@ Promise resolving to operation result object.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:311](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L311)
+[packages/host/src/lib/host.ts:329](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L329)
 
 ___
 
@@ -386,7 +386,7 @@ Promise resolving to operation result.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:384](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L384)
+[packages/host/src/lib/host.ts:403](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L403)
 
 ___
 
@@ -414,7 +414,7 @@ Promise resolving to operation result object.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:424](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L424)
+[packages/host/src/lib/host.ts:448](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L448)
 
 ___
 
@@ -431,7 +431,7 @@ Used to recover sequences information after restart.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:357](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L357)
+[packages/host/src/lib/host.ts:376](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L376)
 
 ___
 
@@ -461,7 +461,7 @@ Instance middleware.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:275](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L275)
+[packages/host/src/lib/host.ts:293](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L293)
 
 ___
 
@@ -487,7 +487,7 @@ Promise resolving to instance of Host.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:145](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L145)
+[packages/host/src/lib/host.ts:163](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L163)
 
 ___
 
@@ -511,7 +511,7 @@ Creates new CSIController [CSIController](CSIController.md) object and handles i
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:477](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L477)
+[packages/host/src/lib/host.ts:491](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L491)
 
 ___
 
@@ -528,7 +528,7 @@ using its CSIController [CSIController](CSIController.md)
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:644](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L644)
+[packages/host/src/lib/host.ts:661](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L661)
 
 ## Constructors
 
@@ -549,4 +549,4 @@ Sets used modules with provided configuration.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:106](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L106)
+[packages/host/src/lib/host.ts:110](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L110)

--- a/docs/host/classes/ServiceDiscovery.md
+++ b/docs/host/classes/ServiceDiscovery.md
@@ -51,7 +51,7 @@ added topic data.
 
 #### Defined in
 
-[packages/host/src/lib/sd-adapter.ts:62](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L62)
+[packages/host/src/lib/sd-adapter.ts:64](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L64)
 
 ___
 
@@ -75,7 +75,7 @@ Topic details.
 
 #### Defined in
 
-[packages/host/src/lib/sd-adapter.ts:107](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L107)
+[packages/host/src/lib/sd-adapter.ts:110](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L110)
 
 ___
 
@@ -101,7 +101,7 @@ Topic stream.
 
 #### Defined in
 
-[packages/host/src/lib/sd-adapter.ts:136](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L136)
+[packages/host/src/lib/sd-adapter.ts:139](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L139)
 
 ___
 
@@ -119,7 +119,7 @@ All topics.
 
 #### Defined in
 
-[packages/host/src/lib/sd-adapter.ts:95](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L95)
+[packages/host/src/lib/sd-adapter.ts:98](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L98)
 
 ___
 
@@ -141,7 +141,7 @@ Removes store topic with given id.
 
 #### Defined in
 
-[packages/host/src/lib/sd-adapter.ts:177](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L177)
+[packages/host/src/lib/sd-adapter.ts:180](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L180)
 
 ___
 
@@ -163,7 +163,7 @@ Unsets local provider for given topic.
 
 #### Defined in
 
-[packages/host/src/lib/sd-adapter.ts:120](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L120)
+[packages/host/src/lib/sd-adapter.ts:123](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L123)
 
 ___
 
@@ -185,7 +185,7 @@ Sets the CPM connector.
 
 #### Defined in
 
-[packages/host/src/lib/sd-adapter.ts:51](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L51)
+[packages/host/src/lib/sd-adapter.ts:53](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L53)
 
 ## Constructors
 
@@ -201,7 +201,7 @@ Sets the CPM connector.
 
 #### Defined in
 
-[packages/host/src/lib/sd-adapter.ts:44](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L44)
+[packages/host/src/lib/sd-adapter.ts:46](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L46)
 
 ___
 
@@ -217,8 +217,8 @@ ___
 
 ### logger
 
-• **logger**: `Console`
+• **logger**: `ObjLogger`
 
 #### Defined in
 
-[packages/host/src/lib/sd-adapter.ts:43](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L43)
+[packages/host/src/lib/sd-adapter.ts:44](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L44)

--- a/docs/host/classes/SocketServer.md
+++ b/docs/host/classes/SocketServer.md
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/socket-server.ts:94](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/socket-server.ts#L94)
+[packages/host/src/lib/socket-server.ts:98](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/socket-server.ts#L98)
 
 ___
 
@@ -499,7 +499,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/socket-server.ts:33](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/socket-server.ts#L33)
+[packages/host/src/lib/socket-server.ts:37](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/socket-server.ts#L37)
 
 ## Constructors
 
@@ -519,13 +519,13 @@ TypedEmitter&lt;Events\&gt;.constructor
 
 #### Defined in
 
-[packages/host/src/lib/socket-server.ts:28](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/socket-server.ts#L28)
+[packages/host/src/lib/socket-server.ts:31](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/socket-server.ts#L31)
 
 ## Properties
 
 ### logger
 
-• **logger**: `Console`
+• **logger**: `IObjectLogger`
 
 #### Implementation of
 
@@ -533,7 +533,7 @@ IComponent.logger
 
 #### Defined in
 
-[packages/host/src/lib/socket-server.ts:24](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/socket-server.ts#L24)
+[packages/host/src/lib/socket-server.ts:27](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/socket-server.ts#L27)
 
 ___
 
@@ -543,4 +543,4 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/socket-server.ts:23](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/socket-server.ts#L23)
+[packages/host/src/lib/socket-server.ts:25](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/socket-server.ts#L25)

--- a/docs/host/modules.md
+++ b/docs/host/modules.md
@@ -36,7 +36,7 @@
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:23](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L23)
+[packages/host/src/lib/host.ts:27](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L27)
 
 ___
 

--- a/docs/load-check/classes/LoadCheck.md
+++ b/docs/load-check/classes/LoadCheck.md
@@ -54,7 +54,7 @@ ___
 
 ### logger
 
-• **logger**: `Console`
+• **logger**: `ObjLogger`
 
 Logger instance.
 

--- a/docs/logger/classes/ObjLogger.md
+++ b/docs/logger/classes/ObjLogger.md
@@ -1,0 +1,428 @@
+[@scramjet/obj-logger](../README.md) / ObjLogger
+
+# Class: ObjLogger
+
+## Implements
+
+- `IObjectLogger`
+
+## Table of contents
+
+### Constructors
+
+- [constructor](ObjLogger.md#constructor)
+
+### Properties
+
+- [baseLog](ObjLogger.md#baselog)
+- [inputLogStream](ObjLogger.md#inputlogstream)
+- [inputStringifiedLogStream](ObjLogger.md#inputstringifiedlogstream)
+- [logLevel](ObjLogger.md#loglevel)
+- [name](ObjLogger.md#name)
+- [output](ObjLogger.md#output)
+- [outputLogStream](ObjLogger.md#outputlogstream)
+- [outputs](ObjLogger.md#outputs)
+- [levels](ObjLogger.md#levels)
+
+### Methods
+
+- [addOutput](ObjLogger.md#addoutput)
+- [debug](ObjLogger.md#debug)
+- [error](ObjLogger.md#error)
+- [fatal](ObjLogger.md#fatal)
+- [info](ObjLogger.md#info)
+- [pipe](ObjLogger.md#pipe)
+- [trace](ObjLogger.md#trace)
+- [updateBaseLog](ObjLogger.md#updatebaselog)
+- [warn](ObjLogger.md#warn)
+- [write](ObjLogger.md#write)
+
+## Constructors
+
+### constructor
+
+• **new ObjLogger**(`reference`, `baseLog?`, `logLevel?`)
+
+#### Parameters
+
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `reference` | `any` | `undefined` | Used to obtain a name for the logger. |
+| `baseLog` | `DeepPartial`<`Object`\> | `{}` | Default log object. |
+| `logLevel` | `LogLevel` | `"TRACE"` | Log level. |
+
+#### Defined in
+
+[obj-logger/src/obj-logger.ts:58](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L58)
+
+## Properties
+
+### baseLog
+
+• **baseLog**: `DeepPartial`<`Object`\>
+
+Default log object.
+
+#### Defined in
+
+[obj-logger/src/obj-logger.ts:35](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L35)
+
+___
+
+### inputLogStream
+
+• **inputLogStream**: `PassThrough`
+
+Input log stream in object mode.
+
+#### Implementation of
+
+IObjectLogger.inputLogStream
+
+#### Defined in
+
+[obj-logger/src/obj-logger.ts:15](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L15)
+
+___
+
+### inputStringifiedLogStream
+
+• **inputStringifiedLogStream**: `PassThrough`
+
+Input log stream in string mode.
+
+#### Implementation of
+
+IObjectLogger.inputStringifiedLogStream
+
+#### Defined in
+
+[obj-logger/src/obj-logger.ts:20](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L20)
+
+___
+
+### logLevel
+
+• **logLevel**: `LogLevel`
+
+Log level.
+
+#### Defined in
+
+[obj-logger/src/obj-logger.ts:40](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L40)
+
+___
+
+### name
+
+• **name**: `string`
+
+Name used to indicate the source of the log.
+
+#### Defined in
+
+[obj-logger/src/obj-logger.ts:30](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L30)
+
+___
+
+### output
+
+• **output**: `DataStream`
+
+Output stream in object mode.
+
+#### Implementation of
+
+IObjectLogger.output
+
+#### Defined in
+
+[obj-logger/src/obj-logger.ts:25](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L25)
+
+___
+
+### outputLogStream
+
+• **outputLogStream**: `PassThrough`
+
+#### Implementation of
+
+IObjectLogger.outputLogStream
+
+#### Defined in
+
+[obj-logger/src/obj-logger.ts:10](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L10)
+
+___
+
+### outputs
+
+• **outputs**: `Writable`[] = `[]`
+
+Additional output streams.
+
+#### Defined in
+
+[obj-logger/src/obj-logger.ts:45](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L45)
+
+___
+
+### levels
+
+▪ `Static` **levels**: `LogLevel`[]
+
+Logging levels chierarchy.
+
+#### Defined in
+
+[obj-logger/src/obj-logger.ts:50](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L50)
+
+## Methods
+
+### addOutput
+
+▸ **addOutput**(`output`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `output` | `Writable` |
+
+#### Returns
+
+`void`
+
+#### Implementation of
+
+IObjectLogger.addOutput
+
+#### Defined in
+
+[obj-logger/src/obj-logger.ts:117](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L117)
+
+___
+
+### debug
+
+▸ **debug**(`entry`, ...`optionalParams`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `entry` | `string` \| `DeepPartial`<`Object`\> |
+| `...optionalParams` | `any`[] |
+
+#### Returns
+
+`void`
+
+#### Implementation of
+
+IObjectLogger.debug
+
+#### Defined in
+
+[obj-logger/src/obj-logger.ts:133](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L133)
+
+___
+
+### error
+
+▸ **error**(`entry`, ...`optionalParams`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `entry` | `string` \| `DeepPartial`<`Object`\> |
+| `...optionalParams` | `any`[] |
+
+#### Returns
+
+`void`
+
+#### Implementation of
+
+IObjectLogger.error
+
+#### Defined in
+
+[obj-logger/src/obj-logger.ts:129](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L129)
+
+___
+
+### fatal
+
+▸ **fatal**(`entry`, ...`optionalParams`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `entry` | `string` \| `DeepPartial`<`Object`\> |
+| `...optionalParams` | `any`[] |
+
+#### Returns
+
+`void`
+
+#### Implementation of
+
+IObjectLogger.fatal
+
+#### Defined in
+
+[obj-logger/src/obj-logger.ts:137](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L137)
+
+___
+
+### info
+
+▸ **info**(`entry`, ...`optionalParams`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `entry` | `string` \| `DeepPartial`<`Object`\> |
+| `...optionalParams` | `any`[] |
+
+#### Returns
+
+`void`
+
+#### Implementation of
+
+IObjectLogger.info
+
+#### Defined in
+
+[obj-logger/src/obj-logger.ts:125](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L125)
+
+___
+
+### pipe
+
+▸ **pipe**(`target`, `options?`): `Writable`
+
+Pipes output logger to provided target. The target can be a writable stream or an ObjectLogger instance.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `target` | `Writable` \| `IObjectLogger` | Target for log stream. |
+| `options` | `Object` | Pipe options. If option `stringified` is set to true, the output will be stringified. |
+| `options.stringified?` | `boolean` | - |
+
+#### Returns
+
+`Writable`
+
+Piped stream
+
+#### Implementation of
+
+IObjectLogger.pipe
+
+#### Defined in
+
+[obj-logger/src/obj-logger.ts:156](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L156)
+
+___
+
+### trace
+
+▸ **trace**(`entry`, ...`optionalParams`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `entry` | `string` \| `DeepPartial`<`Object`\> |
+| `...optionalParams` | `any`[] |
+
+#### Returns
+
+`void`
+
+#### Implementation of
+
+IObjectLogger.trace
+
+#### Defined in
+
+[obj-logger/src/obj-logger.ts:121](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L121)
+
+___
+
+### updateBaseLog
+
+▸ **updateBaseLog**(`baseLog`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `baseLog` | `DeepPartial`<`Object`\> |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[obj-logger/src/obj-logger.ts:145](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L145)
+
+___
+
+### warn
+
+▸ **warn**(`entry`, ...`optionalParams`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `entry` | `string` \| `DeepPartial`<`Object`\> |
+| `...optionalParams` | `any`[] |
+
+#### Returns
+
+`void`
+
+#### Implementation of
+
+IObjectLogger.warn
+
+#### Defined in
+
+[obj-logger/src/obj-logger.ts:141](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L141)
+
+___
+
+### write
+
+▸ **write**(`level`, `entry`, ...`optionalParams`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `level` | `LogLevel` |
+| `entry` | `string` \| `DeepPartial`<`Object`\> |
+| `...optionalParams` | `any`[] |
+
+#### Returns
+
+`void`
+
+#### Implementation of
+
+IObjectLogger.write
+
+#### Defined in
+
+[obj-logger/src/obj-logger.ts:85](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L85)

--- a/docs/runner/classes/runner.md
+++ b/docs/runner/classes/runner.md
@@ -66,7 +66,7 @@ reacts to control messages such as stopping etc.
 
 #### Defined in
 
-[runner.ts:224](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L224)
+[runner.ts:234](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L234)
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 #### Defined in
 
-[runner.ts:147](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L147)
+[runner.ts:154](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L154)
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[runner.ts:103](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L103)
+[runner.ts:110](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L110)
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 #### Defined in
 
-[runner.ts:137](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L137)
+[runner.ts:144](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L144)
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-[runner.ts:405](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L405)
+[runner.ts:418](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L418)
 
 ___
 
@@ -142,7 +142,7 @@ ___
 
 #### Defined in
 
-[runner.ts:208](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L208)
+[runner.ts:218](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L218)
 
 ___
 
@@ -162,7 +162,7 @@ ___
 
 #### Defined in
 
-[runner.ts:184](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L184)
+[runner.ts:192](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L192)
 
 ___
 
@@ -176,7 +176,7 @@ ___
 
 #### Defined in
 
-[runner.ts:558](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L558)
+[runner.ts:570](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L570)
 
 ___
 
@@ -199,7 +199,7 @@ set up streams process.stdin, process.stdout, process.stderr, fifo downstream, f
 
 #### Defined in
 
-[runner.ts:372](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L372)
+[runner.ts:384](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L384)
 
 ___
 
@@ -213,7 +213,7 @@ ___
 
 #### Defined in
 
-[runner.ts:257](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L257)
+[runner.ts:267](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L267)
 
 ___
 
@@ -234,7 +234,7 @@ ___
 
 #### Defined in
 
-[runner.ts:417](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L417)
+[runner.ts:430](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L430)
 
 ___
 
@@ -248,7 +248,7 @@ ___
 
 #### Defined in
 
-[runner.ts:393](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L393)
+[runner.ts:406](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L406)
 
 ___
 
@@ -268,7 +268,7 @@ ___
 
 #### Defined in
 
-[runner.ts:171](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L171)
+[runner.ts:179](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L179)
 
 ___
 
@@ -282,7 +282,7 @@ ___
 
 #### Defined in
 
-[runner.ts:399](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L399)
+[runner.ts:412](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L412)
 
 ## Constructors
 
@@ -306,7 +306,7 @@ ___
 
 #### Defined in
 
-[runner.ts:74](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L74)
+[runner.ts:76](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L76)
 
 ## Accessors
 
@@ -320,7 +320,7 @@ ___
 
 #### Defined in
 
-[runner.ts:93](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L93)
+[runner.ts:100](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L100)
 
 ## Properties
 
@@ -337,13 +337,13 @@ ___
 
 #### Defined in
 
-[runner.ts:69](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L69)
+[runner.ts:71](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L71)
 
 ___
 
 ### logger
 
-• **logger**: `Console`
+• **logger**: `IObjectLogger`
 
 #### Implementation of
 
@@ -351,4 +351,4 @@ IComponent.logger
 
 #### Defined in
 
-[runner.ts:71](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L71)
+[runner.ts:73](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L73)

--- a/docs/sth-config/classes/configservice.md
+++ b/docs/sth-config/classes/configservice.md
@@ -28,7 +28,7 @@
 
 #### Defined in
 
-[sth-config/src/config-service.ts:50](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L50)
+[sth-config/src/config-service.ts:52](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L52)
 
 ## Methods
 
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[sth-config/src/config-service.ts:60](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L60)
+[sth-config/src/config-service.ts:62](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L62)
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 #### Defined in
 
-[sth-config/src/config-service.ts:64](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L64)
+[sth-config/src/config-service.ts:66](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L66)
 
 ___
 
@@ -81,4 +81,4 @@ ___
 
 #### Defined in
 
-[sth-config/src/config-service.ts:68](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L68)
+[sth-config/src/config-service.ts:70](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L70)

--- a/docs/sth-config/modules.md
+++ b/docs/sth-config/modules.md
@@ -24,7 +24,7 @@
 
 #### Defined in
 
-[sth-config/src/config-service.ts:47](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L47)
+[sth-config/src/config-service.ts:49](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L49)
 
 ## Functions
 

--- a/docs/types/interfaces/appcontext.md
+++ b/docs/types/interfaces/appcontext.md
@@ -85,11 +85,11 @@ ___
 
 ### logger
 
-• **logger**: `Console`
+• **logger**: [`IObjectLogger`](iobjectlogger.md)
 
 #### Defined in
 
-[packages/types/src/app-context.ts:38](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/app-context.ts#L38)
+[packages/types/src/app-context.ts:37](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/app-context.ts#L37)
 
 ## Methods
 

--- a/docs/types/interfaces/icomponent.md
+++ b/docs/types/interfaces/icomponent.md
@@ -18,8 +18,8 @@
 
 ### logger
 
-• **logger**: `Console`
+• **logger**: [`IObjectLogger`](iobjectlogger.md)
 
 #### Defined in
 
-[packages/types/src/component.ts:2](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/component.ts#L2)
+[packages/types/src/component.ts:4](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/component.ts#L4)

--- a/docs/types/interfaces/ihostclient.md
+++ b/docs/types/interfaces/ihostclient.md
@@ -62,7 +62,7 @@ ___
 
 ### logger
 
-• **logger**: `Console`
+• **logger**: [`IObjectLogger`](iobjectlogger.md)
 
 #### Inherited from
 
@@ -70,7 +70,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/component.ts:2](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/component.ts#L2)
+[packages/types/src/component.ts:4](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/component.ts#L4)
 
 ___
 

--- a/docs/types/interfaces/ilifecycleadaptermain.md
+++ b/docs/types/interfaces/ilifecycleadaptermain.md
@@ -16,6 +16,10 @@
 - [init](ilifecycleadaptermain.md#init)
 - [remove](ilifecycleadaptermain.md#remove)
 
+### Properties
+
+- [logger](ilifecycleadaptermain.md#logger)
+
 ## Methods
 
 ### cleanup
@@ -30,7 +34,7 @@ Removes resources.
 
 #### Defined in
 
-[packages/types/src/lifecycle-adapters.ts:16](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/lifecycle-adapters.ts#L16)
+[packages/types/src/lifecycle-adapters.ts:19](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/lifecycle-adapters.ts#L19)
 
 ___
 
@@ -46,7 +50,7 @@ Initializes Lifecycle adapter.
 
 #### Defined in
 
-[packages/types/src/lifecycle-adapters.ts:11](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/lifecycle-adapters.ts#L11)
+[packages/types/src/lifecycle-adapters.ts:14](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/lifecycle-adapters.ts#L14)
 
 ___
 
@@ -60,4 +64,14 @@ ___
 
 #### Defined in
 
-[packages/types/src/lifecycle-adapters.ts:19](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/lifecycle-adapters.ts#L19)
+[packages/types/src/lifecycle-adapters.ts:22](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/lifecycle-adapters.ts#L22)
+
+## Properties
+
+### logger
+
+• **logger**: [`IObjectLogger`](iobjectlogger.md)
+
+#### Defined in
+
+[packages/types/src/lifecycle-adapters.ts:9](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/lifecycle-adapters.ts#L9)

--- a/docs/types/interfaces/ilifecycleadapterrun.md
+++ b/docs/types/interfaces/ilifecycleadapterrun.md
@@ -19,6 +19,10 @@
 - [run](ilifecycleadapterrun.md#run)
 - [stats](ilifecycleadapterrun.md#stats)
 
+### Properties
+
+- [logger](ilifecycleadapterrun.md#logger)
+
 ## Methods
 
 ### cleanup
@@ -37,7 +41,7 @@ Removes resources.
 
 #### Defined in
 
-[packages/types/src/lifecycle-adapters.ts:16](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/lifecycle-adapters.ts#L16)
+[packages/types/src/lifecycle-adapters.ts:19](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/lifecycle-adapters.ts#L19)
 
 ___
 
@@ -57,7 +61,7 @@ Initializes Lifecycle adapter.
 
 #### Defined in
 
-[packages/types/src/lifecycle-adapters.ts:11](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/lifecycle-adapters.ts#L11)
+[packages/types/src/lifecycle-adapters.ts:14](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/lifecycle-adapters.ts#L14)
 
 ___
 
@@ -77,7 +81,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/lifecycle-adapters.ts:32](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/lifecycle-adapters.ts#L32)
+[packages/types/src/lifecycle-adapters.ts:35](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/lifecycle-adapters.ts#L35)
 
 ___
 
@@ -95,7 +99,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/lifecycle-adapters.ts:19](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/lifecycle-adapters.ts#L19)
+[packages/types/src/lifecycle-adapters.ts:22](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/lifecycle-adapters.ts#L22)
 
 ___
 
@@ -121,7 +125,7 @@ Runner exit code.
 
 #### Defined in
 
-[packages/types/src/lifecycle-adapters.ts:30](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/lifecycle-adapters.ts#L30)
+[packages/types/src/lifecycle-adapters.ts:33](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/lifecycle-adapters.ts#L33)
 
 ___
 
@@ -141,4 +145,18 @@ ___
 
 #### Defined in
 
-[packages/types/src/lifecycle-adapters.ts:34](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/lifecycle-adapters.ts#L34)
+[packages/types/src/lifecycle-adapters.ts:37](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/lifecycle-adapters.ts#L37)
+
+## Properties
+
+### logger
+
+• **logger**: [`IObjectLogger`](iobjectlogger.md)
+
+#### Inherited from
+
+[ILifeCycleAdapterMain](ilifecycleadaptermain.md).[logger](ilifecycleadaptermain.md#logger)
+
+#### Defined in
+
+[packages/types/src/lifecycle-adapters.ts:9](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/lifecycle-adapters.ts#L9)

--- a/docs/types/interfaces/iobjectlogger.md
+++ b/docs/types/interfaces/iobjectlogger.md
@@ -1,0 +1,254 @@
+[@scramjet/types](../README.md) / [Exports](../modules.md) / IObjectLogger
+
+# Interface: IObjectLogger
+
+## Table of contents
+
+### Methods
+
+- [addOutput](iobjectlogger.md#addoutput)
+- [debug](iobjectlogger.md#debug)
+- [error](iobjectlogger.md#error)
+- [fatal](iobjectlogger.md#fatal)
+- [info](iobjectlogger.md#info)
+- [pipe](iobjectlogger.md#pipe)
+- [trace](iobjectlogger.md#trace)
+- [warn](iobjectlogger.md#warn)
+- [write](iobjectlogger.md#write)
+
+### Properties
+
+- [inputLogStream](iobjectlogger.md#inputlogstream)
+- [inputStringifiedLogStream](iobjectlogger.md#inputstringifiedlogstream)
+- [output](iobjectlogger.md#output)
+- [outputLogStream](iobjectlogger.md#outputlogstream)
+
+## Methods
+
+### addOutput
+
+▸ **addOutput**(`output`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `output` | `Writable` |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/types/src/object-logger.ts:26](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L26)
+
+___
+
+### debug
+
+▸ **debug**(`entry`, ...`optionalParams`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `entry` | `string` \| [`DeepPartial`](../modules.md#deeppartial)<`Object`\> |
+| `...optionalParams` | `any`[] |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/types/src/object-logger.ts:29](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L29)
+
+___
+
+### error
+
+▸ **error**(`entry`, ...`optionalParams`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `entry` | `string` \| [`DeepPartial`](../modules.md#deeppartial)<`Object`\> |
+| `...optionalParams` | `any`[] |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/types/src/object-logger.ts:30](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L30)
+
+___
+
+### fatal
+
+▸ **fatal**(`entry`, ...`optionalParams`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `entry` | `string` \| [`DeepPartial`](../modules.md#deeppartial)<`Object`\> |
+| `...optionalParams` | `any`[] |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/types/src/object-logger.ts:31](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L31)
+
+___
+
+### info
+
+▸ **info**(`entry`, ...`optionalParams`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `entry` | `string` \| [`DeepPartial`](../modules.md#deeppartial)<`Object`\> |
+| `...optionalParams` | `any`[] |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/types/src/object-logger.ts:32](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L32)
+
+___
+
+### pipe
+
+▸ **pipe**(`target`, `options?`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `target` | `Writable` \| [`IObjectLogger`](iobjectlogger.md) |
+| `options?` | `Object` |
+| `options.stringified?` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/types/src/object-logger.ts:35](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L35)
+
+___
+
+### trace
+
+▸ **trace**(`entry`, ...`optionalParams`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `entry` | `string` \| [`DeepPartial`](../modules.md#deeppartial)<`Object`\> |
+| `...optionalParams` | `any`[] |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/types/src/object-logger.ts:33](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L33)
+
+___
+
+### warn
+
+▸ **warn**(`entry`, ...`optionalParams`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `entry` | `string` \| [`DeepPartial`](../modules.md#deeppartial)<`Object`\> |
+| `...optionalParams` | `any`[] |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/types/src/object-logger.ts:34](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L34)
+
+___
+
+### write
+
+▸ **write**(`level`, `entry`, ...`optionalParams`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `level` | `undefined` \| [`DeepPartial`](../modules.md#deeppartial)<[`LogLevel`](../modules.md#loglevel)\> |
+| `entry` | `string` \| [`DeepPartial`](../modules.md#deeppartial)<`Object`\> |
+| `...optionalParams` | `any`[] |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/types/src/object-logger.ts:28](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L28)
+
+## Properties
+
+### inputLogStream
+
+• **inputLogStream**: `PassThrough`
+
+#### Defined in
+
+[packages/types/src/object-logger.ts:21](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L21)
+
+___
+
+### inputStringifiedLogStream
+
+• **inputStringifiedLogStream**: `PassThrough`
+
+#### Defined in
+
+[packages/types/src/object-logger.ts:22](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L22)
+
+___
+
+### output
+
+• **output**: `DataStream`
+
+#### Defined in
+
+[packages/types/src/object-logger.ts:24](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L24)
+
+___
+
+### outputLogStream
+
+• **outputLogStream**: `PassThrough`
+
+#### Defined in
+
+[packages/types/src/object-logger.ts:23](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L23)

--- a/docs/types/interfaces/isequenceadapter.md
+++ b/docs/types/interfaces/isequenceadapter.md
@@ -11,6 +11,11 @@
 - [list](isequenceadapter.md#list)
 - [remove](isequenceadapter.md#remove)
 
+### Properties
+
+- [logger](isequenceadapter.md#logger)
+- [name](isequenceadapter.md#name)
+
 ## Methods
 
 ### identify
@@ -32,7 +37,7 @@ Identifies new sequence
 
 #### Defined in
 
-[packages/types/src/sequence-adapter.ts:22](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sequence-adapter.ts#L22)
+[packages/types/src/sequence-adapter.ts:27](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sequence-adapter.ts#L27)
 
 ___
 
@@ -46,7 +51,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/sequence-adapter.ts:12](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sequence-adapter.ts#L12)
+[packages/types/src/sequence-adapter.ts:17](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sequence-adapter.ts#L17)
 
 ___
 
@@ -62,7 +67,7 @@ Identifies existing sequences
 
 #### Defined in
 
-[packages/types/src/sequence-adapter.ts:17](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sequence-adapter.ts#L17)
+[packages/types/src/sequence-adapter.ts:22](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sequence-adapter.ts#L22)
 
 ___
 
@@ -82,4 +87,26 @@ ___
 
 #### Defined in
 
-[packages/types/src/sequence-adapter.ts:24](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sequence-adapter.ts#L24)
+[packages/types/src/sequence-adapter.ts:29](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sequence-adapter.ts#L29)
+
+## Properties
+
+### logger
+
+• **logger**: [`IObjectLogger`](iobjectlogger.md)
+
+#### Defined in
+
+[packages/types/src/sequence-adapter.ts:31](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sequence-adapter.ts#L31)
+
+___
+
+### name
+
+• **name**: `string`
+
+Adapter name.
+
+#### Defined in
+
+[packages/types/src/sequence-adapter.ts:15](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sequence-adapter.ts#L15)

--- a/docs/types/modules.md
+++ b/docs/types/modules.md
@@ -17,6 +17,7 @@
 - [ILifeCycleAdapter](interfaces/ilifecycleadapter.md)
 - [ILifeCycleAdapterMain](interfaces/ilifecycleadaptermain.md)
 - [ILifeCycleAdapterRun](interfaces/ilifecycleadapterrun.md)
+- [IObjectLogger](interfaces/iobjectlogger.md)
 - [ISequenceAdapter](interfaces/isequenceadapter.md)
 - [ReadableStream](interfaces/readablestream.md)
 - [WritableStream](interfaces/writablestream.md)
@@ -91,6 +92,8 @@
 - [LoadCheckContstants](modules.md#loadcheckcontstants)
 - [LoadCheckStat](modules.md#loadcheckstat)
 - [LoadCheckStatMessage](modules.md#loadcheckstatmessage)
+- [LogEntry](modules.md#logentry)
+- [LogLevel](modules.md#loglevel)
 - [Logger](modules.md#logger)
 - [LoggerOptions](modules.md#loggeroptions)
 - [LoggerOutput](modules.md#loggeroutput)
@@ -433,7 +436,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/sth-configuration.ts:1](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L1)
+[packages/types/src/sth-configuration.ts:3](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L3)
 
 ___
 
@@ -450,7 +453,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/sth-configuration.ts:13](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L13)
+[packages/types/src/sth-configuration.ts:15](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L15)
 
 ___
 
@@ -781,7 +784,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/lifecycle-adapters.ts:5](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/lifecycle-adapters.ts#L5)
+[packages/types/src/lifecycle-adapters.ts:6](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/lifecycle-adapters.ts#L6)
 
 ___
 
@@ -940,7 +943,7 @@ Host process configuration.
 
 #### Defined in
 
-[packages/types/src/sth-configuration.ts:38](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L38)
+[packages/types/src/sth-configuration.ts:40](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L40)
 
 ___
 
@@ -1178,7 +1181,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/lifecycle-adapters.ts:38](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/lifecycle-adapters.ts#L38)
+[packages/types/src/lifecycle-adapters.ts:41](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/lifecycle-adapters.ts#L41)
 
 ___
 
@@ -1249,6 +1252,28 @@ ___
 #### Defined in
 
 [packages/types/src/messages/load.ts:4](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/messages/load.ts#L4)
+
+___
+
+### LogEntry
+
+Ƭ **LogEntry**: [`DeepPartial`](modules.md#deeppartial)<`Object`\>
+
+Single log entry.
+
+#### Defined in
+
+[packages/types/src/object-logger.ts:10](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L10)
+
+___
+
+### LogLevel
+
+Ƭ **LogLevel**: ``"ERROR"`` \| ``"WARN"`` \| ``"INFO"`` \| ``"DEBUG"`` \| ``"FATAL"`` \| ``"TRACE"``
+
+#### Defined in
+
+[packages/types/src/object-logger.ts:5](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L5)
 
 ___
 
@@ -1727,7 +1752,7 @@ PreRunner container configuraion.
 
 #### Defined in
 
-[packages/types/src/sth-configuration.ts:28](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L28)
+[packages/types/src/sth-configuration.ts:30](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L30)
 
 ___
 
@@ -1844,7 +1869,7 @@ Runner container configuration.
 
 #### Defined in
 
-[packages/types/src/sth-configuration.ts:33](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L33)
+[packages/types/src/sth-configuration.ts:35](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L35)
 
 ___
 
@@ -1903,13 +1928,15 @@ ___
 | `instanceRequirements.cpuLoad` | `number` | Required free CPU. In percentage. |
 | `instanceRequirements.freeMem` | `number` | Free memory required to start instance. In megabytes. |
 | `instanceRequirements.freeSpace` | `number` | Free disk space required to start instance. In megabytes. |
+| `logColors` | `boolean` | Enable colors in logging. |
+| `logLevel` | [`LogLevel`](modules.md#loglevel) | Logging level. |
 | `noDocker` | `boolean` | Whether host should run all the instances on the host machine, instead of in docker containers **UNSAFE FOR RUNNING ARBITRARY CODE (e.g. user submitted)** |
 | `safeOperationLimit` | `number` | The amount of memory that must remain free. |
 | `sequencesRoot` | `string` | Only used when `noDocker` is true Where should ProcessSequenceAdapter save new sequences |
 
 #### Defined in
 
-[packages/types/src/sth-configuration.ts:70](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L70)
+[packages/types/src/sth-configuration.ts:72](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L72)
 
 ___
 


### PR DESCRIPTION
Updated CHANGELOG:

Prominent

- f0963d02 - Logger upgrade, now it operates on objects not strings
- e89113b2 - CLI: fix for saving instance id in config
- 5217044e - Introduce a new, faster building for development using esbuild
- fe364b1a - Add support for complex packages in python apps

Bugfixes:

- Fix for the id replacement in CLI.

## @scramjet/transform Hub - v0.15.1

This is the last release in changelog.
