### PR TITLE
Python runner BDD tests

### DIFF
--- a/bdd/README.md
+++ b/bdd/README.md
@@ -85,6 +85,20 @@ In the situation like this above, when you want to execute tests with `@ci` tag 
 yarn test:bdd --tags="@ci" --tags="not @starts-host"
 ```
 
+### Python tests :snake:
+
+Python BDD tests are not enabled in CI yet. They are tagged `@python` and require compiling python sequences, which can be done with the following command:
+
+```bash
+for seq_name in `ls python/reference-apps/`; do si pack "python/reference-apps/$seq_name" -o "$seq_name.tar.gz"; done
+```
+
+Also, python runner does not support Docker yet, so run tests with
+
+```bash
+NO_DOCKER=1 SCRAMJET_SPAWN_TS=1 yarn test:bdd --tags=@python
+```
+
 ### Results :bar_chart:
 
 The results of the performed test will be displayed in the console as a summary of executed tests. There is also a report generated in `html` which illustrates the results in a very user friendly form. Html report is generated every time we run a BDD test, those html's are saved in `bdd/reports` folder.

--- a/bdd/README.md
+++ b/bdd/README.md
@@ -96,7 +96,7 @@ for seq_name in `ls python/reference-apps/`; do si pack "python/reference-apps/$
 Also, python runner does not support Docker yet, so run tests with
 
 ```bash
-NO_DOCKER=1 SCRAMJET_SPAWN_TS=1 yarn test:bdd --tags=@python
+NO_DOCKER=1 yarn test:bdd --tags=@python
 ```
 
 ### Results :bar_chart:

--- a/bdd/features/e2e/E2E-014-python.feature
+++ b/bdd/features/e2e/E2E-014-python.feature
@@ -75,3 +75,19 @@ Feature: Test our shiny new Python runner
         Then runner has ended execution
         And kept instance stream "stdout" should be "Cleaning up... Cleanup done.\n"
         And host is still running
+
+    @python
+    Scenario: E2E-014 TC-009 Instance by default reports as healthy
+        Given host is running
+        When sequence "../python-forever.tar.gz" loaded
+        And instance started
+        Then instance health is "true"
+        And host is still running
+
+    @python
+    Scenario: E2E-014 TC-010 User can override health check method
+        Given host is running
+        When sequence "../unhealthy-sequence.tar.gz" loaded
+        And instance started
+        Then instance health is "false"
+        And host is still running

--- a/bdd/features/e2e/E2E-014-python.feature
+++ b/bdd/features/e2e/E2E-014-python.feature
@@ -63,3 +63,15 @@ Feature: Test our shiny new Python runner
         And send file "../python/test/sample_unicode_1.txt" as binary input
         Then "output" is "20,"
         And host is still running
+
+    @python
+    Scenario: E2E-014 TC-008 Instance can run stop handler before it shuts down
+        Given host is running
+        When sequence "../python-stop-handler.tar.gz" loaded
+        And instance started
+        And get runner PID
+        And keep instance streams "stdout"
+        And send stop with timeout 2000
+        Then runner has ended execution
+        And kept instance stream "stdout" should be "Cleaning up... Cleanup done.\n"
+        And host is still running

--- a/bdd/features/e2e/E2E-014-python.feature
+++ b/bdd/features/e2e/E2E-014-python.feature
@@ -8,3 +8,12 @@ Feature: Test our shiny new Python runner
         And send "python runner" to input
         Then "output" is "Hello python runner!"
         And host is still running
+
+    @python
+    Scenario: E2E-014 TC-002 Python sequences can use stdin and stdout
+        Given host is running
+        When sequence "../python-stdinout.tar.gz" loaded
+        And instance started
+        And send "python runner" to stdin
+        Then "stdout" is "Got on stdin: python runner"
+        And host is still running

--- a/bdd/features/e2e/E2E-014-python.feature
+++ b/bdd/features/e2e/E2E-014-python.feature
@@ -17,3 +17,11 @@ Feature: Test our shiny new Python runner
         And send "python runner" to stdin
         Then "stdout" is "Got on stdin: python runner"
         And host is still running
+
+    @python
+    Scenario: E2E-014 TC-003 Exceptions thrown in python sequences appear in stderr
+        Given host is running
+        When sequence "../python-exception-test.tar.gz" loaded
+        And instance started
+        Then "stderr" contains "TestException: This exception should appear on stderr"
+        And host is still running

--- a/bdd/features/e2e/E2E-014-python.feature
+++ b/bdd/features/e2e/E2E-014-python.feature
@@ -94,11 +94,23 @@ Feature: Test our shiny new Python runner
 
     @python
     Scenario: E2E-014 TC-011 Send data between python instances using topics
-        When start host
-        And sequence "../python-topic-producer.tar.gz" loaded
+        Given host is running
+        When sequence "../python-topic-producer.tar.gz" loaded
         And instance started
         And send "topic test input" to input
         And sequence "../python-topic-consumer.tar.gz" loaded
         And instance started
         Then "output" is "consumer got: producer got: topic test input"
+        And host is still running
+
+    @python
+    Scenario: E2E-014 TC-012 Sequence can receive and emit events
+        Given host is running
+        When sequence "../python-events.tar.gz" loaded
+        And instance started
+        And send event "test-event" to instance with message "foo"
+        Then instance emits event "test-response" with body
+            """
+            {"eventName":"test-response","message":"reply to foo"}
+            """
         And host is still running

--- a/bdd/features/e2e/E2E-014-python.feature
+++ b/bdd/features/e2e/E2E-014-python.feature
@@ -25,3 +25,11 @@ Feature: Test our shiny new Python runner
         And instance started
         Then "stderr" contains "TestException: This exception should appear on stderr"
         And host is still running
+
+    @python
+    Scenario: E2E-014 TC-004 Arguments can be passed to Python sequences
+        Given host is running
+        When sequence "../python-debug-args.tar.gz" loaded
+        And instance started with arguments "foo 3 4 bar"
+        Then "output" is "{'named_arg': 'foo', 'wildcard_args': ('3', '4', 'bar')}"
+        And host is still running

--- a/bdd/features/e2e/E2E-014-python.feature
+++ b/bdd/features/e2e/E2E-014-python.feature
@@ -91,3 +91,14 @@ Feature: Test our shiny new Python runner
         And instance started
         Then instance health is "false"
         And host is still running
+
+    @python
+    Scenario: E2E-014 TC-011 Send data between python instances using topics
+        When start host
+        And sequence "../python-topic-producer.tar.gz" loaded
+        And instance started
+        And send "topic test input" to input
+        And sequence "../python-topic-consumer.tar.gz" loaded
+        And instance started
+        Then "output" is "consumer got: producer got: topic test input"
+        And host is still running

--- a/bdd/features/e2e/E2E-014-python.feature
+++ b/bdd/features/e2e/E2E-014-python.feature
@@ -33,3 +33,13 @@ Feature: Test our shiny new Python runner
         And instance started with arguments "foo 3 4 bar"
         Then "output" is "{'named_arg': 'foo', 'wildcard_args': ('3', '4', 'bar')}"
         And host is still running
+
+    @python
+    Scenario: E2E-014 TC-005 Python sequences can be killed
+        Given host is running
+        When sequence "../python-forever.tar.gz" loaded
+        And instance started
+        And get runner PID
+        And send kill message to instance
+        Then runner has ended execution
+        And host is still running

--- a/bdd/features/e2e/E2E-014-python.feature
+++ b/bdd/features/e2e/E2E-014-python.feature
@@ -92,6 +92,7 @@ Feature: Test our shiny new Python runner
         Then instance health is "false"
         And host is still running
 
+    @ignore
     @python
     Scenario: E2E-014 TC-011 Send data between python instances using topics
         Given host is running
@@ -103,6 +104,7 @@ Feature: Test our shiny new Python runner
         Then "output" is "consumer got: producer got: topic test input"
         And host is still running
 
+    @ignore
     @python
     Scenario: E2E-014 TC-012 Sequence can receive and emit events
         Given host is running

--- a/bdd/features/e2e/E2E-014-python.feature
+++ b/bdd/features/e2e/E2E-014-python.feature
@@ -43,3 +43,23 @@ Feature: Test our shiny new Python runner
         And send kill message to instance
         Then runner has ended execution
         And host is still running
+
+    @python
+    Scenario: E2E-014 TC-006 Text input is decoded and split into lines
+        Input contains multibyte chars which should be counted as 1 letter each.
+        Given host is running
+        When sequence "../chunk-lengths.tar.gz" loaded
+        And instance started
+        And send file "../python/test/sample_unicode_1.txt" as text input
+        Then "output" is "4,8,5,"
+        And host is still running
+
+    @python
+    Scenario: E2E-014 TC-007 Binary input is not decoded and not split into lines
+        Input contains multibyte chars; each byte should be counted separately.
+        Given host is running
+        When sequence "../chunk-lengths.tar.gz" loaded
+        And instance started
+        And send file "../python/test/sample_unicode_1.txt" as binary input
+        Then "output" is "20,"
+        And host is still running

--- a/bdd/features/e2e/E2E-014-python.feature
+++ b/bdd/features/e2e/E2E-014-python.feature
@@ -1,0 +1,10 @@
+Feature: Test our shiny new Python runner
+
+    @python
+    Scenario: E2E-014 TC-001 Run simple python sequence with input and output
+        Given host is running
+        When sequence "../python-hello.tar.gz" loaded
+        And instance started
+        And send "python runner" to input
+        Then "output" is "Hello python runner!"
+        And host is still running

--- a/bdd/step-definitions/e2e/host-steps.ts
+++ b/bdd/step-definitions/e2e/host-steps.ts
@@ -645,6 +645,20 @@ When("instance health is {string}", async function(this: CustomWorld, health: st
     assert.equal(health, actual);
 });
 
+Then("instance emits event {string} with body", { timeout: 10000 },
+    async function(this:CustomWorld, event: string, body: string) {
+        const expectedHttpCode = 200;
+
+        const resp = await this.resources.instance?.getNextEvent(event);
+
+        assert.equal(resp?.status, expectedHttpCode);
+        console.log("getNextEvent response:", resp);
+
+        const actual = JSON.stringify(resp.data);
+
+        assert.equal(actual, body);
+    });
+
 Then("send data {string} named {string}", async (data: any, topic: string) => {
     const ps = new Readable();
     const sendDataP = hostClient.sendNamedData(

--- a/bdd/step-definitions/e2e/host-steps.ts
+++ b/bdd/step-definitions/e2e/host-steps.ts
@@ -577,6 +577,17 @@ When("send {string} to input", async function(this: CustomWorld, str) {
     console.log(status);
 });
 
+When("send {string} to stdin", async function(this: CustomWorld, str) {
+    const pipe = new Readable();
+
+    pipe.push(str);
+    pipe.push(null);
+
+    const status = await this.resources.instance?.sendStream("stdin", pipe);
+
+    console.log(status);
+});
+
 Then("{string} is {string}", async function(this: CustomWorld, stream, text) {
     const result = await this.resources.instance?.getStream(stream);
 

--- a/bdd/step-definitions/e2e/host-steps.ts
+++ b/bdd/step-definitions/e2e/host-steps.ts
@@ -577,6 +577,22 @@ When("send {string} to input", async function(this: CustomWorld, str) {
     console.log(status);
 });
 
+When("send file {string} as text input", async function(this: CustomWorld, path) {
+    const status = await this.resources.instance?.sendStream(
+        "input", createReadStream(path), { type: "text/plain", end: true }
+    );
+
+    console.log(status);
+});
+
+When("send file {string} as binary input", async function(this: CustomWorld, path) {
+    const status = await this.resources.instance?.sendStream(
+        "input", createReadStream(path), { type: "application/octet-stream", end: true }
+    );
+
+    console.log(status);
+});
+
 When("send {string} to stdin", async function(this: CustomWorld, str) {
     const pipe = new Readable();
 

--- a/bdd/step-definitions/e2e/host-steps.ts
+++ b/bdd/step-definitions/e2e/host-steps.ts
@@ -336,14 +336,14 @@ When("send kill message to instance", async function(this: CustomWorld) {
 
 When("get runner PID", { timeout: 31000 }, async function(this: CustomWorld) {
     if (process.env.NO_DOCKER) {
-        const res = actualResponse()?.data?.processId;
+        const res = (await this.resources.instance?.getHealth())?.data?.processId;
 
         if (!res) assert.fail();
 
         processId = res;
         console.log("Process is identified.", processId);
     } else {
-        const res = actualResponse()?.data?.containerId;
+        const res = (await this.resources.instance?.getHealth())?.data?.containerId;
 
         if (!res) assert.fail();
 

--- a/bdd/step-definitions/e2e/host-steps.ts
+++ b/bdd/step-definitions/e2e/host-steps.ts
@@ -568,6 +568,22 @@ When("send data", async function(this: CustomWorld) {
     console.log(status);
 });
 
+When("send {string} to input", async function(this: CustomWorld, str) {
+    const status = await this.resources.instance?.sendStream("input", str, {
+        type: "text/plain",
+        end: true
+    });
+
+    console.log(status);
+});
+
+Then("{string} is {string}", async function(this: CustomWorld, stream, text) {
+    const result = await this.resources.instance?.getStream(stream);
+
+    if (!result?.data) assert.fail(`No data in ${stream}!`);
+    assert.equal(text, await streamToString(result.data));
+});
+
 Then("output is {string}", async function(this: CustomWorld, str) {
     const output = await this.resources.instance?.getStream("output");
 

--- a/bdd/step-definitions/e2e/host-steps.ts
+++ b/bdd/step-definitions/e2e/host-steps.ts
@@ -638,6 +638,13 @@ Then("{string} contains {string}", async function(this: CustomWorld, stream, tex
     assert.equal(outputString.includes(text), true);
 });
 
+When("instance health is {string}", async function(this: CustomWorld, health: string) {
+    const resp = await this.resources.instance?.getHealth();
+    const actual = resp?.data?.healthy.toString();
+
+    assert.equal(health, actual);
+});
+
 Then("send data {string} named {string}", async (data: any, topic: string) => {
     const ps = new Readable();
     const sendDataP = hostClient.sendNamedData(

--- a/bdd/step-definitions/e2e/host-steps.ts
+++ b/bdd/step-definitions/e2e/host-steps.ts
@@ -605,6 +605,16 @@ Then("output is {string}", async function(this: CustomWorld, str) {
     assert(outputString, str);
 });
 
+Then("{string} contains {string}", async function(this: CustomWorld, stream, text) {
+    const output = await this.resources.instance?.getStream(stream);
+
+    if (!output?.data) assert.fail("No output!");
+
+    const outputString = await streamToString(output.data);
+
+    assert.equal(outputString.includes(text), true);
+});
+
 Then("send data {string} named {string}", async (data: any, topic: string) => {
     const ps = new Readable();
     const sendDataP = hostClient.sendNamedData(

--- a/bdd/step-definitions/e2e/host-steps.ts
+++ b/bdd/step-definitions/e2e/host-steps.ts
@@ -604,6 +604,13 @@ When("send {string} to stdin", async function(this: CustomWorld, str) {
     console.log(status);
 });
 
+When("send stop with timeout {int}", async function(this: CustomWorld, timeout: number) {
+    console.log(`Sent stop message with timeouts ${timeout}`);
+    const resp = await this.resources.instance?.stop(timeout, false);
+
+    assert.equal(resp?.status, 202);
+});
+
 Then("{string} is {string}", async function(this: CustomWorld, stream, text) {
     const result = await this.resources.instance?.getStream(stream);
 

--- a/packages/adapters/src/process-instance-adapter.ts
+++ b/packages/adapters/src/process-instance-adapter.ts
@@ -57,10 +57,11 @@ IComponent {
 
         if ("python3" in config.engines) {
             this.logger.trace(gotPython);
-            return [
-                "python3",
-                path.resolve(__dirname, "../../../python/runner/runner.py")
-            ];
+            const runnerPath = isTSNode
+                ? "../../../python/runner/runner.py"
+                : "../../python/runner/runner.py";
+
+            return ["python3", path.resolve(__dirname, runnerPath)];
         }
         return [
             isTSNode ? "ts-node" : process.execPath,

--- a/python/reference-apps/chunk-lengths/chunk-lengths.py
+++ b/python/reference-apps/chunk-lengths/chunk-lengths.py
@@ -1,0 +1,5 @@
+from scramjet.streams import Stream
+
+def run(context, input: Stream):
+    return input.map(len).each(print).map(lambda l: f"{l},")
+

--- a/python/reference-apps/chunk-lengths/package.json
+++ b/python/reference-apps/chunk-lengths/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@scramjet/chunk-lengths",
+  "version": "0.11.0-0",
+  "main": "./chunk-lengths.py",
+  "author": "Jan Warchoł <open-source@scramjet.org>",
+  "license": "GPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scramjetorg/transform-hub.git"
+  },
+  "engines": {
+    "python3": "3.5.0"
+  }
+}

--- a/python/reference-apps/chunk-lengths/scramjet
+++ b/python/reference-apps/chunk-lengths/scramjet
@@ -1,0 +1,1 @@
+../../scramjet-framework/scramjet/

--- a/python/reference-apps/python-debug-args/args.py
+++ b/python/reference-apps/python-debug-args/args.py
@@ -1,0 +1,5 @@
+from scramjet.streams import Stream
+
+def run(context, input, named_arg, *wildcard_args):
+    output = {'named_arg': named_arg, 'wildcard_args': wildcard_args}
+    return Stream.read_from(f"{output}")

--- a/python/reference-apps/python-debug-args/package.json
+++ b/python/reference-apps/python-debug-args/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@scramjet/debug-args",
+  "version": "0.11.0-0",
+  "main": "./args.py",
+  "author": "Jan Warchoł <open-source@scramjet.org>",
+  "license": "GPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scramjetorg/transform-hub.git"
+  },
+  "engines": {
+    "python3": "3.5.0"
+  }
+}

--- a/python/reference-apps/python-debug-args/scramjet
+++ b/python/reference-apps/python-debug-args/scramjet
@@ -1,0 +1,1 @@
+../../scramjet-framework/scramjet/

--- a/python/reference-apps/python-exception-test/exception.py
+++ b/python/reference-apps/python-exception-test/exception.py
@@ -1,0 +1,4 @@
+class TestException(Exception): pass
+
+def run(context, input):
+    raise TestException("This exception should appear on stderr")

--- a/python/reference-apps/python-exception-test/package.json
+++ b/python/reference-apps/python-exception-test/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@scramjet/exception-test",
+  "version": "0.11.0-0",
+  "main": "./exception.py",
+  "author": "Jan Warchoł <open-source@scramjet.org>",
+  "license": "GPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scramjetorg/transform-hub.git"
+  },
+  "engines": {
+    "python3": "3.5.0"
+  }
+}

--- a/python/reference-apps/python-forever/forever.py
+++ b/python/reference-apps/python-forever/forever.py
@@ -1,0 +1,4 @@
+import asyncio
+
+async def run(context, input):
+    await asyncio.sleep(10**9)

--- a/python/reference-apps/python-forever/package.json
+++ b/python/reference-apps/python-forever/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@scramjet/forever-test",
+  "version": "0.11.0-0",
+  "main": "./forever.py",
+  "author": "Jan Warchoł <open-source@scramjet.org>",
+  "license": "GPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scramjetorg/transform-hub.git"
+  },
+  "engines": {
+    "python3": "3.5.0"
+  }
+}

--- a/python/reference-apps/python-hello/hello.py
+++ b/python/reference-apps/python-hello/hello.py
@@ -1,0 +1,4 @@
+from scramjet.streams import Stream
+
+def run(context, input):
+    return Stream.read_from(input).map(lambda s: f"Hello {s}!")

--- a/python/reference-apps/python-hello/package.json
+++ b/python/reference-apps/python-hello/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@scramjet/hello-python",
+  "version": "0.11.0-0",
+  "lang": "python",
+  "main": "./hello.py",
+  "author": "Jan Warchoł <open-source@scramjet.org>",
+  "license": "GPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scramjetorg/transform-hub.git"
+  },
+  "engines": {
+    "python3": "3.5.0"
+  }
+}

--- a/python/reference-apps/python-hello/scramjet
+++ b/python/reference-apps/python-hello/scramjet
@@ -1,0 +1,1 @@
+../../scramjet-framework/scramjet/

--- a/python/reference-apps/python-stdinout/package.json
+++ b/python/reference-apps/python-stdinout/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@scramjet/hello-python",
+  "version": "0.11.0-0",
+  "lang": "python",
+  "main": "./stdinout.py",
+  "author": "Jan Warchoł <open-source@scramjet.org>",
+  "license": "GPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scramjetorg/transform-hub.git"
+  },
+  "engines": {
+    "python3": "3.5.0"
+  }
+}

--- a/python/reference-apps/python-stdinout/scramjet
+++ b/python/reference-apps/python-stdinout/scramjet
@@ -1,0 +1,1 @@
+../../scramjet-framework/scramjet/

--- a/python/reference-apps/python-stdinout/stdinout.py
+++ b/python/reference-apps/python-stdinout/stdinout.py
@@ -1,0 +1,10 @@
+import sys
+from scramjet.streams import Stream
+
+async def run(context, input):
+    await (
+        Stream
+            .read_from(sys.stdin)
+            .map(lambda s: f"Got on stdin: {s}")
+            .write_to(sys.stdout)
+    )

--- a/python/reference-apps/python-stop-handler/package.json
+++ b/python/reference-apps/python-stop-handler/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@scramjet/stop-handler",
+  "version": "0.11.0-0",
+  "main": "./stop-handler.py",
+  "author": "Jan Warchoł <open-source@scramjet.org>",
+  "license": "GPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scramjetorg/transform-hub.git"
+  },
+  "engines": {
+    "python3": "3.5.0"
+  }
+}

--- a/python/reference-apps/python-stop-handler/stop-handler.py
+++ b/python/reference-apps/python-stop-handler/stop-handler.py
@@ -1,0 +1,10 @@
+import asyncio
+
+async def stop_handler():
+    print("Cleaning up...", end=' ')
+    await asyncio.sleep(1)
+    print("Cleanup done.")
+
+async def run(context, input):
+    context.set_stop_handler(stop_handler)
+    await asyncio.sleep(10**9)

--- a/python/reference-apps/unhealthy-sequence/package.json
+++ b/python/reference-apps/unhealthy-sequence/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "@scramjet/unhealthy-sequence-py",
+    "version": "0.11.0-0",
+    "main": "./unhealthy.py",
+    "author": "Michał Piotrowski <open-source@scramjet.org>",
+    "license": "GPL-3.0",
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/scramjetorg/transform-hub.git"
+    },
+    "engines": {
+      "python3": "3.7.0"
+    }
+}

--- a/python/reference-apps/unhealthy-sequence/unhealthy.py
+++ b/python/reference-apps/unhealthy-sequence/unhealthy.py
@@ -1,0 +1,5 @@
+import asyncio
+
+async def run(context, input):
+    context.set_health_check(lambda: {'healthy': False})
+    await asyncio.sleep(1000)

--- a/python/runner/runner.py
+++ b/python/runner/runner.py
@@ -81,6 +81,7 @@ class Runner:
         # pretend to have API compatibiliy
         sys.stdout.flush = lambda: True
         sys.stderr.flush = lambda: True
+        self.logger.info("Stdio connected.")
 
 
     def connect_log_stream(self):
@@ -189,7 +190,10 @@ class Runner:
 
         if asyncio.iscoroutine(result):
             result = await result
-        await self.forward_output_stream(result)
+        if result:
+            await self.forward_output_stream(result)
+        else:
+            self.logger.debug("Sequence returned no output.")
 
         self.logger.info('Finished.')
 

--- a/python/runner/runner.py
+++ b/python/runner/runner.py
@@ -128,7 +128,7 @@ class Runner:
             if code == msg_codes.KILL.value:
                 self.exit_immediately()
             if code == msg_codes.STOP.value:
-                self.handle_stop(data)
+                await self.handle_stop(data)
 
 
     async def handle_stop(self, data):

--- a/python/test/sample_unicode_1.txt
+++ b/python/test/sample_unicode_1.txt
@@ -1,0 +1,3 @@
+foo
+bar baz
+żółw


### PR DESCRIPTION
According to list in https://app.clickup.com/t/24308805/SCP-3184

Python BDD tests are not enabled in CI yet. They are tagged `@python` and require compiling python sequences, which can be done with teh following command

```bash
for seq_name in `ls python/reference-apps/`; do si pack "python/reference-apps/$seq_name" -o "$seq_name.tar.gz"; done
```

then, run tests with

```bash
NO_DOCKER=1 yarn test:bdd --tags=@python
```