### PR TITLE
CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ Prominent
 - e89113b2 - CLI: fix for saving instance id in config
 - 5217044e - Introduce a new, faster building for development using esbuild
 - fe364b1a - Add support for complex packages in python apps
+- 2d193278 - Introduce HTTPS support in the API Server
+- 38d69826 - The Docker Sequence and Instance Adapters specify the volume permissions
+- e46e9d80 - Scramjet community moving to Discord documentation update
 
 New features:
 
@@ -44,8 +47,9 @@ New features:
 - **TCP Runner** - Connection between Runner and Host is replaced from socket to TCP
 - **CLI extension** - Last uploaded/added sequence can now be referenced when starting etc. This will massively improve the CLI experience, as there's no longer need to parse the previous command line if we want to do quick deployment of a sequence
 - **Python runner WIP** - Running STH without docker can now spawn sequences written in python
+- **HTTPS Upgrade** - The API server can now be secured using HTTPS
 
-Bugfixes:
+Bugfixes and minor improvements:
 
 - Fix for spawning runner process
 - Container close issues now show not occur
@@ -65,7 +69,14 @@ Bugfixes:
 - Fix STH to be able to run from within a docker container (bugged since 0.13 and TCP Runner)
 - STH is able to reconnect to Scramjet Cloud Platform automatically
 - Fix for the id replacement in CLI.
+- Improved chunk size handling for the input and controls streams in the Python Runner
+- Smarter Python Runner selection based on the Sequence configuration
+- Sequence configuration can now be provided to Python Sequence on startup
+- Python Runner operates on the JSON logs (aligned with the new ObjLogger used in the Host)
+- Better error handling in the ObjectLogger and the CommunicationHandler
+- Added Docker Sequence and Instance Adapter volume permissions
+- Python Runner implements the complete Host handshake (including the default topic messages)
 
-## @scramjet/transform Hub - v0.15.1
+## @scramjet/transform Hub - v0.16.0
 
 This is the last release in changelog.

--- a/docs/adapters/classes/dockerinstanceadapter.md
+++ b/docs/adapters/classes/dockerinstanceadapter.md
@@ -53,7 +53,7 @@ ILifeCycleAdapterMain.cleanup
 
 #### Defined in
 
-[docker-instance-adapter.ts:251](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-instance-adapter.ts#L251)
+[docker-instance-adapter.ts:252](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-instance-adapter.ts#L252)
 
 ___
 
@@ -134,7 +134,7 @@ ILifeCycleAdapterRun.monitorRate
 
 #### Defined in
 
-[docker-instance-adapter.ts:263](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-instance-adapter.ts#L263)
+[docker-instance-adapter.ts:264](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-instance-adapter.ts#L264)
 
 ___
 
@@ -180,7 +180,7 @@ ILifeCycleAdapterMain.remove
 
 #### Defined in
 
-[docker-instance-adapter.ts:270](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-instance-adapter.ts#L270)
+[docker-instance-adapter.ts:271](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-instance-adapter.ts#L271)
 
 ___
 

--- a/docs/adapters/classes/dockerodedockerhelper.md
+++ b/docs/adapters/classes/dockerodedockerhelper.md
@@ -64,7 +64,7 @@ Object with container's standard I/O streams.
 
 #### Defined in
 
-[dockerode-docker-helper.ts:242](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L242)
+[dockerode-docker-helper.ts:243](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L243)
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 #### Defined in
 
-[dockerode-docker-helper.ts:334](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L334)
+[dockerode-docker-helper.ts:335](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L335)
 
 ___
 
@@ -152,7 +152,7 @@ ___
 
 #### Defined in
 
-[dockerode-docker-helper.ts:338](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L338)
+[dockerode-docker-helper.ts:339](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L339)
 
 ___
 
@@ -180,7 +180,7 @@ IDockerHelper.createVolume
 
 #### Defined in
 
-[dockerode-docker-helper.ts:206](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L206)
+[dockerode-docker-helper.ts:207](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L207)
 
 ___
 
@@ -204,7 +204,7 @@ ___
 
 #### Defined in
 
-[dockerode-docker-helper.ts:320](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L320)
+[dockerode-docker-helper.ts:321](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L321)
 
 ___
 
@@ -242,7 +242,7 @@ ___
 
 #### Defined in
 
-[dockerode-docker-helper.ts:315](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L315)
+[dockerode-docker-helper.ts:316](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L316)
 
 ___
 
@@ -260,7 +260,7 @@ IDockerHelper.listVolumes
 
 #### Defined in
 
-[dockerode-docker-helper.ts:227](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L227)
+[dockerode-docker-helper.ts:228](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L228)
 
 ___
 
@@ -343,7 +343,7 @@ IDockerHelper.removeVolume
 
 #### Defined in
 
-[dockerode-docker-helper.ts:223](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L223)
+[dockerode-docker-helper.ts:224](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L224)
 
 ___
 
@@ -371,7 +371,7 @@ IDockerHelper.run
 
 #### Defined in
 
-[dockerode-docker-helper.ts:252](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L252)
+[dockerode-docker-helper.ts:253](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L253)
 
 ___
 
@@ -512,7 +512,7 @@ Container exit code.
 
 #### Defined in
 
-[dockerode-docker-helper.ts:309](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L309)
+[dockerode-docker-helper.ts:310](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L310)
 
 ## Constructors
 

--- a/docs/adapters/interfaces/idockerhelper.md
+++ b/docs/adapters/interfaces/idockerhelper.md
@@ -50,7 +50,7 @@
 
 #### Defined in
 
-[types.ts:288](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L288)
+[types.ts:301](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L301)
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 #### Defined in
 
-[types.ts:290](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L290)
+[types.ts:303](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L303)
 
 ___
 
@@ -90,7 +90,7 @@ ___
 
 #### Defined in
 
-[types.ts:286](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L286)
+[types.ts:299](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L299)
 
 ___
 
@@ -104,7 +104,7 @@ ___
 
 #### Defined in
 
-[types.ts:284](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L284)
+[types.ts:297](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L297)
 
 ___
 
@@ -127,7 +127,7 @@ Fetches the image from repo
 
 #### Defined in
 
-[types.ts:282](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L282)
+[types.ts:295](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L295)
 
 ___
 
@@ -150,7 +150,7 @@ Waits until containter exits
 
 #### Defined in
 
-[types.ts:274](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L274)
+[types.ts:287](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L287)
 
 ## Properties
 
@@ -188,7 +188,7 @@ Created container.
 
 #### Defined in
 
-[types.ts:188](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L188)
+[types.ts:201](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L201)
 
 ___
 
@@ -216,7 +216,7 @@ Created volume.
 
 #### Defined in
 
-[types.ts:247](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L247)
+[types.ts:260](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L260)
 
 ___
 
@@ -238,7 +238,7 @@ List of existing volumes
 
 #### Defined in
 
-[types.ts:238](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L238)
+[types.ts:251](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L251)
 
 ___
 
@@ -248,7 +248,7 @@ ___
 
 #### Defined in
 
-[types.ts:166](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L166)
+[types.ts:179](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L179)
 
 ___
 
@@ -274,7 +274,7 @@ Removes container.
 
 #### Defined in
 
-[types.ts:231](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L231)
+[types.ts:244](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L244)
 
 ___
 
@@ -300,7 +300,7 @@ Removes volume.
 
 #### Defined in
 
-[types.ts:256](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L256)
+[types.ts:269](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L269)
 
 ___
 
@@ -326,7 +326,7 @@ Executes command in container.
 
 #### Defined in
 
-[types.ts:265](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L265)
+[types.ts:278](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L278)
 
 ___
 
@@ -352,7 +352,7 @@ Starts container.
 
 #### Defined in
 
-[types.ts:212](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L212)
+[types.ts:225](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L225)
 
 ___
 
@@ -376,7 +376,7 @@ ___
 
 #### Defined in
 
-[types.ts:223](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L223)
+[types.ts:236](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L236)
 
 ___
 
@@ -402,7 +402,7 @@ Stops container.
 
 #### Defined in
 
-[types.ts:221](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L221)
+[types.ts:234](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L234)
 
 ___
 
@@ -430,4 +430,4 @@ DockerHelper volume configuration.
 
 #### Defined in
 
-[types.ts:175](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L175)
+[types.ts:188](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L188)

--- a/docs/adapters/modules.md
+++ b/docs/adapters/modules.md
@@ -60,7 +60,7 @@
 
 #### Defined in
 
-[types.ts:134](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L134)
+[types.ts:147](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L147)
 
 ___
 
@@ -88,7 +88,7 @@ Configuration used to run command in container.
 
 #### Defined in
 
-[types.ts:57](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L57)
+[types.ts:70](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L70)
 
 ___
 
@@ -105,7 +105,7 @@ ___
 
 #### Defined in
 
-[types.ts:43](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L43)
+[types.ts:56](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L56)
 
 ___
 
@@ -125,7 +125,7 @@ Result of running command in container.
 
 #### Defined in
 
-[types.ts:148](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L148)
+[types.ts:161](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L161)
 
 ___
 
@@ -145,13 +145,13 @@ Standard streams connected with container.
 
 #### Defined in
 
-[types.ts:113](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L113)
+[types.ts:126](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L126)
 
 ___
 
 ### DockerAdapterVolumeConfig
 
-Ƭ **DockerAdapterVolumeConfig**: { `mountPoint`: `string`  } & { `volume`: [`DockerVolume`](modules.md#dockervolume)  } \| { `bind`: `string`  }
+Ƭ **DockerAdapterVolumeConfig**: { `mountPoint`: `string` ; `writeable`: `boolean`  } & { `volume`: [`DockerVolume`](modules.md#dockervolume)  } \| { `bind`: `string`  }
 
 Volume mounting configuration.
 
@@ -173,7 +173,7 @@ ___
 
 #### Defined in
 
-[types.ts:141](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L141)
+[types.ts:154](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L154)
 
 ___
 
@@ -203,7 +203,7 @@ ___
 
 #### Defined in
 
-[types.ts:50](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L50)
+[types.ts:63](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L63)
 
 ___
 
@@ -231,7 +231,7 @@ ___
 
 #### Defined in
 
-[types.ts:48](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L48)
+[types.ts:61](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L61)
 
 ___
 
@@ -259,7 +259,7 @@ ___
 
 #### Defined in
 
-[types.ts:130](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L130)
+[types.ts:143](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L143)
 
 ___
 
@@ -275,7 +275,7 @@ ___
 
 #### Defined in
 
-[types.ts:293](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L293)
+[types.ts:306](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/types.ts#L306)
 
 ## Variables
 

--- a/docs/api-server/modules.md
+++ b/docs/api-server/modules.md
@@ -125,12 +125,14 @@ ___
 | Name | Type |
 | :------ | :------ |
 | `router?` | [`CeroRouter`](interfaces/CeroRouter.md) |
-| `server?` | `Server` |
+| `server?` | `HttpsServer` \| `HttpServer` |
+| `sslCertPath?` | `string` |
+| `sslKeyPath?` | `string` |
 | `verbose?` | `boolean` |
 
 #### Defined in
 
-[packages/api-server/src/index.ts:11](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-server/src/index.ts#L11)
+[packages/api-server/src/index.ts:12](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-server/src/index.ts#L12)
 
 ## Functions
 
@@ -182,7 +184,7 @@ ___
 
 #### Defined in
 
-[packages/api-server/src/index.ts:66](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-server/src/index.ts#L66)
+[packages/api-server/src/index.ts:87](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-server/src/index.ts#L87)
 
 ___
 
@@ -196,7 +198,7 @@ ___
 
 #### Defined in
 
-[packages/api-server/src/index.ts:48](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-server/src/index.ts#L48)
+[packages/api-server/src/index.ts:69](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-server/src/index.ts#L69)
 
 ___
 

--- a/docs/host/classes/Host.md
+++ b/docs/host/classes/Host.md
@@ -233,7 +233,7 @@ Stops running servers.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:678](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L678)
+[packages/host/src/lib/host.ts:679](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L679)
 
 ___
 
@@ -267,7 +267,7 @@ List of instances.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:597](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L597)
+[packages/host/src/lib/host.ts:598](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L598)
 
 ___
 
@@ -291,7 +291,7 @@ Sequence info object.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:612](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L612)
+[packages/host/src/lib/host.ts:613](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L613)
 
 ___
 
@@ -315,7 +315,7 @@ List of instances.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:646](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L646)
+[packages/host/src/lib/host.ts:647](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L647)
 
 ___
 
@@ -333,7 +333,7 @@ List of sequences.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:631](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L631)
+[packages/host/src/lib/host.ts:632](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L632)
 
 ___
 
@@ -528,7 +528,7 @@ using its CSIController [CSIController](CSIController.md)
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:661](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L661)
+[packages/host/src/lib/host.ts:662](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L662)
 
 ## Constructors
 

--- a/docs/logger/classes/ObjLogger.md
+++ b/docs/logger/classes/ObjLogger.md
@@ -48,24 +48,24 @@
 | Name | Type | Default value | Description |
 | :------ | :------ | :------ | :------ |
 | `reference` | `any` | `undefined` | Used to obtain a name for the logger. |
-| `baseLog` | `DeepPartial`<{ `data?`: `any`[] ; `error`: `string` ; `from`: `string` ; `id`: `string` ; `level`: `LogLevel` ; `msg`: `string` ; `ts`: `number`  }\> | `{}` | Default log object. |
+| `baseLog` | `Partial`<{ `data`: `any`[] ; `error`: `string` ; `from`: `string` ; `id`: `string` ; `level`: `LogLevel` ; `msg`: `string` ; `ts`: `number`  }\> | `{}` | Default log object. |
 | `logLevel` | `LogLevel` | `"TRACE"` | Log level. |
 
 #### Defined in
 
-[obj-logger/src/obj-logger.ts:58](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L58)
+[obj-logger/src/obj-logger.ts:59](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L59)
 
 ## Properties
 
 ### baseLog
 
-• **baseLog**: `DeepPartial`<{ `data?`: `any`[] ; `error`: `string` ; `from`: `string` ; `id`: `string` ; `level`: `LogLevel` ; `msg`: `string` ; `ts`: `number`  }\>
+• **baseLog**: `Partial`<{ `data`: `any`[] ; `error`: `string` ; `from`: `string` ; `id`: `string` ; `level`: `LogLevel` ; `msg`: `string` ; `ts`: `number`  }\>
 
 Default log object.
 
 #### Defined in
 
-[obj-logger/src/obj-logger.ts:35](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L35)
+[obj-logger/src/obj-logger.ts:36](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L36)
 
 ___
 
@@ -81,7 +81,7 @@ IObjectLogger.inputLogStream
 
 #### Defined in
 
-[obj-logger/src/obj-logger.ts:15](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L15)
+[obj-logger/src/obj-logger.ts:16](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L16)
 
 ___
 
@@ -97,7 +97,7 @@ IObjectLogger.inputStringifiedLogStream
 
 #### Defined in
 
-[obj-logger/src/obj-logger.ts:20](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L20)
+[obj-logger/src/obj-logger.ts:21](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L21)
 
 ___
 
@@ -109,7 +109,7 @@ Log level.
 
 #### Defined in
 
-[obj-logger/src/obj-logger.ts:40](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L40)
+[obj-logger/src/obj-logger.ts:41](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L41)
 
 ___
 
@@ -121,7 +121,7 @@ Name used to indicate the source of the log.
 
 #### Defined in
 
-[obj-logger/src/obj-logger.ts:30](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L30)
+[obj-logger/src/obj-logger.ts:31](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L31)
 
 ___
 
@@ -137,7 +137,7 @@ IObjectLogger.output
 
 #### Defined in
 
-[obj-logger/src/obj-logger.ts:25](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L25)
+[obj-logger/src/obj-logger.ts:26](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L26)
 
 ___
 
@@ -151,7 +151,7 @@ IObjectLogger.outputLogStream
 
 #### Defined in
 
-[obj-logger/src/obj-logger.ts:10](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L10)
+[obj-logger/src/obj-logger.ts:11](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L11)
 
 ___
 
@@ -163,7 +163,7 @@ Additional output streams.
 
 #### Defined in
 
-[obj-logger/src/obj-logger.ts:45](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L45)
+[obj-logger/src/obj-logger.ts:46](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L46)
 
 ___
 
@@ -175,7 +175,7 @@ Logging levels chierarchy.
 
 #### Defined in
 
-[obj-logger/src/obj-logger.ts:50](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L50)
+[obj-logger/src/obj-logger.ts:51](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L51)
 
 ## Methods
 
@@ -199,7 +199,7 @@ IObjectLogger.addOutput
 
 #### Defined in
 
-[obj-logger/src/obj-logger.ts:117](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L117)
+[obj-logger/src/obj-logger.ts:121](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L121)
 
 ___
 
@@ -211,7 +211,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `entry` | `string` \| `DeepPartial`<{ `data?`: `any`[] ; `error`: `string` ; `from`: `string` ; `id`: `string` ; `level`: `LogLevel` ; `msg`: `string` ; `ts`: `number`  }\> |
+| `entry` | `string` \| `Partial`<{ `data`: `any`[] ; `error`: `string` ; `from`: `string` ; `id`: `string` ; `level`: `LogLevel` ; `msg`: `string` ; `ts`: `number`  }\> |
 | `...optionalParams` | `any`[] |
 
 #### Returns
@@ -224,7 +224,7 @@ IObjectLogger.debug
 
 #### Defined in
 
-[obj-logger/src/obj-logger.ts:133](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L133)
+[obj-logger/src/obj-logger.ts:137](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L137)
 
 ___
 
@@ -236,7 +236,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `entry` | `string` \| `DeepPartial`<{ `data?`: `any`[] ; `error`: `string` ; `from`: `string` ; `id`: `string` ; `level`: `LogLevel` ; `msg`: `string` ; `ts`: `number`  }\> |
+| `entry` | `string` \| `Partial`<{ `data`: `any`[] ; `error`: `string` ; `from`: `string` ; `id`: `string` ; `level`: `LogLevel` ; `msg`: `string` ; `ts`: `number`  }\> |
 | `...optionalParams` | `any`[] |
 
 #### Returns
@@ -249,7 +249,7 @@ IObjectLogger.error
 
 #### Defined in
 
-[obj-logger/src/obj-logger.ts:129](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L129)
+[obj-logger/src/obj-logger.ts:133](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L133)
 
 ___
 
@@ -261,7 +261,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `entry` | `string` \| `DeepPartial`<{ `data?`: `any`[] ; `error`: `string` ; `from`: `string` ; `id`: `string` ; `level`: `LogLevel` ; `msg`: `string` ; `ts`: `number`  }\> |
+| `entry` | `string` \| `Partial`<{ `data`: `any`[] ; `error`: `string` ; `from`: `string` ; `id`: `string` ; `level`: `LogLevel` ; `msg`: `string` ; `ts`: `number`  }\> |
 | `...optionalParams` | `any`[] |
 
 #### Returns
@@ -274,7 +274,7 @@ IObjectLogger.fatal
 
 #### Defined in
 
-[obj-logger/src/obj-logger.ts:137](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L137)
+[obj-logger/src/obj-logger.ts:141](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L141)
 
 ___
 
@@ -286,7 +286,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `entry` | `string` \| `DeepPartial`<{ `data?`: `any`[] ; `error`: `string` ; `from`: `string` ; `id`: `string` ; `level`: `LogLevel` ; `msg`: `string` ; `ts`: `number`  }\> |
+| `entry` | `string` \| `Partial`<{ `data`: `any`[] ; `error`: `string` ; `from`: `string` ; `id`: `string` ; `level`: `LogLevel` ; `msg`: `string` ; `ts`: `number`  }\> |
 | `...optionalParams` | `any`[] |
 
 #### Returns
@@ -299,7 +299,7 @@ IObjectLogger.info
 
 #### Defined in
 
-[obj-logger/src/obj-logger.ts:125](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L125)
+[obj-logger/src/obj-logger.ts:129](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L129)
 
 ___
 
@@ -307,7 +307,8 @@ ___
 
 ▸ **pipe**(`target`, `options?`): `Writable`
 
-Pipes output logger to provided target. The target can be a writable stream or an ObjectLogger instance.
+Pipes output logger to provided target. The target can be a writable stream
+or an instance of class fulfiling IObjectLogger interface.
 
 #### Parameters
 
@@ -329,7 +330,7 @@ IObjectLogger.pipe
 
 #### Defined in
 
-[obj-logger/src/obj-logger.ts:156](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L156)
+[obj-logger/src/obj-logger.ts:161](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L161)
 
 ___
 
@@ -341,7 +342,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `entry` | `string` \| `DeepPartial`<{ `data?`: `any`[] ; `error`: `string` ; `from`: `string` ; `id`: `string` ; `level`: `LogLevel` ; `msg`: `string` ; `ts`: `number`  }\> |
+| `entry` | `string` \| `Partial`<{ `data`: `any`[] ; `error`: `string` ; `from`: `string` ; `id`: `string` ; `level`: `LogLevel` ; `msg`: `string` ; `ts`: `number`  }\> |
 | `...optionalParams` | `any`[] |
 
 #### Returns
@@ -354,7 +355,7 @@ IObjectLogger.trace
 
 #### Defined in
 
-[obj-logger/src/obj-logger.ts:121](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L121)
+[obj-logger/src/obj-logger.ts:125](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L125)
 
 ___
 
@@ -366,7 +367,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `baseLog` | `DeepPartial`<{ `data?`: `any`[] ; `error`: `string` ; `from`: `string` ; `id`: `string` ; `level`: `LogLevel` ; `msg`: `string` ; `ts`: `number`  }\> |
+| `baseLog` | `Partial`<{ `data`: `any`[] ; `error`: `string` ; `from`: `string` ; `id`: `string` ; `level`: `LogLevel` ; `msg`: `string` ; `ts`: `number`  }\> |
 
 #### Returns
 
@@ -374,7 +375,7 @@ ___
 
 #### Defined in
 
-[obj-logger/src/obj-logger.ts:145](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L145)
+[obj-logger/src/obj-logger.ts:149](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L149)
 
 ___
 
@@ -386,7 +387,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `entry` | `string` \| `DeepPartial`<{ `data?`: `any`[] ; `error`: `string` ; `from`: `string` ; `id`: `string` ; `level`: `LogLevel` ; `msg`: `string` ; `ts`: `number`  }\> |
+| `entry` | `string` \| `Partial`<{ `data`: `any`[] ; `error`: `string` ; `from`: `string` ; `id`: `string` ; `level`: `LogLevel` ; `msg`: `string` ; `ts`: `number`  }\> |
 | `...optionalParams` | `any`[] |
 
 #### Returns
@@ -399,7 +400,7 @@ IObjectLogger.warn
 
 #### Defined in
 
-[obj-logger/src/obj-logger.ts:141](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L141)
+[obj-logger/src/obj-logger.ts:145](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L145)
 
 ___
 
@@ -412,7 +413,7 @@ ___
 | Name | Type |
 | :------ | :------ |
 | `level` | `LogLevel` |
-| `entry` | `string` \| `DeepPartial`<{ `data?`: `any`[] ; `error`: `string` ; `from`: `string` ; `id`: `string` ; `level`: `LogLevel` ; `msg`: `string` ; `ts`: `number`  }\> |
+| `entry` | `string` \| `Partial`<{ `data`: `any`[] ; `error`: `string` ; `from`: `string` ; `id`: `string` ; `level`: `LogLevel` ; `msg`: `string` ; `ts`: `number`  }\> |
 | `...optionalParams` | `any`[] |
 
 #### Returns
@@ -425,4 +426,4 @@ IObjectLogger.write
 
 #### Defined in
 
-[obj-logger/src/obj-logger.ts:85](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L85)
+[obj-logger/src/obj-logger.ts:89](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/obj-logger/src/obj-logger.ts#L89)

--- a/docs/model/classes/communicationhandler.md
+++ b/docs/model/classes/communicationhandler.md
@@ -14,6 +14,7 @@
 - [controlHandlerHash](communicationhandler.md#controlhandlerhash)
 - [controlPassThrough](communicationhandler.md#controlpassthrough)
 - [downstreams](communicationhandler.md#downstreams)
+- [logger](communicationhandler.md#logger)
 - [loggerPassThrough](communicationhandler.md#loggerpassthrough)
 - [monitoringHandlerHash](communicationhandler.md#monitoringhandlerhash)
 - [monitoringPassThrough](communicationhandler.md#monitoringpassthrough)
@@ -48,7 +49,7 @@
 
 #### Defined in
 
-[packages/model/src/stream-handler.ts:65](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L65)
+[packages/model/src/stream-handler.ts:69](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L69)
 
 ___
 
@@ -58,7 +59,7 @@ ___
 
 #### Defined in
 
-[packages/model/src/stream-handler.ts:71](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L71)
+[packages/model/src/stream-handler.ts:75](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L75)
 
 ___
 
@@ -68,7 +69,7 @@ ___
 
 #### Defined in
 
-[packages/model/src/stream-handler.ts:62](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L62)
+[packages/model/src/stream-handler.ts:66](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L66)
 
 ___
 
@@ -78,7 +79,21 @@ ___
 
 #### Defined in
 
-[packages/model/src/stream-handler.ts:59](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L59)
+[packages/model/src/stream-handler.ts:63](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L63)
+
+___
+
+### logger
+
+• **logger**: `IObjectLogger`
+
+#### Implementation of
+
+ICommunicationHandler.logger
+
+#### Defined in
+
+[packages/model/src/stream-handler.ts:60](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L60)
 
 ___
 
@@ -88,7 +103,7 @@ ___
 
 #### Defined in
 
-[packages/model/src/stream-handler.ts:61](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L61)
+[packages/model/src/stream-handler.ts:65](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L65)
 
 ___
 
@@ -98,7 +113,7 @@ ___
 
 #### Defined in
 
-[packages/model/src/stream-handler.ts:70](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L70)
+[packages/model/src/stream-handler.ts:74](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L74)
 
 ___
 
@@ -108,7 +123,7 @@ ___
 
 #### Defined in
 
-[packages/model/src/stream-handler.ts:63](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L63)
+[packages/model/src/stream-handler.ts:67](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L67)
 
 ___
 
@@ -118,7 +133,7 @@ ___
 
 #### Defined in
 
-[packages/model/src/stream-handler.ts:58](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L58)
+[packages/model/src/stream-handler.ts:62](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L62)
 
 ## Methods
 
@@ -150,7 +165,7 @@ ICommunicationHandler.addControlHandler
 
 #### Defined in
 
-[packages/model/src/stream-handler.ts:250](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L250)
+[packages/model/src/stream-handler.ts:278](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L278)
 
 ___
 
@@ -182,7 +197,7 @@ ICommunicationHandler.addMonitoringHandler
 
 #### Defined in
 
-[packages/model/src/stream-handler.ts:238](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L238)
+[packages/model/src/stream-handler.ts:265](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L265)
 
 ___
 
@@ -196,7 +211,7 @@ ___
 
 #### Defined in
 
-[packages/model/src/stream-handler.ts:197](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L197)
+[packages/model/src/stream-handler.ts:222](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L222)
 
 ___
 
@@ -214,7 +229,7 @@ ICommunicationHandler.getLogOutput
 
 #### Defined in
 
-[packages/model/src/stream-handler.ts:201](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L201)
+[packages/model/src/stream-handler.ts:226](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L226)
 
 ___
 
@@ -232,7 +247,7 @@ ICommunicationHandler.getMonitorStream
 
 #### Defined in
 
-[packages/model/src/stream-handler.ts:110](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L110)
+[packages/model/src/stream-handler.ts:117](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L117)
 
 ___
 
@@ -256,7 +271,7 @@ ICommunicationHandler.getStdio
 
 #### Defined in
 
-[packages/model/src/stream-handler.ts:114](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L114)
+[packages/model/src/stream-handler.ts:121](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L121)
 
 ___
 
@@ -280,7 +295,7 @@ ICommunicationHandler.hookDownstreamStreams
 
 #### Defined in
 
-[packages/model/src/stream-handler.ts:131](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L131)
+[packages/model/src/stream-handler.ts:139](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L139)
 
 ___
 
@@ -304,7 +319,7 @@ ICommunicationHandler.hookUpstreamStreams
 
 #### Defined in
 
-[packages/model/src/stream-handler.ts:126](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L126)
+[packages/model/src/stream-handler.ts:134](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L134)
 
 ___
 
@@ -322,7 +337,7 @@ ICommunicationHandler.pipeDataStreams
 
 #### Defined in
 
-[packages/model/src/stream-handler.ts:217](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L217)
+[packages/model/src/stream-handler.ts:243](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L243)
 
 ___
 
@@ -340,7 +355,7 @@ ICommunicationHandler.pipeMessageStreams
 
 #### Defined in
 
-[packages/model/src/stream-handler.ts:136](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L136)
+[packages/model/src/stream-handler.ts:144](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L144)
 
 ___
 
@@ -358,7 +373,7 @@ ICommunicationHandler.pipeStdio
 
 #### Defined in
 
-[packages/model/src/stream-handler.ts:205](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L205)
+[packages/model/src/stream-handler.ts:230](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L230)
 
 ___
 
@@ -378,7 +393,7 @@ ___
 
 #### Defined in
 
-[packages/model/src/stream-handler.ts:103](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L103)
+[packages/model/src/stream-handler.ts:111](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L111)
 
 ___
 
@@ -409,7 +424,7 @@ ICommunicationHandler.sendControlMessage
 
 #### Defined in
 
-[packages/model/src/stream-handler.ts:268](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L268)
+[packages/model/src/stream-handler.ts:297](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L297)
 
 ___
 
@@ -440,7 +455,7 @@ ICommunicationHandler.sendMonitoringMessage
 
 #### Defined in
 
-[packages/model/src/stream-handler.ts:262](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L262)
+[packages/model/src/stream-handler.ts:291](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L291)
 
 ## Constructors
 
@@ -450,4 +465,4 @@ ICommunicationHandler.sendMonitoringMessage
 
 #### Defined in
 
-[packages/model/src/stream-handler.ts:71](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L71)
+[packages/model/src/stream-handler.ts:75](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L75)

--- a/docs/model/modules.md
+++ b/docs/model/modules.md
@@ -48,7 +48,7 @@
 
 #### Defined in
 
-[packages/model/src/stream-handler.ts:23](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L23)
+[packages/model/src/stream-handler.ts:25](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/model/src/stream-handler.ts#L25)
 
 ___
 

--- a/docs/types/interfaces/icommunicationhandler.md
+++ b/docs/types/interfaces/icommunicationhandler.md
@@ -19,6 +19,10 @@
 - [sendControlMessage](icommunicationhandler.md#sendcontrolmessage)
 - [sendMonitoringMessage](icommunicationhandler.md#sendmonitoringmessage)
 
+### Properties
+
+- [logger](icommunicationhandler.md#logger)
+
 ## Methods
 
 ### addControlHandler
@@ -44,7 +48,7 @@
 
 #### Defined in
 
-[packages/types/src/communication-handler.ts:29](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L29)
+[packages/types/src/communication-handler.ts:31](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L31)
 
 ___
 
@@ -72,7 +76,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/communication-handler.ts:22](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L22)
+[packages/types/src/communication-handler.ts:24](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L24)
 
 ▸ **addMonitoringHandler**<`T`\>(`code`, `handler`, `blocking`): [`ICommunicationHandler`](icommunicationhandler.md)
 
@@ -96,7 +100,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/communication-handler.ts:24](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L24)
+[packages/types/src/communication-handler.ts:26](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L26)
 
 ▸ **addMonitoringHandler**<`T`\>(`code`, `handler`): [`ICommunicationHandler`](icommunicationhandler.md)
 
@@ -119,7 +123,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/communication-handler.ts:26](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L26)
+[packages/types/src/communication-handler.ts:28](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L28)
 
 ___
 
@@ -135,7 +139,7 @@ Returns log stream for writing
 
 #### Defined in
 
-[packages/types/src/communication-handler.ts:45](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L45)
+[packages/types/src/communication-handler.ts:47](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L47)
 
 ___
 
@@ -151,7 +155,7 @@ Returns a copy of monitor stream for reading - does not interact with the fifo s
 
 #### Defined in
 
-[packages/types/src/communication-handler.ts:41](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L41)
+[packages/types/src/communication-handler.ts:43](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L43)
 
 ___
 
@@ -173,7 +177,7 @@ Gets stdio streams for full interaction
 
 #### Defined in
 
-[packages/types/src/communication-handler.ts:50](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L50)
+[packages/types/src/communication-handler.ts:52](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L52)
 
 ___
 
@@ -193,7 +197,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/communication-handler.ts:20](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L20)
+[packages/types/src/communication-handler.ts:22](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L22)
 
 ___
 
@@ -213,7 +217,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/communication-handler.ts:19](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L19)
+[packages/types/src/communication-handler.ts:21](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L21)
 
 ___
 
@@ -227,7 +231,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/communication-handler.ts:33](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L33)
+[packages/types/src/communication-handler.ts:35](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L35)
 
 ___
 
@@ -241,7 +245,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/communication-handler.ts:31](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L31)
+[packages/types/src/communication-handler.ts:33](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L33)
 
 ___
 
@@ -255,7 +259,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/communication-handler.ts:32](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L32)
+[packages/types/src/communication-handler.ts:34](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L34)
 
 ___
 
@@ -282,7 +286,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/communication-handler.ts:36](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L36)
+[packages/types/src/communication-handler.ts:38](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L38)
 
 ___
 
@@ -309,4 +313,14 @@ ___
 
 #### Defined in
 
-[packages/types/src/communication-handler.ts:35](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L35)
+[packages/types/src/communication-handler.ts:37](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L37)
+
+## Properties
+
+### logger
+
+• **logger**: [`IObjectLogger`](iobjectlogger.md)
+
+#### Defined in
+
+[packages/types/src/communication-handler.ts:19](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L19)

--- a/docs/types/interfaces/iobjectlogger.md
+++ b/docs/types/interfaces/iobjectlogger.md
@@ -41,7 +41,7 @@
 
 #### Defined in
 
-[packages/types/src/object-logger.ts:26](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L26)
+[packages/types/src/object-logger.ts:54](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L54)
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `entry` | `string` \| [`DeepPartial`](../modules.md#deeppartial)<`Object`\> |
+| `entry` | `string` \| `Partial`<`Object`\> |
 | `...optionalParams` | `any`[] |
 
 #### Returns
@@ -62,7 +62,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/object-logger.ts:29](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L29)
+[packages/types/src/object-logger.ts:57](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L57)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `entry` | `string` \| [`DeepPartial`](../modules.md#deeppartial)<`Object`\> |
+| `entry` | `string` \| `Partial`<`Object`\> |
 | `...optionalParams` | `any`[] |
 
 #### Returns
@@ -83,7 +83,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/object-logger.ts:30](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L30)
+[packages/types/src/object-logger.ts:58](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L58)
 
 ___
 
@@ -95,7 +95,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `entry` | `string` \| [`DeepPartial`](../modules.md#deeppartial)<`Object`\> |
+| `entry` | `string` \| `Partial`<`Object`\> |
 | `...optionalParams` | `any`[] |
 
 #### Returns
@@ -104,7 +104,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/object-logger.ts:31](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L31)
+[packages/types/src/object-logger.ts:59](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L59)
 
 ___
 
@@ -116,7 +116,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `entry` | `string` \| [`DeepPartial`](../modules.md#deeppartial)<`Object`\> |
+| `entry` | `string` \| `Partial`<`Object`\> |
 | `...optionalParams` | `any`[] |
 
 #### Returns
@@ -125,7 +125,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/object-logger.ts:32](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L32)
+[packages/types/src/object-logger.ts:60](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L60)
 
 ___
 
@@ -147,7 +147,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/object-logger.ts:35](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L35)
+[packages/types/src/object-logger.ts:63](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L63)
 
 ___
 
@@ -159,7 +159,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `entry` | `string` \| [`DeepPartial`](../modules.md#deeppartial)<`Object`\> |
+| `entry` | `string` \| `Partial`<`Object`\> |
 | `...optionalParams` | `any`[] |
 
 #### Returns
@@ -168,7 +168,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/object-logger.ts:33](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L33)
+[packages/types/src/object-logger.ts:61](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L61)
 
 ___
 
@@ -180,7 +180,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `entry` | `string` \| [`DeepPartial`](../modules.md#deeppartial)<`Object`\> |
+| `entry` | `string` \| `Partial`<`Object`\> |
 | `...optionalParams` | `any`[] |
 
 #### Returns
@@ -189,7 +189,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/object-logger.ts:34](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L34)
+[packages/types/src/object-logger.ts:62](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L62)
 
 ___
 
@@ -201,8 +201,8 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `level` | `undefined` \| [`DeepPartial`](../modules.md#deeppartial)<[`LogLevel`](../modules.md#loglevel)\> |
-| `entry` | `string` \| [`DeepPartial`](../modules.md#deeppartial)<`Object`\> |
+| `level` | `undefined` \| [`LogLevel`](../modules.md#loglevel) |
+| `entry` | `string` \| `Partial`<`Object`\> |
 | `...optionalParams` | `any`[] |
 
 #### Returns
@@ -211,7 +211,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/object-logger.ts:28](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L28)
+[packages/types/src/object-logger.ts:56](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L56)
 
 ## Properties
 
@@ -221,7 +221,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/object-logger.ts:21](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L21)
+[packages/types/src/object-logger.ts:49](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L49)
 
 ___
 
@@ -231,7 +231,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/object-logger.ts:22](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L22)
+[packages/types/src/object-logger.ts:50](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L50)
 
 ___
 
@@ -241,7 +241,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/object-logger.ts:24](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L24)
+[packages/types/src/object-logger.ts:52](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L52)
 
 ___
 
@@ -251,4 +251,4 @@ ___
 
 #### Defined in
 
-[packages/types/src/object-logger.ts:23](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L23)
+[packages/types/src/object-logger.ts:51](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/object-logger.ts#L51)

--- a/docs/types/modules.md
+++ b/docs/types/modules.md
@@ -493,7 +493,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/communication-handler.ts:14](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L14)
+[packages/types/src/communication-handler.ts:15](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L15)
 
 ___
 
@@ -589,11 +589,11 @@ ___
 
 ### DockerSequenceConfig
 
-Ƭ **DockerSequenceConfig**: `CommonSequenceConfig` & { `config?`: { `ports?`: [`PortConfig`](modules.md#portconfig)[] \| ``null``  } ; `container`: [`RunnerContainerConfiguration`](modules.md#runnercontainerconfiguration) ; `engines`: `Record`<`string`, `string`\> ; `type`: ``"docker"``  }
+Ƭ **DockerSequenceConfig**: `CommonSequenceConfig` & { `config?`: { `ports?`: [`PortConfig`](modules.md#portconfig)[] \| ``null``  } ; `container`: [`RunnerContainerConfiguration`](modules.md#runnercontainerconfiguration) ; `type`: ``"docker"``  }
 
 #### Defined in
 
-[packages/types/src/runner-config.ts:17](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/runner-config.ts#L17)
+[packages/types/src/runner-config.ts:18](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/runner-config.ts#L18)
 
 ___
 
@@ -1257,7 +1257,7 @@ ___
 
 ### LogEntry
 
-Ƭ **LogEntry**: [`DeepPartial`](modules.md#deeppartial)<`Object`\>
+Ƭ **LogEntry**: `Partial`<`Object`\>
 
 Single log entry.
 
@@ -1513,7 +1513,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/communication-handler.ts:10](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L10)
+[packages/types/src/communication-handler.ts:11](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L11)
 
 ___
 
@@ -1572,7 +1572,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/communication-handler.ts:12](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L12)
+[packages/types/src/communication-handler.ts:13](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/communication-handler.ts#L13)
 
 ___
 


### PR DESCRIPTION
Changelog changes for release 0.16.0:

Prominent:

- 2d193278 - Introduce HTTPS support in the API Server
- 38d69826 - The Docker Sequence and Instance Adapters specify the volume permissions
- e46e9d80 - Scramjet community moving to Discord documentation update

New features:

- **HTTPS Upgrade** - The API server can now be secured using HTTPS

Bugfixes and minor improvements:

- Improved chunk size handling for the input and controls streams in the Python Runner
- Smarter Python Runner selection based on the Sequence configuration
- Sequence configuration can now be provided to Python Sequence on startup
- Python Runner operates on the JSON logs (aligned with the new ObjLogger used in the Host)
- Better error handling in the ObjectLogger and the CommunicationHandler
- Added Docker Sequence and Instance Adapter volume permissions
- Python Runner implements the complete Host handshake (including the default topic messages)