### PR TITLE
Python-alice: don't show additional newline in stdout

### DIFF
--- a/python/reference-apps/python-alice/alice.py
+++ b/python/reference-apps/python-alice/alice.py
@@ -9,4 +9,4 @@ async def delayed_hello(person):
 def run(context, input):
     source = open('data.json')
     data = Stream.read_from(source, chunk_size=1024, max_parallel=1)
-    return data.flatmap(json.loads).map(delayed_hello).each(print)
+    return data.flatmap(json.loads).map(delayed_hello).each(lambda x: print(x.strip()))


### PR DESCRIPTION
This way there's exactly one newline (at the end of each Hello) in both
output stream and stdout.