### PR TITLE
Docker support for python runner

### DIFF
--- a/bdd/features/e2e/hub/HUB-001-host-config.feature
+++ b/bdd/features/e2e/hub/HUB-001-host-config.feature
@@ -46,13 +46,13 @@ Feature: Host configuration
         * exit hub process
 
     @ci @starts-host @docker-specific
-    Scenario: HUB-001 TC-010  Default runner image
+    Scenario: HUB-001 TC-010  Default runner image for js/ts sequences
         When hub process is started with parameters "''"
         And sequence "../packages/reference-apps/inert-function.tar.gz" is loaded
         And instance started
         And wait for "2000" ms
         And get runner container information
-        Then container uses image defined in sth-config
+        Then container uses node image defined in sth-config
         * exit hub process
 
     @ci @starts-host @docker-specific

--- a/bdd/step-definitions/hub/config.ts
+++ b/bdd/step-definitions/hub/config.ts
@@ -97,8 +97,8 @@ Then("container uses {string} image", async function(this: CustomWorld, image: s
     assert.equal(this.resources.containerInfo.Image, image);
 });
 
-Then("container uses image defined in sth-config", async function(this: CustomWorld) {
-    const defaultRunnerImage = defaultConfig.docker.runner.image;
+Then("container uses node image defined in sth-config", async function(this: CustomWorld) {
+    const defaultRunnerImage = defaultConfig.docker.runnerImages.node;
 
     assert.equal(this.resources.containerInfo.Image, defaultRunnerImage);
 });

--- a/packages/adapters/src/docker-sequence-adapter.ts
+++ b/packages/adapters/src/docker-sequence-adapter.ts
@@ -205,9 +205,15 @@ class DockerSequenceAdapter implements ISequenceAdapter {
         const engines = validPackageJson.engines ? { ...validPackageJson.engines } : {};
         const config = validPackageJson.scramjet?.config ? { ...validPackageJson.scramjet.config } : {};
 
+        const container = Object.assign({}, this.config.docker.runner);
+
+        container.image = "python3" in engines
+            ? this.config.docker.runnerImages.python3
+            : this.config.docker.runnerImages.node;
+
         return {
             type: "docker",
-            container: this.config.docker.runner,
+            container,
             name: validPackageJson.name || "",
             version: validPackageJson.version || "",
             engines,

--- a/packages/adapters/src/process-instance-adapter.ts
+++ b/packages/adapters/src/process-instance-adapter.ts
@@ -61,7 +61,12 @@ IComponent {
                 ? "../../../python/runner/runner.py"
                 : "../../python/runner/runner.py";
 
-            return ["python3", path.resolve(__dirname, runnerPath)];
+            return [
+                "/usr/bin/env",
+                "python3",
+                path.resolve(__dirname, runnerPath),
+                "./python-runner-startup.log",
+            ];
         }
         return [
             isTSNode ? "ts-node" : process.execPath,

--- a/packages/reference-apps/hello-alice-out/package.json
+++ b/packages/reference-apps/hello-alice-out/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scramjet/hello-alice-out",
   "version": "0.17.0",
-  "main": "index",
+  "main": "index.js",
   "assets": [
     "data.json"
   ],

--- a/packages/reference-apps/hello-hulk-out/package.json
+++ b/packages/reference-apps/hello-hulk-out/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scramjet/hello-hulk-out",
   "version": "0.17.0",
-  "main": "index",
+  "main": "index.js",
   "scripts": {
     "build:refapps": "tsc -p tsconfig.json",
     "postbuild:refapps": "yarn prepack && yarn packseq",

--- a/packages/reference-apps/hello-input-out/package.json
+++ b/packages/reference-apps/hello-input-out/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scramjet/hello-input-out",
   "version": "0.17.0",
-  "main": "index",
+  "main": "index.js",
   "scripts": {
     "build:refapps": "tsc -p tsconfig.json",
     "postbuild:refapps": "yarn prepack && yarn packseq",

--- a/packages/runner/src/bin/start-runner.ts
+++ b/packages/runner/src/bin/start-runner.ts
@@ -5,7 +5,7 @@ import fs from "fs";
 import { AppConfig } from "@scramjet/types";
 import { HostClient } from "../host-client";
 
-const sequencePath: string = process.env.SEQUENCE_PATH?.replace(/.js$/, "") + ".js";
+const sequencePath: string = process.env.SEQUENCE_PATH ?? "";
 const instancesServerPort = process.env.INSTANCES_SERVER_PORT;
 const instancesServerHost = process.env.INSTANCES_SERVER_HOST;
 const instanceId = process.env.INSTANCE_ID;

--- a/packages/sth-config/src/config-service.ts
+++ b/packages/sth-config/src/config-service.ts
@@ -20,6 +20,10 @@ const _defaultConfig: STHConfiguration = {
             exposePortsRange: [30000, 32767],
             hostIp: "0.0.0.0"
         },
+        runnerImages: {
+            python3: "",
+            node: "",
+        },
     },
     identifyExisting: false,
     host: {
@@ -50,7 +54,7 @@ const _defaultConfig: STHConfiguration = {
 merge(_defaultConfig, {
     docker: {
         prerunner: { image: imageConfig.prerunner },
-        runner: { image: imageConfig.runner },
+        runnerImages: imageConfig.runner,
     }
 });
 

--- a/packages/sth-config/src/image-config.json
+++ b/packages/sth-config/src/image-config.json
@@ -1,4 +1,7 @@
 {
   "prerunner": "scramjetorg/pre-runner:0.17.0",
-  "runner": "scramjetorg/runner:0.17.0"
+  "runner": {
+    "node": "scramjetorg/runner:0.17.0",
+    "python3": "scramjetorg/python-runner:0.17.0"
+  }
 }

--- a/packages/sth-config/test/index.spec.ts
+++ b/packages/sth-config/test/index.spec.ts
@@ -22,11 +22,14 @@ test("Check if the tags of the images match packages version", async t => {
     const runnerPackageJson = require("../../runner/package.json");
     const preRunnerPackageJson = require("../../pre-runner/package.json");
     const dockerConfig = configService.getDockerConfig();
-    const runnerTagImageConfig = dockerConfig.runner.image.split(":")[1];
+    const runnerTagImagesConfig =
+        Object.values(dockerConfig.runnerImages).map(image => image.split(":")[1]);
     const preRunnerTagImageConfig = dockerConfig.prerunner.image.split(":")[1];
     const runnerTagPackageJson = runnerPackageJson.version;
     const preRunnerTagPackageJson = preRunnerPackageJson.version;
 
-    t.is(runnerTagPackageJson, runnerTagImageConfig, "Runner tag is eqal");
+    for (const tag of runnerTagImagesConfig) {
+        t.is(runnerTagPackageJson, tag, "Runner tag is eqal");
+    }
     t.is(preRunnerTagPackageJson, preRunnerTagImageConfig, "Prerunner tag is eqal");
 });

--- a/packages/types/src/sth-configuration.ts
+++ b/packages/types/src/sth-configuration.ts
@@ -106,6 +106,10 @@ export type STHConfiguration = {
          * Runner container configuration.
          */
         runner: RunnerContainerConfiguration,
+        runnerImages: {
+            python3: string,
+            node: string,
+        },
     },
 
     /**

--- a/python/runner/Dockerfile
+++ b/python/runner/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.8.12-bullseye
+
+ENV PACKAGE_DIR=/package \
+    HUB_DIR=/opt/transform-hub
+
+RUN groupadd -g 1200 runner \
+    && useradd -g 1200 -u 1200 -m -d ${HUB_DIR} -s /bin/false runner \
+    && mkdir -p ${PACKAGE_DIR} \
+    && chown runner:runner ${PACKAGE_DIR}
+
+RUN apt-get update \
+    && apt-get install -y gosu --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY scramjet-framework/scramjet ./scramjet
+COPY runner/*.py ./
+COPY runner/requirements.txt ./requirements.txt
+COPY runner/docker-entrypoint.sh /usr/local/bin/
+
+RUN pip install -r requirements.txt
+
+ENTRYPOINT [ "docker-entrypoint.sh" ]
+CMD [ "start-runner" ]

--- a/python/runner/docker-entrypoint.sh
+++ b/python/runner/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+RUNNER_USER="${RUNNER_USER:-runner}"
+
+if [ "$1" == "start-runner" ]; then
+	shift
+	set -- python runner.py "$@"
+fi
+
+exec gosu ${RUNNER_USER} "$@"

--- a/python/runner/logging_setup.py
+++ b/python/runner/logging_setup.py
@@ -17,11 +17,12 @@ class JsonFormatter(logging.Formatter):
 
 
 class LoggingSetup():
-    def __init__(self, temp_log_path, min_loglevel=logging.DEBUG) -> None:
-        self._temp_logfile = open(temp_log_path, 'a+')
-        self._temp_logfile.write('\n')
-        sys.stdout = self._temp_logfile
-        sys.stderr = self._temp_logfile
+    def __init__(self, target, min_loglevel=logging.DEBUG) -> None:
+        self._target = target
+        self._target.write('\n')
+        if self._target != sys.stdout:
+            sys.stdout = self._target
+            sys.stderr = self._target
 
         self.logger = logging.getLogger('PythonRunner')
         self.logger.setLevel(min_loglevel)
@@ -32,7 +33,7 @@ class LoggingSetup():
     def create_handlers(self, min_loglevel):
         formatter = JsonFormatter()
 
-        self._main_handler = logging.StreamHandler(self._temp_logfile)
+        self._main_handler = logging.StreamHandler(self._target)
         self._main_handler.setLevel(min_loglevel)
         self._main_handler.setFormatter(formatter)
         self.logger.addHandler(self._main_handler)
@@ -52,9 +53,11 @@ class LoggingSetup():
         self.logger.warn = self.logger.warning
 
 
-    def switch_to(self, target):
-        self._main_handler.setStream(target)
-        self._temp_logfile.close()
+    def switch_target(self, new_target):
+        old_target = self._target
+        self._main_handler.setStream(new_target)
+        self._target = new_target
+        old_target.close()
 
 
     def flush_temp_handler(self):

--- a/python/runner/package.json
+++ b/python/runner/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@scramjet/runner",
+  "version": "0.17.0",
+  "description": "This package is part of Scramjet Transform Hub. The package executes the remote runners and provides communication with them through abstraction layer provided by adapters.",
+  "main": "./runner.py",
+  "scripts": {
+    "build:docker": "docker build -t scramjetorg/python-runner:$npm_package_version -f Dockerfile ../"
+  },
+  "author": "Scramjet <opensource@scramjet.org>",
+  "license": "MIT",
+  "dependencies": {},
+  "devDependencies": {},
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scramjetorg/transform-hub.git"
+  }
+}


### PR DESCRIPTION
## Overview

Py runner: add docker support

- allow choosing runner image in docker-sequence-adapter (based on
  "engines" key in config)
- add Dockerfile for building python runner docker image
- add package.json for automating the above


Py runner: more generic LoggingSetup & server host

a) parameterize server host with env variable, with localhost default
b) abstract away the temporariness of the initial log target.
LoggingSetup should just receive a target to which it will be logging,
and optionally redirect stdout/err there (in case of process runner,
when standard streams are not accessible directly).


Don't append '.js` extension to sequence entrypoint

We don't want to mess around with what user said, especially with
support for new filetypes coming.


## How to verify

* build py-runner image: `cd python/runner; yarn build:docker` 
* Start STH with docker enabled, e.g. `DEVELOPMENT=true yarn start:dev`
* pack, upload and run some python sequence (e.g. `python/reference-apps/python-alice`
* the output should look similar to this: 
![image](https://user-images.githubusercontent.com/1368508/155360907-4687962d-81c0-4e7c-bdbd-0b4dc8eb5c4e.png)
