### PR TITLE
Run release tests with parallel option

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -49,8 +49,11 @@ jobs:
       - name: Start sth
         run: scramjet-transform-hub >> scramjet.log 2>&1 &
 
-      - name: Run BDD npm tests
-        run: SCRAMJET_TEST_LOG=1 SCRAMJET_HOST_BASE_URL="http://127.0.0.1:8000/api/v1" NO_HOST=1 yarn test:bdd-ci
+      - name: Run BDD npm tests (parallel)
+        run: SCRAMJET_TEST_LOG=1 SCRAMJET_HOST_BASE_URL="http://127.0.0.1:8000/api/v1" NO_HOST=1 yarn test:bdd-ci --tags="not @no-parallel" --parallel=2 --format=summary
+
+      - name: Run BDD npm tests (no-parallel)
+        run: SCRAMJET_TEST_LOG=1 SCRAMJET_HOST_BASE_URL="http://127.0.0.1:8000/api/v1" NO_HOST=1 yarn test:bdd-ci --tags="@no-parallel"
 
       - name: Show logs
         if: always()

--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -199,7 +199,8 @@ Feature: CLI tests
         Then confirm data named "hello-input-out-10" received
         * stop host
 
-    @ci @cli
+    # This tests writes and uses shared config file so it may fail if run in parallel
+    @ci @cli @no-parallel
     Scenario: E2E-010 TC-022 Check minus set/remove
         Given I execute CLI with "seq select abc" arguments
         And I execute CLI with "inst select def" arguments
@@ -208,7 +209,8 @@ Feature: CLI tests
         And The sequence id equals "abc"
         And The instance id equals "def"
 
-    @ci @cli
+    # This tests writes and uses shared config file so it may fail if run in parallel
+    @ci @cli @no-parallel
     Scenario: E2E-010 TC-023 Check minus replacements with a sequence
         Given host is running
         When I execute CLI with "pack ../dist/reference-apps/checksum-sequence" arguments

--- a/bdd/step-definitions/e2e/cli.ts
+++ b/bdd/step-definitions/e2e/cli.ts
@@ -7,6 +7,7 @@ import fs from "fs";
 import { STHRestAPI } from "@scramjet/types";
 import { getStreamsFromSpawn, defer } from "../../lib/utils";
 import { expectedResponses } from "./expectedResponses";
+import { CustomWorld } from "../world";
 
 // eslint-disable-next-line no-nested-ternary
 const si = process.env.SCRAMJET_SPAWN_JS
@@ -20,36 +21,35 @@ const connectionFlags = () => process.env.LOCAL_HOST_BASE_URL
 ;
 const formatFlags = () => ["-L", "--format", "json"];
 
-let stdio: [stdout: string, stderr: string, statusCode: any];
-let stdio1: [stdout: string, stderr: string, statusCode: any];
-let stdio2: [stdout: string, stderr: string, statusCode: any];
-let sequenceId: string;
-let sequence1Id: string;
-let sequence2Id: string;
-let instanceId: string;
-let instance1Id: string;
-let instance2Id: string;
-let sequences: any;
-
 When("I execute CLI with bash command {string}", { timeout: 30000 }, async function(cmd: string) {
-    stdio = await getStreamsFromSpawn("/bin/bash", ["-c", `${cmd} ${connectionFlags().join(" ")}`], { ...process.env, SI: si.join(" ") });
-    assert.equal(stdio[2], 0);
+    const res = (this as CustomWorld).cliResources;
+
+    res.stdio = await getStreamsFromSpawn("/bin/bash", ["-c", `${cmd} ${connectionFlags().join(" ")}`], { ...process.env, SI: si.join(" ") });
+    assert.equal(res.stdio[2], 0);
 });
 
 When("I execute CLI with {string} arguments", { timeout: 30000 }, async function(args: string) {
-    stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, ...args.split(" "), ...connectionFlags()]);
+    const res = (this as CustomWorld).cliResources;
+
+    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, ...args.split(" "), ...connectionFlags()]);
 
     if (process.env.SCRAMJET_TEST_LOG) {
-        console.error(stdio);
+        console.error(res.stdio);
     }
-    assert.equal(stdio[2], 0);
+    assert.equal(res.stdio[2], 0);
 });
 
 Then("I get a help information", function() {
-    assert.equal(stdio[0].includes("Usage:"), true);
+    const res = (this as CustomWorld).cliResources;
+    const stdio = res.stdio || [];
+
+    assert.equal(stdio[0]?.includes("Usage:"), true);
 });
 
 Then("the exit status is {int}", function(status: number) {
+    const res = (this as CustomWorld).cliResources;
+    const stdio = res.stdio || [];
+
     if (stdio[2] !== status) {
         console.error(stdio);
         assert.equal(stdio[2], status);
@@ -62,159 +62,199 @@ Then("I get location {string} of compressed directory", function(filepath: strin
 });
 
 Then("I get Sequence id", function() {
-    const seq = JSON.parse(stdio[0].replace("\n", ""));
+    const res = (this as CustomWorld).cliResources;
+    const stdio = res.stdio || [];
 
-    sequenceId = seq._id;
-    assert.equal(typeof sequenceId !== "undefined", true);
+    const seq = JSON.parse((stdio[0] || "").replace("\n", ""));
+
+    res.sequenceId = seq._id;
+    assert.equal(typeof res.sequenceId !== "undefined", true);
 });
 
 Then("I get id from both sequences", function() {
-    const seq1 = JSON.parse(stdio[0].replace("\n", ""))[0];
-    const seq2 = JSON.parse(stdio[0].replace("\n", ""))[1];
+    const res = (this as CustomWorld).cliResources;
+    const stdio = res.stdio || [];
 
-    sequence1Id = seq1.id;
-    sequence2Id = seq2.id;
+    const seq1 = JSON.parse((stdio[0] || "").replace("\n", ""))[0];
+    const seq2 = JSON.parse((stdio[0] || "").replace("\n", ""))[1];
 
-    assert.equal(typeof sequence1Id && typeof sequence2Id !== "undefined", true);
+    res.sequence1Id = seq1.id;
+    res.sequence2Id = seq2.id;
+
+    assert.equal(typeof res.sequence1Id && typeof res.sequence2Id !== "undefined", true);
 });
 
 Then("I start the first sequence", async function() {
+    const res = (this as CustomWorld).cliResources;
+    const sequence1Id: string = res.sequence1Id || "";
+
     try {
-        stdio1 = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "start", sequence1Id, ...formatFlags(), ...connectionFlags()]);
-        assert.equal(stdio1[2], 0);
+        res.stdio1 = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "start", sequence1Id, ...formatFlags(), ...connectionFlags()]);
+        assert.equal(res.stdio1[2], 0);
 
         if (process.env.SCRAMJET_TEST_LOG) {
-            console.error(stdio1[0]);
+            console.error(res.stdio1[0]);
         }
 
-        const instance1 = JSON.parse(stdio1[0].replace("\n", ""));
+        const instance1 = JSON.parse(res.stdio1[0].replace("\n", ""));
 
-        instance1Id = instance1._id;
+        res.instance1Id = instance1._id;
 
-        assert.equal(typeof instance1Id !== "undefined", true);
+        assert.equal(typeof res.instance1Id !== "undefined", true);
     } catch (e: any) {
-        console.error(e.stack, stdio);
+        console.error(e.stack, res.stdio);
         assert.fail("Error occurred");
     }
 });
 
 Then("I start the second sequence", async function() {
+    const res = (this as CustomWorld).cliResources;
+    const sequence2Id: string = res.sequence2Id || "";
+
     try {
-        stdio2 = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "start", sequence2Id, ...formatFlags(), ...connectionFlags()]);
-        assert.equal(stdio2[2], 0);
+        res.stdio2 = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "start", sequence2Id, ...formatFlags(), ...connectionFlags()]);
+        assert.equal(res.stdio2[2], 0);
 
         if (process.env.SCRAMJET_TEST_LOG) {
-            console.error(stdio2[0]);
+            console.error(res.stdio2[0]);
         }
 
-        const instance2 = JSON.parse(stdio2[0].replace("\n", ""));
+        const instance2 = JSON.parse(res.stdio2[0].replace("\n", ""));
 
-        instance2Id = instance2._id;
+        res.instance2Id = instance2._id;
 
-        assert.equal(typeof instance2Id !== "undefined", true);
+        assert.equal(typeof res.instance2Id !== "undefined", true);
     } catch (e: any) {
-        console.error(e.stack, stdio);
+        console.error(e.stack, res.stdio);
         assert.fail("Error occurred");
     }
 });
 
 Then("I get Host load information", function() {
-    assert.equal(stdio[0].includes("avgLoad:"), true);
+    const res = (this as CustomWorld).cliResources;
+    const stdio = res.stdio || [];
+
+    assert.equal(stdio[0]?.includes("avgLoad:"), true);
 });
 
 Then("I get array of information about sequences", function() {
-    const arr = JSON.parse(stdio[0].replace("\n", ""));
+    const res = (this as CustomWorld).cliResources;
+    const stdio = res.stdio || [];
+    const arr = JSON.parse((stdio[0] || "").replace("\n", ""));
 
     assert.equal(Array.isArray(arr), true);
 });
 
 Then('I get the last instance id from config', async function() {
-    // Write code here that turns the phrase above into concrete actions
-    stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "config", "p", "--format", "json"]);
-    instanceId = JSON.parse(stdio[0]).lastInstanceId;
+    const res = (this as CustomWorld).cliResources;
 
-    assert.ok(typeof instanceId === "string", "instanceId must be defined");
-    assert.ok(instanceId.length > 0, "Instance id is not empty");
+    // Write code here that turns the phrase above into concrete actions
+    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "config", "p", "--format", "json"]);
+    res.instanceId = JSON.parse(res.stdio[0]).lastInstanceId;
+
+    assert.ok(typeof res.instanceId === "string", "instanceId must be defined");
+    assert.ok(res.instanceId.length > 0, "Instance id is not empty");
 });
 
 Then('I get the last sequence id from config', async function() {
+    const res = (this as CustomWorld).cliResources;
+
     // Write code here that turns the phrase above into concrete actions
-    stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "config", "p", "--format", "json"]);
+    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "config", "p", "--format", "json"]);
     if (process.env.SCRAMJET_TEST_LOG) {
-        console.error(stdio);
+        console.error(res.stdio);
     }
 
-    sequenceId = JSON.parse(stdio[0]).lastSequenceId;
+    res.sequenceId = JSON.parse(res.stdio[0]).lastSequenceId;
 
-    assert.ok(typeof sequenceId === "string", "sequenceId must be defined");
-    assert.ok(sequenceId.length > 0, "Sequence id is not empty");
+    assert.ok(typeof res.sequenceId === "string", "sequenceId must be defined");
+    assert.ok(res.sequenceId.length > 0, "Sequence id is not empty");
 });
 
 Then('The sequence id equals {string}', function(str: string) {
-    assert.strictEqual(str, sequenceId);
+    const res = (this as CustomWorld).cliResources;
+
+    assert.strictEqual(str, res.sequenceId);
 });
 
 Then('The instance id equals {string}', function(str: string) {
-    assert.strictEqual(str, instanceId);
+    const res = (this as CustomWorld).cliResources;
+
+    assert.strictEqual(str, res.instanceId);
 });
 
 Then("I start Sequence", async function() {
+    const res = (this as CustomWorld).cliResources;
+    const sequenceId: string = res.sequenceId || "";
+
     try {
-        stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "start", sequenceId, ...formatFlags(), ...connectionFlags()]);
-        assert.equal(stdio[2], 0);
+        res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "start", sequenceId, ...formatFlags(), ...connectionFlags()]);
+        assert.equal(res.stdio[2], 0);
 
         if (process.env.SCRAMJET_TEST_LOG) {
-            console.error(stdio[0]);
+            console.error(res.stdio[0]);
         }
 
-        const instance = JSON.parse(stdio[0].replace("\n", ""));
+        const instance = JSON.parse(res.stdio[0].replace("\n", ""));
 
-        instanceId = instance._id;
+        res.instanceId = instance._id;
     } catch (e: any) {
-        console.error(e.stack, stdio);
+        console.error(e.stack, res.stdio);
         assert.fail("Error occurred");
     }
 });
 
 Then("I get instance id", function() {
-    assert.equal(typeof instanceId !== "undefined", true);
+    const res = (this as CustomWorld).cliResources;
+
+    assert.equal(typeof res.instanceId !== "undefined", true);
 });
 
 Then("I kill instance", async function() {
-    stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "kill", instanceId, ...formatFlags(), ...connectionFlags()]);
+    const res = (this as CustomWorld).cliResources;
 
-    assert.equal(stdio[2], 0);
+    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "kill", res.instanceId || "", ...formatFlags(), ...connectionFlags()]);
+
+    assert.equal(res.stdio[2], 0);
 });
 
 Then("I delete sequence", { timeout: 10000 }, async function() {
-    stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "delete", sequenceId, ...formatFlags(), ...connectionFlags()]);
+    const res = (this as CustomWorld).cliResources;
 
-    assert.equal(stdio[2], 0);
+    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "delete", res.sequenceId || "", ...formatFlags(), ...connectionFlags()]);
+
+    assert.equal(res.stdio[2], 0);
 });
 
 Then("I get instance health", { timeout: 10000 }, async function() {
-    stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "health", instanceId, ...formatFlags(), ...connectionFlags()]);
+    const res = (this as CustomWorld).cliResources;
 
-    assert.equal(stdio[2], 0);
-    const msg = JSON.parse(stdio[0].replace("\n", ""));
+    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "health", res.instanceId || "", ...formatFlags(), ...connectionFlags()]);
+
+    assert.equal(res.stdio[2], 0);
+    const msg = JSON.parse((res.stdio[0] || "").replace("\n", ""));
 
     assert.equal(typeof msg.healthy !== "undefined", true);
 });
 
-Then("health outputs 404", async () => {
-    stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "health", instanceId, ...connectionFlags()]);
-    assert.equal(stdio[1].includes("404"), true);
+Then("health outputs 404", async function() {
+    const res = (this as CustomWorld).cliResources;
+
+    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "health", res.instanceId || "", ...connectionFlags()]);
+    assert.equal(res.stdio[1].includes("404"), true);
 });
 
-Then("I wait for instance health status to change from 200 to 404", { timeout: 20000 }, async () => {
+Then("I wait for instance health status to change from 200 to 404", { timeout: 20000 }, async function() {
+    const res = (this as CustomWorld).cliResources;
+
     let success = false;
 
     while (!success) {
-        stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "health", instanceId, ...connectionFlags()]);
+        res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "health", res.instanceId || "", ...connectionFlags()]);
 
-        if (stdio[1].includes("code \"404\" status")) {
+        if (res.stdio[1].includes("code \"404\" status")) {
             success = true;
-        } else if (!stdio[1].includes("status: 200 OK")) {
+        } else if (!res.stdio[1].includes("status: 200 OK")) {
             assert.fail();
         }
 
@@ -225,70 +265,93 @@ Then("I wait for instance health status to change from 200 to 404", { timeout: 2
 });
 
 Then("I get instance log", { timeout: 30000 }, async function() {
-    stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "log", instanceId, ...connectionFlags()]);
-    assert.equal(stdio[2], 0);
+    const res = (this as CustomWorld).cliResources;
+
+    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "log", res.instanceId || "", ...connectionFlags()]);
+    assert.equal(res.stdio[2], 0);
 });
 
 Then("I get instance output", { timeout: 30000 }, async function() {
-    stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "output", instanceId, ...connectionFlags()]);
-    assert.equal(stdio[2], 0);
+    const res = (this as CustomWorld).cliResources;
+
+    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "output", res.instanceId || "", ...connectionFlags()]);
+    assert.equal(res.stdio[2], 0);
 });
 
 Then("I get the second instance output", { timeout: 30000 }, async function() {
-    stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "output", instance2Id, ...connectionFlags()]);
-    assert.equal(stdio[2], 0);
+    const res = (this as CustomWorld).cliResources;
+
+    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "output", res.instance2Id || "", ...connectionFlags()]);
+    assert.equal(res.stdio[2], 0);
 });
 
 Then("I send input data {string}", async function(pathToFile: string) {
-    stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "input", instanceId, pathToFile, ...formatFlags(), ...connectionFlags()]);
-    assert.equal(stdio[2], 0);
+    const res = (this as CustomWorld).cliResources;
+
+    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "input", res.instanceId || "", pathToFile, ...formatFlags(), ...connectionFlags()]);
+    assert.equal(res.stdio[2], 0);
 });
 
 Then("I stop instance {string} {string}", async function(timeout: string, canCallKeepAlive: string) {
-    stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "stop", instanceId, timeout, canCallKeepAlive, ...formatFlags(), ...connectionFlags()]);
-    assert.equal(stdio[2], 0);
+    const res = (this as CustomWorld).cliResources;
+
+    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "stop", res.instanceId || "", timeout, canCallKeepAlive, ...formatFlags(), ...connectionFlags()]);
+    assert.equal(res.stdio[2], 0);
 });
 
 Then("I get list of sequences", async function() {
-    stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "ls", ...formatFlags(), ...connectionFlags()]);
-    assert.equal(stdio[2], 0);
-    sequences = JSON.parse(stdio[0].replace("\n", ""));
+    const res = (this as CustomWorld).cliResources;
 
-    assert.equal(sequences.length > 0, true);
+    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "ls", ...formatFlags(), ...connectionFlags()]);
+    assert.equal(res.stdio[2], 0);
+    res.sequences = JSON.parse(res.stdio[0].replace("\n", ""));
+
+    assert.equal(res.sequences.length > 0, true);
 });
 
 Then("I get list of instances", async function() {
-    stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "ls", ...formatFlags(), ...connectionFlags()]);
+    const res = (this as CustomWorld).cliResources;
 
-    assert.equal(stdio[2], 0);
-    const instances = JSON.parse(stdio[0].replace("\n", "")) as STHRestAPI.GetInstancesResponse;
+    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "ls", ...formatFlags(), ...connectionFlags()]);
 
-    const instanceFound = instances.some(({ id }) => id === instanceId);
+    assert.equal(res.stdio[2], 0);
+    const instances = JSON.parse(res.stdio[0].replace("\n", "")) as STHRestAPI.GetInstancesResponse;
+
+    const instanceFound = instances.some(({ id }) => id === res.instanceId);
 
     assert.equal(instanceFound, true);
 });
 
 Then("I get instance info", async function() {
-    stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "info", instanceId, ...formatFlags(), ...connectionFlags()]);
-    assert.equal(stdio[2], 0);
-    const info = JSON.parse(stdio[0].replace("\n", ""));
+    const res = (this as CustomWorld).cliResources;
+
+    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "info", res.instanceId || "", ...formatFlags(), ...connectionFlags()]);
+    assert.equal(res.stdio[2], 0);
+    const info = JSON.parse(res.stdio[0].replace("\n", ""));
     const seqId = info.sequence;
 
-    assert.equal(seqId, sequenceId);
+    assert.equal(seqId, res.sequenceId);
 });
 
 When("I send an event named {string} with event message {string} to Instance", async function(eventName: string, eventMsg: string) {
-    stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "emit", instanceId, eventName, eventMsg, ...formatFlags(), ...connectionFlags()]);
-    assert.equal(stdio[2], 0);
+    const res = (this as CustomWorld).cliResources;
+
+    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "emit", res.instanceId || "", eventName, eventMsg, ...formatFlags(), ...connectionFlags()]);
+    assert.equal(res.stdio[2], 0);
 });
 
 Then("I get event {string} with event message {string} from instance", async function(eventName: string, value: string) {
-    stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "on", instanceId, eventName, ...formatFlags(), ...connectionFlags()]);
-    assert.equal(stdio[2], 0);
-    assert.equal(stdio[0].trim(), value);
+    const res = (this as CustomWorld).cliResources;
+
+    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "on", res.instanceId || "", eventName, ...formatFlags(), ...connectionFlags()]);
+    assert.equal(res.stdio[2], 0);
+    assert.equal(res.stdio[0].trim(), value);
 });
 
 Then("confirm data named {string} received", async function(data) {
+    const res = (this as CustomWorld).cliResources;
+    const stdio = res.stdio || [];
+
     console.log("Received data:\n", stdio[0]);
     assert.equal(stdio[0], expectedResponses[data]);
 });

--- a/bdd/step-definitions/world.ts
+++ b/bdd/step-definitions/world.ts
@@ -19,6 +19,19 @@ export class CustomWorld implements World {
         sequence2?: SequenceClient
     } = {}
 
+    cliResources: {
+        stdio?: [stdout: string, stderr: string, statusCode: any];
+        stdio1?: [stdout: string, stderr: string, statusCode: any];
+        stdio2?: [stdout: string, stderr: string, statusCode: any];
+        sequenceId?: string;
+        sequence1Id?: string;
+        sequence2Id?: string;
+        instanceId?: string;
+        instance1Id?: string;
+        instance2Id?: string;
+        sequences?: any;
+    } = {};
+
     constructor({ attach, log, parameters }: any) {
         this.attach = attach;
         this.log = log;


### PR DESCRIPTION
This PR adds `--parallel 2` flag to "release tests" run on CI. I also had to get rid of "global" `let`s in CLI test steps (it still needs a proper cleanup but I wasn't focusing on that :see_no_evil:). After few runs it seems like tests are stable.

OTOH, I tried to do the same with "dev tests" and there was always something failing, kind of randomly. So it looks like we need to clean up and rework those tests a bit to make it run with `--parallel` option.

**Good news** - release tests instead of usual 7 to 9 minutes:

![image](https://user-images.githubusercontent.com/1061942/156798383-d136324f-18f1-448e-ad1f-6a314a94dc0e.png)

now are done in around 5 minutes:

![image](https://user-images.githubusercontent.com/1061942/156797300-f4c85f69-60a0-4dde-8e27-58ad68ef251e.png)

**Bad news** - due to [issue with mixed up logs](https://github.com/cucumber/cucumber-js-pretty-formatter/issues/13), for parallel run I changed formatter to `progress` which means it might be harder to conclude something (when test fails) looking on CI output, because there will be no steps (or if enabled, it will be mixed up).