### PR TITLE
Fix tests explicit waits

### DIFF
--- a/bdd/features/e2e/E2E-001-samples.feature
+++ b/bdd/features/e2e/E2E-001-samples.feature
@@ -10,7 +10,9 @@ Feature: Sample e2e tests
         And get runner PID
         When response in every line contains "Hello " followed by name from file "data.json" finished by "!"
         And send kill message to instance
-        And wait for "12000" ms
+        And wait for instance healthy is "false"
+        # Give instance some time to close correctly
+        And wait for "1000" ms
         And delete sequence and volumes
         And confirm that sequence and volumes are removed
         Then runner has ended execution

--- a/bdd/features/e2e/E2E-006-stdio.feature
+++ b/bdd/features/e2e/E2E-006-stdio.feature
@@ -9,7 +9,8 @@ Feature: Stdio e2e tests
         And wait for instance healthy is "true"
         And get runner PID
         When send stdin to instance with contents of file "../packages/reference-apps/stdio-sequence/numbers.txt"
-        And wait for "8000" ms
+        # Make sure that entire file contents were sent and received
+        And wait for "1000" ms
         When send kill message to instance
         And runner has ended execution
         Then host is still running

--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -219,6 +219,8 @@ Feature: CLI tests
         Then I get the last instance id from config
         And I get instance info
         And I execute CLI with "inst kill -" arguments
-        And wait for "8000" ms
+        And wait for instance healthy is "false"
+        # Give instance some time to close correctly
+        And wait for "1000" ms
         And I execute CLI with "seq rm -" arguments
         And host is still running

--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -143,14 +143,13 @@ Feature: CLI tests
         And host is still running
 
     @ci @cli
-    Scenario: E2E-010 TC-017
+    Scenario: E2E-010 TC-017 Get 404 on health endpoint for finished instance
         Given host is running
         When I execute CLI with bash command "$SI seq send ../packages/reference-apps/inert-function.tar.gz --format json"
         Then I get Sequence id
         Then I start Sequence
         Then I get instance health
-        Then wait for "20000" ms
-        Then health outputs 404
+        Then I wait for instance health status to change from 200 to 404
         And host is still running
 
     @ci @cli @starts-host


### PR DESCRIPTION
Instead of random timeouts, tests will try to use more reliable methods to determine if, for example, instance was stopped.

```
yarn test:bdd-ci --name="E2E"
```

Before:

```
29 scenarios (29 passed)
225 steps (225 passed)
5m25.421s (executing steps: 5m24.514s)
```

After:

```
29 scenarios (29 passed)
226 steps (226 passed)
4m59.492s (executing steps: 4m58.617s)
```

**Another ~25 seconds saved** :hourglass_flowing_sand:  