### PR TITLE
Return error response on delete seq error

### DIFF
--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -365,7 +365,10 @@ export class Host implements IComponent {
         } catch (error: any) {
             this.logger.error("Error removing sequence!", error);
 
-            throw new HostError("CONTROLLER_ERROR");
+            return {
+                opStatus: ReasonPhrases.INTERNAL_SERVER_ERROR,
+                error: `Error removing sequence: ${error.message}`
+            };
         }
     }
 


### PR DESCRIPTION
I'm not 100% sure if that would be a valid change regarding how we would like to handle such errors but in the current state it results in crashing entire host process which I assume we would like to avoid:

> Error response is returned instead of rethrowing an error. The error is thrown in the top level layer (host) and there is nothing to catch it. This results in crashing entire host process.