### PR TITLE
STH: update docker to bullseye, silent yarn

### DIFF
--- a/packages/sth/Dockerfile
+++ b/packages/sth/Dockerfile
@@ -1,6 +1,4 @@
-FROM node:lts-buster-slim as builder
-
-RUN apt-get update && apt-get upgrade -y
+FROM node:lts-bullseye-slim as builder
 
 WORKDIR /build
 
@@ -25,12 +23,10 @@ COPY scripts ./scripts
 COPY conf ./conf
 COPY LICENSE ./
 
-RUN yarn install --frozen-lock \
+RUN yarn install --frozen-lock --silent \
   && yarn build:packages
 
-FROM node:lts-buster-slim as release
-
-RUN apt-get update && apt-get upgrade -y
+FROM node:lts-bullseye-slim as release
 
 RUN set -xe \
   && mkdir -p /app


### PR DESCRIPTION
- Upgrade STH docker image to Bullseye
- Silent yarn install
- remove problematic apt update/upgrade 