### PR TITLE
Support for topics in Python Runner

### DIFF
--- a/bdd/README.md
+++ b/bdd/README.md
@@ -96,7 +96,7 @@ for seq_name in `ls python/reference-apps/`; do si pack "python/reference-apps/$
 Also, python runner does not support Docker yet, so run tests with
 
 ```bash
-NO_DOCKER=1 yarn test:bdd --tags=@python
+RUNTIME_ADAPTER=process yarn test:bdd --tags=@python
 ```
 
 ### Results :bar_chart:

--- a/bdd/features/e2e/E2E-014-python.feature
+++ b/bdd/features/e2e/E2E-014-python.feature
@@ -92,7 +92,7 @@ Feature: Test our shiny new Python runner
         Then instance health is "false"
         And host is still running
 
-    @ignore
+
     @python
     Scenario: E2E-014 TC-011 Send data between python instances using topics
         Given host is running

--- a/python/reference-apps/python-topic-consumer/main.py
+++ b/python/reference-apps/python-topic-consumer/main.py
@@ -1,0 +1,7 @@
+requires = {
+   'requires': 'pytopic-test',
+   'contentType': 'text/plain'
+}
+
+def run(context, input):
+    return input.map(lambda s: f'consumer got: {s}').each(print)

--- a/python/reference-apps/python-topic-consumer/package.json
+++ b/python/reference-apps/python-topic-consumer/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "@scramjet/python-topic-consumer-sequence",
+    "version": "0.11.0-0",
+    "main": "./main.py",
+    "author": "Michał Piotrowski <open-source@scramjet.org>",
+    "license": "GPL-3.0",
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/scramjetorg/transform-hub.git"
+    },
+    "engines": {
+      "python3": "3.7.0"
+    }
+}

--- a/python/reference-apps/python-topic-producer/main.py
+++ b/python/reference-apps/python-topic-producer/main.py
@@ -1,0 +1,7 @@
+provides = {
+   'provides': 'pytopic-test',
+   'contentType': 'text/plain'
+}
+
+def run(context, input):
+    return input.map(lambda s: f'producer got: {s}').each(print)

--- a/python/reference-apps/python-topic-producer/package.json
+++ b/python/reference-apps/python-topic-producer/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "@scramjet/python-topic-producer-sequence",
+    "version": "0.11.0-0",
+    "main": "./main.py",
+    "author": "Michał Piotrowski <open-source@scramjet.org>",
+    "license": "GPL-3.0",
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/scramjetorg/transform-hub.git"
+    },
+    "engines": {
+      "python3": "3.7.0"
+    }
+}


### PR DESCRIPTION
**`yarn install:python-deps`** before

To run bdd tests:
**RUNTIME_ADAPTER=process yarn test:bdd --tags=@python**

1. Run sth
`DEVELOPMENT=1 yarn start:dev --no-docker`
2. pack seq and send to sth
3. To test consumer, send some data on topic:
`si topic send pytopic-test python/reference-apps/python-alice/data.json`
4. Data can be retrieved also with
  `si topic get pytopic-test`