### PR TITLE
BDD tests: remove unneeded test cases

### DIFF
--- a/bdd/features/e2e/E2E-001-samples.feature
+++ b/bdd/features/e2e/E2E-001-samples.feature
@@ -1,16 +1,5 @@
 Feature: Sample e2e tests
 
-    Scenario: E2E-001 TC-001 Execute hello-alice-out example for host
-        Given host is running
-        When sequence "../packages/reference-apps/hello-alice-out.tar.gz" loaded
-        And instance started
-        And get "output" with instanceId and wait for it to finish
-        And wait for instance healthy is "true"
-        And get runner PID
-        When response in every line contains "Hello " followed by name from file "data.json" finished by "!"
-        And runner has ended execution
-        Then host is still running
-
     @ci
     Scenario: E2E-001 TC-002 API test - Get instance output
         Given host is running
@@ -26,16 +15,3 @@ Feature: Sample e2e tests
         And confirm that sequence and volumes are removed
         Then runner has ended execution
         And host is still running
-
-    Scenario: E2E-001 TC-003 - KM5_Cloud Server Instance Component
-        Given host is running
-        When sequence "../packages/reference-apps/hello-alice-out.tar.gz" loaded
-        And instance started
-        And get "output" with instanceId and wait for it to finish
-        And wait for instance healthy is "true"
-        And get runner PID
-        When response in every line contains "Hello " followed by name from file "data.json" finished by "!"
-        And delete sequence and volumes
-        And confirm that sequence and volumes are removed
-        And runner has ended execution
-        Then host is still running

--- a/bdd/features/e2e/E2E-003-kill.feature
+++ b/bdd/features/e2e/E2E-003-kill.feature
@@ -10,17 +10,3 @@ Feature: Kill e2e tests
         And send kill message to instance
         And runner has ended execution
         Then host is still running
-
-    # This is a potential edge case so it's currently ignored.
-    @ignore
-    Scenario: E2E-003 TC-002 Kill sequence - kill handler should emit event when executed
-        Given host is running
-        When sequence "../packages/reference-apps/sequence-20s-kill-handler.tar.gz" loaded
-        And instance started
-        And wait for instance healthy is "true"
-        And get runner PID
-        Then get event "kill-handler-called" from instance
-        When send kill message to instance
-        Then instance response body is "{\"eventName\":\"kill-handler-called\",\"message\":\"\"}"
-        And runner has ended execution
-        Then host is still running

--- a/bdd/features/e2e/E2E-004-event.feature
+++ b/bdd/features/e2e/E2E-004-event.feature
@@ -12,15 +12,3 @@ Feature: Event e2e tests
         Then instance response body is "{\"eventName\":\"test-event-response\",\"message\":\"message from sequence\"}"
         And runner has ended execution
         Then host is still running
-
-    @ci
-    Scenario: E2E-004 TC-002 Send test-event in one function and emit this event in another function within one sequence
-        Given host is running
-        When sequence "../packages/reference-apps/event-sequence-2.tar.gz" loaded
-        And instance started
-        And wait for instance healthy is "true"
-        And get runner PID
-        Then get event "new-test-event" from instance
-        Then instance response body is "{\"eventName\":\"new-test-event\",\"message\":\"event sent between functions in one sequence\"}"
-        And runner has ended execution
-        Then host is still running

--- a/bdd/features/e2e/E2E-005-monitoring.feature
+++ b/bdd/features/e2e/E2E-005-monitoring.feature
@@ -9,12 +9,3 @@ Feature: Monitoring e2e tests
         And wait for instance healthy is "false"
         And runner has ended execution
         Then host is still running
-
-    Scenario: E2E-005 TC-002 Get monitoring from sequence, should return default monitoring value: healthy true
-        Given host is running
-        When sequence "../packages/reference-apps/healthy-sequence.tar.gz" loaded
-        And instance started
-        And wait for instance healthy is "true"
-        And get runner PID
-        And runner has ended execution
-        Then host is still running

--- a/bdd/features/e2e/hub/HUB-001-host-config.feature
+++ b/bdd/features/e2e/hub/HUB-001-host-config.feature
@@ -13,19 +13,6 @@ Feature: Host configuration
         * exit hub process
 
     @ci @starts-host
-    Scenario: HUB-001 TC-003 Set host port (-P)
-        When hub process is started with parameters "-P 19001"
-        Then API is available on port 19001
-        * exit hub process
-
-    @ci @starts-host
-    Scenario: HUB-001 TC-004 Set host port (--port)
-        When hub process is started with parameters "--port 19001"
-        Then API is available on port 19001
-        * exit hub process
-
-
-    @ci @starts-host
     Scenario: HUB-001 TC-007  Set API server name (--hostname)
         When hub process is started with parameters "--hostname 0.0.0.0"
         Then API starts with "0.0.0.0" server name


### PR DESCRIPTION
* "E2E-001 TC-001 Execute hello-alice-out example for host" and
  "E2E-001 TC-003 - KM5_Cloud Server Instance Component" duplicate
  "E2E-001 TC-002 API test - Get instance output"
* "E2E-003 TC-002 Kill sequence - kill handler should emit event when
  executed" was ignored for a very long time with a comment "potential
  edge case", so it appears to be no longer relevant
* "E2E-004 TC-002 Send test-event in one function and emit this event in
  another function" was not actually checking what it advertised, so
  it's removed. A ticket for replacing it in the future:
  https://app.clickup.com/t/25d148c
* "Scenario: E2E-005 TC-002 Get monitoring from sequence, should return
  default monitoring value: healthy true" is not needed because we check
  "healthy: true" in most other test cases
* Two HUB scenarios basically duplicated previous two, just with a
  different port parameter.