### PR TITLE
Fix "output is <string>" cucumber step

### DIFF
--- a/bdd/step-definitions/e2e/host-steps.ts
+++ b/bdd/step-definitions/e2e/host-steps.ts
@@ -575,7 +575,7 @@ Then("output is {string}", async function(this: CustomWorld, str) {
 
     const outputString = await streamToString(output.data);
 
-    assert(outputString, str);
+    assert.equal(outputString, str);
 });
 
 Then("send data {string} named {string}", async (data: any, topic: string) => {


### PR DESCRIPTION
The assertion was not actually checking anything.