### PR TITLE
Python: configure PYTHONPATH for loading dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ There are several installations you need to perform to get STH up and running, a
 - typescript
 - ts-node
 - docker
+- pip
 
 To check if you already have Node.js(v16.xx.x) and npm installed, please check the installed version, run the following commands in your console:
 
@@ -226,6 +227,15 @@ The same as before the installations can be confirmed by checking the installed 
 ![versions](./images/versions.png)
 
 OK! The installation was successful. 🎉 🎆
+
+STH can run python packages, and for that it needs to have `python` and `pip`. These should be already installed on your system - check with:
+
+```bash
+python --version
+pip --version
+```
+
+If they are not present, refer to the official installation guide for [Python](https://wiki.python.org/moin/BeginnersGuide/Download) and [Pip](https://pip.pypa.io/en/stable/installation/).
 
 We also work with Docker, but this is optional. Running STH is possible without Docker in the background. If you don't want to use Docker, please skip this step. If you want to use Docker, you can install it by running the following commands in your console:
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "start": "node dist/sth/bin/hub.js",
     "start:dev": "ts-node packages/sth/src/bin/hub.ts",
     "install:clean": "yarn clean && yarn clean:modules && yarn install",
+    "install:python-deps": "pip install -r python/runner/requirements.txt --target python_modules",
     "postinstall": "lerna link",
     "prepare": "npx husky install",
     "test": "lerna run test",

--- a/packages/adapters/src/process-instance-adapter.ts
+++ b/packages/adapters/src/process-instance-adapter.ts
@@ -73,6 +73,17 @@ IComponent {
         ];
     }
 
+    getPythonpath() {
+        let pythonpath = path.resolve(
+            __dirname,
+            isTSNode ? "../../../python_modules" : "../../python_modules"
+        );
+
+        if (process.env.PYTHONPATH) pythonpath += `:${process.env.PYTHONPATH}`;
+
+        return pythonpath;
+    }
+
     async run(config: SequenceConfig, instancesServerPort: number, instanceId: string): Promise<ExitCode> {
         if (config.type !== "process") {
             throw new Error("Process instance adapter run with invalid runner config");
@@ -100,6 +111,7 @@ IComponent {
         const runnerProcess = spawn(runnerCommand[0], runnerCommand.slice(1), {
             env: {
                 PATH: process.env.PATH,
+                PYTHONPATH: this.getPythonpath(),
                 DEVELOPMENT: process.env.DEVELOPMENT,
                 PRODUCTION: process.env.PRODUCTION,
                 SEQUENCE_PATH: sequencePath,


### PR DESCRIPTION
We're going to need some python dependencies soon. To make sure they can
be accessed by the runner, setup a directory for installing them and
configure PYTHONPATH so that they will be accessible.

Note that we're not using virtualenv for this purpose because actual
python executable may change (as the user can specify which python
version he wants).