### PR TITLE
Restore proper STOP/KILL supervisor mechanisms in CSIController

### DIFF
--- a/.github/workflows/sth-build-test.yml
+++ b/.github/workflows/sth-build-test.yml
@@ -421,4 +421,4 @@ jobs:
           run: yarn install --frozen-lockfile --silent
 
         - name: Run BDD tests
-          run: ls && ls packages && ls packages/reference-apps && SCRAMJET_TEST_LOG=1 yarn test:bdd-ci-no-docker
+          run: SCRAMJET_TEST_LOG=1 yarn test:bdd-ci-no-docker

--- a/.github/workflows/sth-build-test.yml
+++ b/.github/workflows/sth-build-test.yml
@@ -421,4 +421,4 @@ jobs:
           run: yarn install --frozen-lockfile --silent
 
         - name: Run BDD tests
-          run: SCRAMJET_TEST_LOG=1 yarn test:bdd-ci-no-docker
+          run: ls && ls packages && ls packages/reference-apps && SCRAMJET_TEST_LOG=1 yarn test:bdd-ci-no-docker

--- a/bdd/features/e2e/E2E-003-kill.feature
+++ b/bdd/features/e2e/E2E-003-kill.feature
@@ -10,3 +10,29 @@ Feature: Kill e2e tests
         And send kill message to instance
         And runner has ended execution
         Then host is still running
+
+    # This is a potential edge case so it's currently ignored.
+    @ignore
+    Scenario: E2E-003 TC-002 Kill sequence - kill handler should emit event when executed
+        Given host is running
+        When sequence "../packages/reference-apps/sequence-20s-kill-handler.tar.gz" loaded
+        And instance started
+        And wait for instance healthy is "true"
+        And get runner PID
+        Then get event "kill-handler-called" from instance
+        When send kill message to instance
+        Then instance response body is "{\"eventName\":\"kill-handler-called\",\"message\":\"\"}"
+        And runner has ended execution
+        Then host is still running
+
+    @ci
+    Scenario: E2E-003 TC-003 API test - Kill instance when it's not responding
+        Given host is running
+        When sequence "../packages/reference-apps/process-not-responding.tar.gz" loaded
+        And instance started
+        And wait for instance healthy is "true"
+        And get runner PID
+        And send kill message to instance
+        And wait for "10000" ms
+        And runner has ended execution
+        Then host is still running

--- a/bdd/step-definitions/e2e/host-steps.ts
+++ b/bdd/step-definitions/e2e/host-steps.ts
@@ -385,7 +385,7 @@ When("get runner PID", { timeout: 31000 }, async function(this: CustomWorld) {
     }
 });
 
-When("runner has ended execution", { timeout: 500000 }, async () => {
+When("runner has ended execution", { timeout: 20000 }, async () => {
     if (process.env.RUNTIME_ADAPTER === "kubernetes") {
         // @TODO
         return;

--- a/bdd/step-definitions/e2e/host-steps.ts
+++ b/bdd/step-definitions/e2e/host-steps.ts
@@ -91,9 +91,12 @@ const killRunner = async () => {
     }
 
     if (process.env.RUNTIME_ADAPTER === "process" && processId) {
-        process.kill(processId);
-
-        await waitForProcessToEnd(processId);
+        try {
+            process.kill(processId);
+            await waitForProcessToEnd(processId);
+        } catch (e) {
+            console.error("Couldn't kill runner", e);
+        }
     }
 
     if (process.env.RUNTIME_ADAPTER === "docker" && containerId) {

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -38,6 +38,7 @@ import { getRouter } from "@scramjet/api-server";
 import { getInstanceAdapter } from "@scramjet/adapters";
 import { defer, promiseTimeout, TypedEmitter } from "@scramjet/utility";
 import { ObjLogger } from "@scramjet/obj-logger";
+import { ReasonPhrases } from "http-status-codes";
 
 const runnerExitDelay = 11000;
 
@@ -478,10 +479,13 @@ export class CSIController extends TypedEmitter<Events> {
         this.router.op("post", "/_kill", async () => {
             await this.communicationHandler.sendControlMessage(RunnerMessageCode.KILL, {});
 
-            await promiseTimeout(this.endOfSequence, runnerExitDelay)
+            // This will be resolved after HTTP response. It's not awaited on purpose
+            promiseTimeout(this.endOfSequence, runnerExitDelay)
                 .catch(() => this.instanceAdapter.remove());
 
-            return {};
+            return {
+                opStatus: ReasonPhrases.ACCEPTED
+            };
         }, this.communicationHandler);
     }
 

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -537,7 +537,6 @@ export class CSIController extends TypedEmitter<Events> {
     }
 
     async handleSequenceStopped(message: EncodedMessage<RunnerMessageCode.SEQUENCE_STOPPED>) {
-        // @TODO redesign this process, currently it's not used by any sequence
         this.logger.trace("Sequence ended, sending kill");
 
         try {

--- a/packages/reference-apps/process-not-responding/.eslintrc.js
+++ b/packages/reference-apps/process-not-responding/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+    ignorePatterns: [".eslintrc.js"],
+    parserOptions:{
+        project: "./tsconfig.json",
+        tsconfigRootDir: __dirname
+    }
+};

--- a/packages/reference-apps/process-not-responding/package.json
+++ b/packages/reference-apps/process-not-responding/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@scramjet/process-not-responding",
+  "version": "0.17.0",
+  "main": "index.js",
+  "scripts": {
+    "build:refapps": "tsc -p tsconfig.json",
+    "postbuild:refapps": "yarn prepack",
+    "clean": "rm -rf ./dist .bic_cache",
+    "prepack": "node ../../../scripts/publish.js",
+    "packseq": "node ../../../scripts/packsequence.js"
+  },
+  "engines": {
+    "node": ">=10"
+  },
+  "scramjet": {
+    "image": "node"
+  },
+  "author": "Scramjet <open-source@scramjet.org>",
+  "license": "GPL-3.0",
+  "devDependencies": {
+    "@types/node": "15.12.5",
+    "typescript": "^4.3.4"
+  },
+  "dependencies": {
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scramjetorg/transform-hub.git"
+  }
+}

--- a/packages/reference-apps/process-not-responding/package.json
+++ b/packages/reference-apps/process-not-responding/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "build:refapps": "tsc -p tsconfig.json",
-    "postbuild:refapps": "yarn prepack",
+    "postbuild:refapps": "yarn prepack && yarn packseq",
     "clean": "rm -rf ./dist .bic_cache",
     "prepack": "node ../../../scripts/publish.js",
     "packseq": "node ../../../scripts/packsequence.js"

--- a/packages/reference-apps/process-not-responding/src/index.ts
+++ b/packages/reference-apps/process-not-responding/src/index.ts
@@ -1,0 +1,4 @@
+export default function() {
+    // eslint-disable-next-line no-constant-condition
+    while (true);
+}

--- a/packages/reference-apps/process-not-responding/tsconfig.build.json
+++ b/packages/reference-apps/process-not-responding/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/reference-apps/process-not-responding/tsconfig.json
+++ b/packages/reference-apps/process-not-responding/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "extends": "../../../tsconfig.base.json",
+  "include": [
+    "./src",
+    "./test"
+  ],
+  "exclude": [
+    "node_modules"
+  ],
+  "typedocOptions": {
+    "entryPoints": [
+      "index.ts"
+    ],
+    "out": "../../docs/model",
+    "gitRevision": "HEAD"
+  }
+}

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -371,14 +371,16 @@ export class Runner<X extends AppConfig> implements IComponent {
         try {
             await this.runSequence(sequence, args);
 
+            this.writeMonitoringMessage([RunnerMessageCode.SEQUENCE_COMPLETED, {}]);
             this.logger.trace(`Sequence completed. Waiting ${exitDelay}ms with exit.`);
 
-            await defer(exitDelay); // @TODO: investigate why we need to wait
+            await defer(exitDelay);
         } catch (error: any) {
+            this.writeMonitoringMessage([RunnerMessageCode.SEQUENCE_COMPLETED, {}]);
+
             this.logger.error("Error occured during sequence execution: ", error.stack);
 
             await this.cleanup();
-
             this.exit(20);
         }
 


### PR DESCRIPTION
This fixes: #258 

The implemented behavior should resemble the one from before Supervisor removal.
I guess all these flows should be revisited and refactored. They are a bit messy and quite complex.

Changes include:
* Process kill after Runner is not exiting after KILL control msg
* Send KILL msg after Runner is not emitting SEQUENCE_STOPPED after STOP control msg
* Process kill after Runner is not exiting after sending SEQUENCE_COMPLETED
* BDD test to confirm that Runner that is not responding is correctly killed



### Veryify
New CI test should confirm the case when Runner is not responding and the instance adapter removes the process forcefully after instance kill command 