### PR TITLE
Revert "Don't append '.js` extension to sequence entrypoint"

### DIFF
--- a/packages/reference-apps/hello-alice-out/package.json
+++ b/packages/reference-apps/hello-alice-out/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scramjet/hello-alice-out",
   "version": "0.18.0",
-  "main": "index.js",
+  "main": "index",
   "assets": [
     "data.json"
   ],

--- a/packages/reference-apps/hello-hulk-out/package.json
+++ b/packages/reference-apps/hello-hulk-out/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scramjet/hello-hulk-out",
   "version": "0.18.0",
-  "main": "index.js",
+  "main": "index",
   "scripts": {
     "build:refapps": "tsc -p tsconfig.json",
     "postbuild:refapps": "yarn prepack && yarn packseq",

--- a/packages/reference-apps/hello-input-out/package.json
+++ b/packages/reference-apps/hello-input-out/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scramjet/hello-input-out",
   "version": "0.18.0",
-  "main": "index.js",
+  "main": "index",
   "scripts": {
     "build:refapps": "tsc -p tsconfig.json",
     "postbuild:refapps": "yarn prepack && yarn packseq",

--- a/packages/runner/src/bin/start-runner.ts
+++ b/packages/runner/src/bin/start-runner.ts
@@ -5,7 +5,7 @@ import fs from "fs";
 import { AppConfig } from "@scramjet/types";
 import { HostClient } from "../host-client";
 
-const sequencePath: string = process.env.SEQUENCE_PATH ?? "";
+const sequencePath: string = process.env.SEQUENCE_PATH?.replace(/.js$/, "") + ".js";
 const instancesServerPort = process.env.INSTANCES_SERVER_PORT;
 const instancesServerHost = process.env.INSTANCES_SERVER_HOST;
 const instanceId = process.env.INSTANCE_ID;


### PR DESCRIPTION
Restore backwards compatibility.
This reverts commit cbebb3e67379598930994f6d958a24b07f311349.

Fixes #314 .