### PR TITLE
Fix error details

### DIFF
--- a/packages/cli/src/lib/output.ts
+++ b/packages/cli/src/lib/output.ts
@@ -46,10 +46,14 @@ export async function displayStream(
     output: Writable = process.stdout
 ): Promise<void> {
     try {
-        const resp = (await response) as unknown as Readable;
+        const resp = await response as unknown as Readable;
 
-        resp.pipe(output);
-        return new Promise((res, rej) => resp.on("finish", res).on("error", rej));
+        if (resp) {
+            resp.pipe(output);
+            return new Promise((res, rej) => resp.on("finish", res).on("error", rej));
+        }
+
+        return Promise.reject(new Error("Stream is not available"));
     } catch (e: any) {
         console.error(e && e.stack || e);
         process.exitCode = e.exitCode || 1;
@@ -65,7 +69,9 @@ export async function displayStream(
  */
 export async function displayEntity(_program: Command, response: Promise<any>): Promise<void> {
     // todo: different displays depending on _program.opts().format
-    const res = await response;
+    const res = await response.catch(e => {
+        console.error(e);
+    });
 
     if (!res) {
         return;

--- a/packages/client-utils/src/client-error.ts
+++ b/packages/client-utils/src/client-error.ts
@@ -6,28 +6,25 @@
 export class QueryError extends Error {
     /** The requested url. */
     public readonly url: string;
+
     /** The HTTP status code. */
-    public readonly code: number;
+    public readonly code: string;
+
     /** The returned response body as a string */
-    public readonly body: string;
+    public readonly body?: string;
+
     /** The original {@link Response} object */
-    public readonly response: Response;
+    public readonly response?: Response;
 
-    #json: unknown;
-
-    public constructor(url: string, code: number, response: Response, body: string) {
+    public constructor(url: string, code: string, response?: Response, body?: string) {
         super(`Failed to request '${url}' with code ${code}.`);
         this.url = url;
         this.code = code;
         this.body = body;
         this.response = response;
-        this.#json = null;
-    }
-
-    public toJSON() {
-        return this.#json ?? (this.#json = JSON.parse(this.body));
     }
 }
+
 export type ClientErrorCode =
     | "GENERAL_ERROR"
     | "BAD_PARAMETERS"
@@ -43,34 +40,36 @@ export type ClientErrorCode =
     | "INSUFFICIENT_RESOURCES";
 
 export class ClientError extends Error {
-    reason?: QueryError;
+    reason?: Error;
     source?: Error;
     code: string;
+    status?: string;
+    body: any;
 
     constructor(code: ClientErrorCode, reason?: Error | string, message?: string, source?: Error) {
         super(message || (reason instanceof Error ? reason.message : reason));
 
         this.code = code;
-        if (reason instanceof Error) this.reason = reason as QueryError;
+
+        if (reason instanceof Error) this.reason = reason;
         if (source instanceof Error) this.source = source;
+        if (reason instanceof QueryError) this.body = reason.body;
+        if (reason instanceof QueryError) this.status = reason.code;
     }
 
     // eslint-disable-next-line complexity
     static from(error: Error | QueryError, message?: string, source?: Error): ClientError {
-        if (error instanceof ClientError) {
-            return error;
-        } else if (error instanceof QueryError) {
-            // eslint-disable-next-line no-console
-            console.error(error);
-
+        if (error instanceof QueryError) {
             if (error.code) {
-                if (error.code === 400) return new this("BAD_PARAMETERS", error, message, source);
-                if (error.code === 401) return new this("NEED_AUTHENTICATION", error, message, source);
-                if (error.code === 403) return new this("NOT_AUTHORIZED", error, message, source);
-                if (error.code === 404) return new this("NOT_FOUND", error, message, source);
-                if (error.code === 410) return new this("GONE", error, message, source);
-                if (error.code === 507) return new this("INSUFFICIENT_RESOURCES", error, message, source);
-                //if (error.code === "ECONNREFUSED") return new this("CANNOT_CONNECT", error, message, source);
+                const code = error.code.toString();
+
+                if (code === "400") return new this("BAD_PARAMETERS", error, message, source);
+                if (code === "401") return new this("NEED_AUTHENTICATION", error, message, source);
+                if (code === "403") return new this("NOT_AUTHORIZED", error, message, source);
+                if (code === "404") return new this("NOT_FOUND", error, message, source);
+                if (code === "410") return new this("GONE", error, message, source);
+                if (code === "507") return new this("INSUFFICIENT_RESOURCES", error, message, source);
+                if (code === "ECONNREFUSED") return new this("CANNOT_CONNECT", error, message, source);
                 if (+error.code >= 500) return new this("SERVER_ERROR", error, message, source);
                 if (+error.code >= 400) return new this("REQUEST_ERROR", error, message, source);
                 return new this("UNKNOWN_ERROR", error, `Response code is "${error.code}"`, source);
@@ -78,5 +77,19 @@ export class ClientError extends Error {
             return new this("CANNOT_CONNECT", error);
         }
         return new this("GENERAL_ERROR", error);
+    }
+
+    async toJSON() {
+        return new Promise((res, rej) => {
+            try {
+                if (this.body) {
+                    res(JSON.parse(this.body));
+                } else {
+                    rej();
+                }
+            } catch (error) {
+                rej(error);
+            }
+        });
     }
 }


### PR DESCRIPTION
fixes providing error details in ```client-utils```

```
const response = await instanceClient.get(non-existing-id).catch((error: ClientError) => {
    console.log(error.code) // {ClientErrorCode = "GENERAL_ERROR" | "BAD_PARAMETERS" | "NEED_AUTHENTICATION" ....    
}); 
```

exposes ```body``` in error from fetch result allowing to read response in addition to error code.

```
const response = await instanceClient.get(non-existing-id).catch((error: ClientError) => {
    console.log(await error.toJSON()) // {"error":{"code":"PRERUNNER_ERROR","data":"Invalid pkg tar.gz archive"}}
});
