### PR TITLE
Add HTTPS support to Verser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ aaa/
 **/__pycache__/
 
 **/__pydeps__/**
+*.{crt,csr,ext,key,pem,srl}

--- a/packages/host/src/lib/cpm-connector.ts
+++ b/packages/host/src/lib/cpm-connector.ts
@@ -75,13 +75,6 @@ export class CPMConnector extends TypedEmitter<Events> {
     config: CPMConnectorOptions;
 
     /**
-     * Server to handle request coming from Manager.
-     *
-     * @type {Server}
-     */
-    apiServer?: Server;
-
-    /**
      * Connection status indicator.
      *
      * @type {boolean}
@@ -244,16 +237,6 @@ export class CPMConnector extends TypedEmitter<Events> {
 
             return {};
         }
-    }
-
-    /**
-     * Sets up server to handle incoming requests.
-     *
-     * @param {Server} server Server to handle incoming requests from connected manager.
-     */
-    attachServer(server: Server & { httpAllowHalfOpen?: boolean }) {
-        this.apiServer = server;
-        server.httpAllowHalfOpen = true;
     }
 
     /**

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -2,7 +2,7 @@ import findPackage from "find-package-json";
 import { ReasonPhrases } from "http-status-codes";
 
 import { Readable, Writable } from "stream";
-import { IncomingMessage, ServerResponse } from "http";
+import { IncomingMessage, Server, ServerResponse } from "http";
 import { AddressInfo } from "net";
 
 import { APIExpose, AppConfig, IComponent, IObjectLogger, LogLevel, NextCallback, ParsedMessage, SequenceInfo, STHConfiguration, STHRestAPI } from "@scramjet/types";
@@ -142,6 +142,8 @@ export class Host implements IComponent {
         }
 
         if (this.config.cpmUrl) {
+            (this.api.server as Server & { httpAllowHalfOpen?: boolean }).httpAllowHalfOpen = true;
+
             this.cpmConnector = new CPMConnector(
                 this.config.cpmUrl,
                 { id: this.config.host.id, infoFilePath: this.config.host.infoFilePath },
@@ -210,7 +212,6 @@ export class Host implements IComponent {
      * Initializes connector and connects to Manager.
      */
     connectToCPM() {
-        this.cpmConnector?.attachServer(this.api.server);
         this.cpmConnector?.init();
 
         this.cpmConnector?.on("connect", async () => {

--- a/packages/verser/package.json
+++ b/packages/verser/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node ./src/bin/index",
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf ./dist .bic_cache",
-    "test": "echo no tests yet -- # npm run test:ava",
+    "test": "npm run test:ava",
     "test:ava": "ava",
     "prepack": "node ../../scripts/publish.js",
     "postbuild": "yarn prepack"
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@scramjet/types": "^0.18.6",
+    "@scramjet/api-server": "0.18.6",
     "@types/node": "15.12.5",
     "ava": "^3.15.0",
     "ts-node": "^10.7.0",

--- a/packages/verser/src/lib/verser-client.ts
+++ b/packages/verser/src/lib/verser-client.ts
@@ -1,4 +1,5 @@
-import { OutgoingHttpHeaders, request, Agent } from "http";
+import { OutgoingHttpHeaders, Agent as HttpAgent } from "http";
+import { Agent as HttpsAgent, request } from "https";
 import { merge, TypedEmitter } from "@scramjet/utility";
 import { IObjectLogger } from "@scramjet/types";
 import { VerserClientOptions, VerserClientConnection, RegisteredChannels, RegisteredChannelCallback } from "../types";
@@ -32,7 +33,7 @@ export class VerserClient extends TypedEmitter<Events> {
      *
      * @type {http.Agent} @see https://nodejs.org/api/http.html#http_class_http_agent.
      */
-    private agent: Agent;
+    private agent: HttpsAgent | HttpAgent;
 
     /**
      * Connection socket.
@@ -57,7 +58,7 @@ export class VerserClient extends TypedEmitter<Events> {
         super();
 
         this.opts = opts;
-        this.agent = new Agent({ keepAlive: true });
+        this.agent = this.opts.https ? new HttpsAgent({ keepAlive: true }) : new HttpAgent({ keepAlive: true });
     }
 
     /**
@@ -76,7 +77,9 @@ export class VerserClient extends TypedEmitter<Events> {
                 hostname,
                 method: "CONNECT",
                 pathname,
-                port
+                port,
+                protocol: this.opts.https ? "https:" : "http:",
+                ca: typeof this.opts.https === "object" ? this.opts.https.ca : undefined,
             });
 
             connectRequest.on("error", (err) => {

--- a/packages/verser/src/types/index.ts
+++ b/packages/verser/src/types/index.ts
@@ -24,6 +24,8 @@ export type VerserClientOptions = {
      * @type {Server}
      */
     server?: Server;
+
+    https?: false | true | { ca: (string | Buffer)[] }
 };
 
 /**

--- a/packages/verser/test/cert/cleanup-localhost-cert.sh
+++ b/packages/verser/test/cert/cleanup-localhost-cert.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+rm {localhost,myCA}.*

--- a/packages/verser/test/cert/gen-localhost-cert.sh
+++ b/packages/verser/test/cert/gen-localhost-cert.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Private key for root CA
+openssl genrsa -des3 -out myCA.key -passout pass:test 2048
+
+#  root CA
+openssl req -x509 -new -nodes -key myCA.key -sha256 -days 825 -out myCA.pem -passin pass:test -subj '/CN=www.mydom.com/O=My Company Name LTD./C=US'
+
+# key for cert
+openssl genrsa -out localhost.key 2048
+
+# cert
+openssl req -new -key localhost.key -out localhost.csr -subj '/CN=localhost/O=My Company Name LTD./C=US'
+
+>localhost.ext cat <<-EOF
+authorityKeyIdentifier = keyid,issuer
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = localhost
+IP.1 = 127.0.0.1
+EOF
+
+# sign cert
+openssl x509 -req -in localhost.csr -CA myCA.pem -CAkey myCA.key -passin pass:test -CAcreateserial -out localhost.crt -days 825 -sha256 -extfile localhost.ext
+

--- a/packages/verser/test/http-connection.spec.ts
+++ b/packages/verser/test/http-connection.spec.ts
@@ -1,0 +1,134 @@
+import test from "ava";
+import * as http from "http";
+import * as https from "https";
+import { createServer } from "@scramjet/api-server";
+import { Verser, VerserClient, VerserConnection } from "../src";
+import path from "path";
+import { readFileSync } from "fs";
+import { APIExpose } from "@scramjet/types";
+import { spawnSync } from "child_process";
+
+async function connectVerserClientAToVerserB(
+    apiB: APIExpose,
+    verserClientA: VerserClient,
+): Promise<VerserConnection> {
+    const verserB = new Verser(apiB.server);
+
+    const connectionResolver = { res: (_conn: VerserConnection) => {} };
+    const connectionPromised = new Promise<VerserConnection>(res => { connectionResolver.res = res; });
+
+    verserB.on("connect", (verserConnection) => {
+        verserConnection.respond(200);
+        // @TODO we have to do that, which means that verser api is a bit off
+        verserConnection.reconnect();
+        connectionResolver.res(verserConnection);
+    });
+
+    await verserClientA.connect();
+
+    return connectionPromised;
+}
+
+function getJSONResponseFromRequest(request: http.ClientRequest): Promise<any> {
+    return new Promise<any>(resolve => {
+        request.on("response", async (response) => {
+            let responseBody = "";
+
+            for await (const chunk of response) {
+                responseBody += chunk;
+            }
+
+            resolve(JSON.parse(responseBody));
+        });
+    });
+}
+
+test("Connect VerserClient A to Verser B and send HTTP GET Request to VerserClient A", async (t) => {
+    const SERVER_B_PORT = 1999;
+    const apiB = createServer();
+
+    apiB.server.listen(SERVER_B_PORT);
+
+    const apiA = createServer();
+
+    // @TODO since this is alway needed, maybe we should be setting that in VerserClient?
+    (apiA.server as http.Server & { httpAllowHalfOpen?: boolean }).httpAllowHalfOpen = true;
+
+    const verserClientA = new VerserClient({
+        headers: { city: "Valencia" },
+        verserUrl: `http://127.0.0.1:${SERVER_B_PORT}`,
+        server: apiA.server
+    });
+
+    const verserConnectionB = await connectVerserClientAToVerserB(apiB, verserClientA);
+
+    t.is(verserConnectionB.getHeaders().city, "Valencia");
+
+    // Forward any request to B to A
+    apiB.use("*", (req, res) => verserConnectionB.forward(req, res));
+
+    apiA.get("*", () => ({ greeting: "Bye" }));
+
+    // Make request to B that should be forwarded to A
+    const requestToAThroughB = http.request({
+        port: SERVER_B_PORT,
+        method: "GET",
+    });
+
+    requestToAThroughB.end();
+
+    const responseFromAToB = await getJSONResponseFromRequest(requestToAThroughB);
+
+    // Verify that response from A got back
+    t.deepEqual(responseFromAToB, { greeting: "Bye" });
+});
+
+test("Connect VerserClient A to Verser B over SSL and send HTTPS GET Request to VerserClient A", async (t) => {
+    const certDir = path.join(__dirname, "cert");
+
+    spawnSync("./gen-localhost-cert.sh", { cwd: certDir });
+
+    const SERVER_B_PORT = 2000;
+    const apiB = createServer({
+        sslKeyPath: path.join(certDir, "localhost.key"),
+        sslCertPath: path.join(certDir, "localhost.crt"),
+    });
+
+    apiB.server.listen(SERVER_B_PORT);
+
+    const apiA = createServer();
+
+    (apiA.server as http.Server & { httpAllowHalfOpen?: boolean }).httpAllowHalfOpen = true;
+
+    const verserClientA = new VerserClient({
+        headers: { city: "Valencia" },
+        verserUrl: `https://127.0.0.1:${SERVER_B_PORT}`,
+        server: apiA.server,
+        https: { ca: [readFileSync(path.join(certDir, "myCA.pem"))] }
+    });
+
+    const verserConnectionB = await connectVerserClientAToVerserB(apiB, verserClientA);
+
+    t.is(verserConnectionB.getHeaders().city, "Valencia");
+
+    // Forward any request to B to A
+    apiB.use("*", (req, res) => verserConnectionB.forward(req, res));
+
+    apiA.get("*", () => ({ greeting: "Bye" }));
+
+    // Make request to B that should be forwarded to A
+    const requestToAThroughB = https.request({
+        port: SERVER_B_PORT,
+        method: "GET",
+        ca: [readFileSync(path.join(certDir, "myCA.pem"))]
+    });
+
+    requestToAThroughB.end();
+
+    const responseFromAToB = await getJSONResponseFromRequest(requestToAThroughB);
+
+    // Verify that response from A got back
+    t.deepEqual(responseFromAToB, { greeting: "Bye" });
+
+    spawnSync("./cleanup-localhost-cert.sh", { cwd: certDir });
+});


### PR DESCRIPTION
Changes include:
* Testing `Verser` for a standard HTTP flow 
* Testing `Verser` for a new HTTPS flow
* Git ignoring encryption secrets
* Tweaking `Verser` to support HTTPS
* Cleaning up CPMConnector from useless `attachServer` and `apiServer`

TODO:
* [ ] actually enable using https in Host and Manager (in a separate PR)
