### PR TITLE
Get rid of waits in HUB tests

### DIFF
--- a/bdd/features/e2e/hub/HUB-001-host-config.feature
+++ b/bdd/features/e2e/hub/HUB-001-host-config.feature
@@ -37,7 +37,6 @@ Feature: Host configuration
         When hub process is started with parameters "''"
         And sequence "../packages/reference-apps/inert-function.tar.gz" is loaded
         And instance started
-        And wait for "2000" ms
         And get runner container information
         Then container uses node image defined in sth-config
         * exit hub process
@@ -47,7 +46,6 @@ Feature: Host configuration
         When hub process is started with parameters "--runner-max-mem 128"
         And sequence "../packages/reference-apps/hello-alice-out.tar.gz" is loaded
         And instance started
-        And wait for "2000" ms
         And get runner container information
         Then container memory limit is 128
         * exit hub process
@@ -56,7 +54,6 @@ Feature: Host configuration
         When hub process is started with parameters "--prerunner-image repo.int.scp.ovh/scramjet/pre-runner:0.10.0-pre.7"
         And get all containers
         And send fake stream as sequence
-        And wait for "5000" ms
         And get last container info
         And last container uses "repo.int.scp.ovh/scramjet/pre-runner:0.10.0-pre.7" image
         And end fake stream
@@ -67,7 +64,6 @@ Feature: Host configuration
         When hub process is started with parameters "--prerunner-max-mem 64"
         And get all containers
         And send fake stream as sequence
-        And wait for "5000" ms
         And get last container info
         Then last container memory limit is 64
         And end fake stream

--- a/bdd/step-definitions/hub/config.ts
+++ b/bdd/step-definitions/hub/config.ts
@@ -15,6 +15,8 @@ import { ReadStream } from "fs";
 import { PassThrough } from "stream";
 import { defer } from "../../lib/utils";
 
+const AWAITING_POLL_DEFER_TIME = 250;
+
 When("hub process is started with parameters {string}", function(this: CustomWorld, params: string) {
     return new Promise<void>((resolve, reject) => {
         this.resources.hub = spawn(
@@ -94,7 +96,7 @@ Then("get runner container information", { timeout: 20000 }, async function(this
             this.resources.containerInfo = info;
             this.resources.containerInspect = inspect;
         } else {
-            await defer(50);
+            await defer(AWAITING_POLL_DEFER_TIME);
         }
     }
 });
@@ -151,7 +153,7 @@ Then("get last container info", async function(this: CustomWorld) {
         if (lastContainer.length) {
             this.resources.lastContainer = success = lastContainer[0];
         } else {
-            await defer(50);
+            await defer(AWAITING_POLL_DEFER_TIME);
         }
     }
 });


### PR DESCRIPTION
This is a simple example of how we can get rid of explicit waits in tests. Here I just optimized one test suite (`HUB`).

Test command:
```
yarn test:bdd-ci-no-host --name="HUB-001"
```

Before:
```
9 scenarios (9 passed)
40 steps (40 passed)
0m28.342s (executing steps: 0m28.268s)
Done in 32.56s.
```

After:
```
9 scenarios (9 passed)
37 steps (37 passed)
0m23.382s (executing steps: 0m23.311s)
Done in 27.66s.
```

So it's 5 seconds less (which seems not to be that much), but in fact it is ~18% of the entire tests duration.
