### PR TITLE
Force-close runners in specific tests

### DIFF
--- a/bdd/features/e2e/E2E-002-stop.feature
+++ b/bdd/features/e2e/E2E-002-stop.feature
@@ -1,7 +1,7 @@
 Feature: Stop e2e tests
 
-    @ci @runner-cleanup
-    Scenario: E2E-002 TC-001 API test - Send stop, sequence sends keepAlive
+    @ci
+    Scenario: E2E-002 TC-001 API test - Send stop, sequence sends keepAlive, runner closes successfully
         Given host is running
         When sequence "../packages/reference-apps/can-keep-alive.tar.gz" loaded
         And instance started with arguments "SEND_KEEPALIVE"
@@ -12,6 +12,7 @@ Feature: Stop e2e tests
         And send stop message to instance with arguments timeout 5000 and canCallKeepAlive "true"
         And wait for instance healthy is "true"
         And send stop message to instance with arguments timeout 0 and canCallKeepAlive "false"
+        And runner has ended execution
         Then host is still running
 
     @ci @runner-cleanup

--- a/bdd/features/e2e/E2E-002-stop.feature
+++ b/bdd/features/e2e/E2E-002-stop.feature
@@ -1,6 +1,6 @@
 Feature: Stop e2e tests
 
-    @ci
+    @ci @runner-cleanup
     Scenario: E2E-002 TC-001 API test - Send stop, sequence sends keepAlive
         Given host is running
         When sequence "../packages/reference-apps/can-keep-alive.tar.gz" loaded
@@ -12,10 +12,10 @@ Feature: Stop e2e tests
         And send stop message to instance with arguments timeout 5000 and canCallKeepAlive "true"
         And wait for instance healthy is "true"
         And send stop message to instance with arguments timeout 0 and canCallKeepAlive "false"
-        And runner has ended execution
+        #And runner has ended execution
         Then host is still running
 
-    @ci
+    @ci @runner-cleanup
     Scenario: E2E-002 TC-002 API test - Send stop, sequence doesn't send keepAlive
         Given host is running
         When sequence "../packages/reference-apps/can-keep-alive.tar.gz" loaded
@@ -23,10 +23,10 @@ Feature: Stop e2e tests
         And wait for instance healthy is "true"
         And get runner PID
         And send stop message to instance with arguments timeout 2000 and canCallKeepAlive "true"
-        And runner has ended execution
+        #And runner has ended execution
         Then host is still running
 
-    @ci
+    @ci @runner-cleanup
     Scenario: E2E-002 TC-003 API test - Send stop, sequence send keepAlive
         Given host is running
         When sequence "../packages/reference-apps/can-keep-alive.tar.gz" loaded
@@ -34,5 +34,5 @@ Feature: Stop e2e tests
         And wait for instance healthy is "true"
         And get runner PID
         And send stop message to instance with arguments timeout 0 and canCallKeepAlive "false"
-        And runner has ended execution
+        #And runner has ended execution
         Then host is still running

--- a/bdd/features/e2e/E2E-002-stop.feature
+++ b/bdd/features/e2e/E2E-002-stop.feature
@@ -12,7 +12,6 @@ Feature: Stop e2e tests
         And send stop message to instance with arguments timeout 5000 and canCallKeepAlive "true"
         And wait for instance healthy is "true"
         And send stop message to instance with arguments timeout 0 and canCallKeepAlive "false"
-        #And runner has ended execution
         Then host is still running
 
     @ci @runner-cleanup
@@ -23,7 +22,6 @@ Feature: Stop e2e tests
         And wait for instance healthy is "true"
         And get runner PID
         And send stop message to instance with arguments timeout 2000 and canCallKeepAlive "true"
-        #And runner has ended execution
         Then host is still running
 
     @ci @runner-cleanup
@@ -34,5 +32,4 @@ Feature: Stop e2e tests
         And wait for instance healthy is "true"
         And get runner PID
         And send stop message to instance with arguments timeout 0 and canCallKeepAlive "false"
-        #And runner has ended execution
         Then host is still running

--- a/bdd/features/e2e/E2E-004-event.feature
+++ b/bdd/features/e2e/E2E-004-event.feature
@@ -10,5 +10,4 @@ Feature: Event e2e tests
         And send event "test-event" to instance with message "test message"
         Then wait for event "test-event-response" from instance
         Then instance response body is "{\"eventName\":\"test-event-response\",\"message\":\"message from sequence\"}"
-        #And runner has ended execution
         Then host is still running

--- a/bdd/features/e2e/E2E-004-event.feature
+++ b/bdd/features/e2e/E2E-004-event.feature
@@ -1,6 +1,6 @@
 Feature: Event e2e tests
 
-    @ci
+    @ci @runner-cleanup
     Scenario: E2E-004 TC-001 API test - Send test-event through API and get event emitted by sequence
         Given host is running
         When sequence "../packages/reference-apps/event-sequence-v2.tar.gz" loaded
@@ -10,5 +10,5 @@ Feature: Event e2e tests
         And send event "test-event" to instance with message "test message"
         Then wait for event "test-event-response" from instance
         Then instance response body is "{\"eventName\":\"test-event-response\",\"message\":\"message from sequence\"}"
-        And runner has ended execution
+        #And runner has ended execution
         Then host is still running

--- a/bdd/features/e2e/E2E-005-monitoring.feature
+++ b/bdd/features/e2e/E2E-005-monitoring.feature
@@ -1,5 +1,6 @@
 Feature: Monitoring e2e tests
 
+    @runner-cleanup
     Scenario: E2E-005 TC-001 API test - Get monitoring from sequence where new handler method is added and returning: healthy false
         Given host is running
         When sequence "../packages/reference-apps/unhealthy-sequence.tar.gz" loaded
@@ -7,5 +8,5 @@ Feature: Monitoring e2e tests
         And wait for instance healthy is "true"
         And get runner PID
         And wait for instance healthy is "false"
-        And runner has ended execution
+        # And runner has ended execution # checks health
         Then host is still running

--- a/bdd/features/e2e/E2E-005-monitoring.feature
+++ b/bdd/features/e2e/E2E-005-monitoring.feature
@@ -8,5 +8,4 @@ Feature: Monitoring e2e tests
         And wait for instance healthy is "true"
         And get runner PID
         And wait for instance healthy is "false"
-        # And runner has ended execution # checks health
         Then host is still running

--- a/bdd/features/e2e/E2E-012-stream-flooding-test.feature
+++ b/bdd/features/e2e/E2E-012-stream-flooding-test.feature
@@ -1,6 +1,6 @@
 Feature: Stream flooding tests. Ensure that even if a large amount of data is sent or received, the Instance is able to respond to events.
 
-    @ci
+    @ci @runner-cleanup
     Scenario: E2E-012 TC-001 Flood stdin of Instance, do not consume it and check if Instance responds to event sent.
         Given host is running
         When sequence "../packages/reference-apps/event-sequence-v2.tar.gz" loaded
@@ -12,10 +12,10 @@ Feature: Stream flooding tests. Ensure that even if a large amount of data is se
         And send event "test-event" to instance with message "test message"
         Then get event "test-event-response" from instance
         Then instance response body is "{\"eventName\":\"test-event-response\",\"message\":\"message from sequence\"}"
-        And runner has ended execution
+        #And runner has ended execution #check event, runner ending not important
         Then host is still running
 
-    @ci
+    @ci @runner-cleanup
     Scenario: E2E-012 TC-002 Instance floods wrtites stdout, then Host checks whether even sent by Instance can be still received.
         Given host is running
         When sequence "../packages/reference-apps/flood-stdout-sequence.tar.gz" loaded
@@ -25,7 +25,7 @@ Feature: Stream flooding tests. Ensure that even if a large amount of data is se
         Then get event "test-event-response" from instance
         When wait for "1000" ms
         Then instance response body is "{\"eventName\":\"test-event-response\",\"message\":\"message from sequence\"}"
-        And send kill message to instance
-        And runner has ended execution
+        #And send kill message to instance
+        #And runner has ended execution # checks event, runner ending not important
         Then host is still running
 

--- a/bdd/features/e2e/E2E-012-stream-flooding-test.feature
+++ b/bdd/features/e2e/E2E-012-stream-flooding-test.feature
@@ -12,7 +12,6 @@ Feature: Stream flooding tests. Ensure that even if a large amount of data is se
         And send event "test-event" to instance with message "test message"
         Then get event "test-event-response" from instance
         Then instance response body is "{\"eventName\":\"test-event-response\",\"message\":\"message from sequence\"}"
-        #And runner has ended execution #check event, runner ending not important
         Then host is still running
 
     @ci @runner-cleanup
@@ -25,7 +24,5 @@ Feature: Stream flooding tests. Ensure that even if a large amount of data is se
         Then get event "test-event-response" from instance
         When wait for "1000" ms
         Then instance response body is "{\"eventName\":\"test-event-response\",\"message\":\"message from sequence\"}"
-        #And send kill message to instance
-        #And runner has ended execution # checks event, runner ending not important
         Then host is still running
 

--- a/bdd/features/performance-tests/PT-002-function-call-delay.feature
+++ b/bdd/features/performance-tests/PT-002-function-call-delay.feature
@@ -9,7 +9,6 @@ Feature: Maintain efficiency within a host
         Then file "delay-test-result.txt" is generated
         When calculate average delay time from "delay-test-result.txt" of first "2000" function calls starting "2000"
         When calculated avereage delay time is lower than 0.1 ms
-        #And runner has ended execution
         Then host is still running
 
     @runner-cleanup
@@ -21,7 +20,6 @@ Feature: Maintain efficiency within a host
         Then file "delay-test-result.txt" is generated
         When calculate average delay time from "delay-test-result.txt" of first "10000" function calls starting "2000"
         When calculated avereage delay time is lower than 0.1 ms
-        #And runner has ended execution
         Then host is still running
 
     Scenario: PT-002 TC-003 Maintain efficiency test with core dump

--- a/bdd/features/performance-tests/PT-002-function-call-delay.feature
+++ b/bdd/features/performance-tests/PT-002-function-call-delay.feature
@@ -1,6 +1,6 @@
 Feature: Maintain efficiency within a host
 
-    @ci
+    @ci @runner-cleanup
     Scenario: PT-002 TC-001 Maintain efficiency - quick test
         Given host is running
         When sequence "../packages/reference-apps/inert-sequence-2-with-delay.tar.gz" loaded
@@ -9,9 +9,10 @@ Feature: Maintain efficiency within a host
         Then file "delay-test-result.txt" is generated
         When calculate average delay time from "delay-test-result.txt" of first "2000" function calls starting "2000"
         When calculated avereage delay time is lower than 0.1 ms
-        And runner has ended execution
+        #And runner has ended execution
         Then host is still running
 
+    @runner-cleanup
     Scenario: PT-002 TC-002 Maintain efficiency
         Given host is running
         When sequence "../packages/reference-apps/inert-sequence-2-with-delay.tar.gz" loaded
@@ -20,7 +21,7 @@ Feature: Maintain efficiency within a host
         Then file "delay-test-result.txt" is generated
         When calculate average delay time from "delay-test-result.txt" of first "10000" function calls starting "2000"
         When calculated avereage delay time is lower than 0.1 ms
-        And runner has ended execution
+        #And runner has ended execution
         Then host is still running
 
     Scenario: PT-002 TC-003 Maintain efficiency test with core dump


### PR DESCRIPTION
Instead of waiting for runner to exit itself, it is now force-closed in `After` step. There were some tests in which checking if runner closed successfully seemed like a part of the test (especially when there was a step sending `kill` to runner instance earlier) so I didn't remove it from such tests.

Tested locally with:

```
yarn test:bdd-ci --name="E2E"
```

Before:

```
29 scenarios (29 passed)
225 steps (225 passed)
5m25.421s (executing steps: 5m24.514s)
```

After:

```
29 scenarios (29 passed)
218 steps (218 passed)
4m47.005s (executing steps: 4m46.117s)
```

**Almost 40 seconds less**.

Closes #193.