### PR TITLE
Catch parse errors in CommunicationHandler

### DIFF
--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -510,6 +510,7 @@ export class Host implements IComponent {
         );
 
         csic.logger.pipe(this.logger);
+        communicationHandler.logger.pipe(this.logger);
 
         this.logger.trace("CSIController created", id);
 

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -15,6 +15,7 @@
   "author": "Scramjet <open-source@scramjet.org>",
   "license": "AGPL-3.0",
   "dependencies": {
+    "@scramjet/obj-logger": "^0.15.1",
     "@scramjet/symbols": "^0.15.1",
     "scramjet": "^4.36.0",
     "uuid": "^8.3.2"

--- a/packages/types/src/communication-handler.ts
+++ b/packages/types/src/communication-handler.ts
@@ -1,5 +1,6 @@
 import { DataStream } from "scramjet";
 import { Readable, Writable } from "stream";
+import { IObjectLogger } from "./object-logger";
 import { LoggerOutput } from "./logger";
 import {
     ControlMessageCode, DownstreamStreamsConfig, EncodedMessage, MessageDataType,
@@ -15,6 +16,7 @@ export type ControlMessageHandler<T extends ControlMessageCode> =
     (msg: EncodedMessage<T>) => MaybePromise<EncodedMessage<T> | null>;
 
 export interface ICommunicationHandler {
+    logger: IObjectLogger;
 
     hookUpstreamStreams(str: UpstreamStreamsConfig): this;
     hookDownstreamStreams(str: DownstreamStreamsConfig): this;


### PR DESCRIPTION
Catch and log errors if monitoring/control message can't be parsed to object.