### PR TITLE
Fix: let Python produce JSON logs

### DIFF
--- a/python/runner/logging_setup.py
+++ b/python/runner/logging_setup.py
@@ -1,13 +1,20 @@
 import logging
 from logging.handlers import MemoryHandler
 import sys
+import json
 
 
-class CustomFormatter(logging.Formatter):
-    def formatTime(self, record, datefmt=None):
+class JsonFormatter(logging.Formatter):
+    def formatMessage(self, record):
         # record.created is a float in seconds, we want ms.
         # Note that using timestamp gives us UTC, as desired.
-        return round(record.created*1000)
+        return json.dumps({
+            "ts": round(record.created*1000),
+            "level": record.levelname,
+            "from": record.name,
+            "msg": record.message,
+        })
+
 
 class LoggingSetup():
     def __init__(self, temp_log_path, min_loglevel=logging.DEBUG) -> None:
@@ -22,16 +29,8 @@ class LoggingSetup():
         self.adjust_levels()
 
 
-    def get_formatter(self):
-        log_format = (
-            '{{"ts": {asctime}, "level": "{levelname}", '
-            '"from": "{name}", "msg": "{message}"}}'
-        )
-        return CustomFormatter(fmt=log_format, style='{')
-
-
     def create_handlers(self, min_loglevel):
-        formatter = self.get_formatter()
+        formatter = JsonFormatter()
 
         self._main_handler = logging.StreamHandler(self._temp_logfile)
         self._main_handler.setLevel(min_loglevel)

--- a/python/runner/runner.py
+++ b/python/runner/runner.py
@@ -97,9 +97,11 @@ class Runner:
         send_encoded_msg(monitoring, msg_codes.PING)
 
         message = await control.readuntil(b"\n")
+        self.logger.info(f"Got message: {message}")
         code, data = json.loads(message.decode())
 
         if code == msg_codes.PONG.value:
+            self.logger.info(f"Got configuration: {data}")
             return data['appConfig'], data['args']
 
 

--- a/python/runner/runner.py
+++ b/python/runner/runner.py
@@ -97,11 +97,9 @@ class Runner:
         send_encoded_msg(monitoring, msg_codes.PING)
 
         message = await control.readuntil(b"\n")
-        self.logger.info(f"Got message: {message}")
         code, data = json.loads(message.decode())
 
         if code == msg_codes.PONG.value:
-            self.logger.info(f"Got configuration: {data}")
             return data['appConfig'], data['args']
 
 


### PR DESCRIPTION
hub expects logs in json format -> update logger settings.
Note that we want to have timestamp in miliseconds and it's not possible
to achive with standard formatting options, so I'm subclassing
logging.Formatter and overriding date formatting method.

Also, remove two logging statements that included json literals, they
were breaking log entry parsing.