### PR TITLE
add method to flush logs in logger

### DIFF
--- a/packages/obj-logger/src/obj-logger.ts
+++ b/packages/obj-logger/src/obj-logger.ts
@@ -88,7 +88,11 @@ export class ObjLogger implements IObjectLogger {
 
     async flush() {
         return new Promise<void>(resolve => {
-            this.outputLogStream.on("drain", resolve);
+            if (this.outputLogStream..writableNeedDrain) {
+                this.outputLogStream.once("drain", resolve);
+            } else {
+                resolve();
+            }
         });
     }
 

--- a/packages/obj-logger/src/obj-logger.ts
+++ b/packages/obj-logger/src/obj-logger.ts
@@ -86,6 +86,12 @@ export class ObjLogger implements IObjectLogger {
         this.outputLogStream.pipe(this.output);
     }
 
+    async flush() {
+        return new Promise<void>(resolve => {
+            this.outputLogStream.on("drain", resolve);
+        });
+    }
+
     write(level: LogLevel, entry: LogEntry | string, ...optionalParams: any[]) {
         if (ObjLogger.levels.indexOf(level) > ObjLogger.levels.indexOf(this.logLevel)) {
             return;

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -172,10 +172,11 @@ export class Runner<X extends AppConfig> implements IComponent {
 
         try {
             this.logger.info("Cleaning up streams");
+            await this.logger.flush();
 
             await this.hostClient.disconnect();
 
-            this.logger.info("Streams clear");
+            this.logger.info("Streams clear"); // who cares anymore?
 
             return 0;
         } catch (e: any) {

--- a/packages/types/src/object-logger.ts
+++ b/packages/types/src/object-logger.ts
@@ -52,7 +52,7 @@ export interface IObjectLogger {
     output: DataStream;
 
     addOutput(output: Writable): void;
-
+    flush(): Promise<void>;
     write(level: LogEntry["level"], entry: LogEntry | string, ...optionalParams: any[]): void;
     debug(entry: LogEntry | string, ...optionalParams: any[]): void;
     error(entry: LogEntry | string, ...optionalParams: any[]): void;


### PR DESCRIPTION
with this change
```
2022-02-27T00:30:31.428Z INFO  Runner Sequence loaded, functions count [ 1 ]
2022-02-27T00:30:31.428Z DEBUG Runner Processing function on index [ 0 ]
2022-02-27T00:30:31.428Z ERROR Runner Function errored [
  1,
  'ReferenceError: PassThrough is not defined\n' +
    '    at RunnerAppContext.module.exports (/package/index.js:2:16)\n' +
    '    at Runner.runSequence (/opt/transform-hub/runner/runner.js:314:28)\n' +
    '    at Runner.main (/opt/transform-hub/runner/runner.js:254:24)\n' +
    '    at processTicksAndRejections (node:internal/process/task_queues:96:5)'
]
2022-02-27T00:30:31.429Z ERROR Runner Error occured during sequence execution:  [
  'Error: Application Error Occured\n' +
    '    at Runner.runSequence (/opt/transform-hub/runner/runner.js:319:23)\n' +
    '    at Runner.main (/opt/transform-hub/runner/runner.js:254:24)\n' +
    '    at processTicksAndRejections (node:internal/process/task_queues:96:5)'
]
2022-02-27T00:30:31.429Z INFO  Runner Cleaning up 
2022-02-27T00:30:31.429Z TRACE Runner Monitoring interval removed
```

currently no logs from runner after error. runner disconnects before sending logs
