### PR TITLE
Fix for sending data to topic via stdin

### DIFF
--- a/packages/cli/src/lib/commands/topic.ts
+++ b/packages/cli/src/lib/commands/topic.ts
@@ -20,7 +20,7 @@ export const topic: CommandDefinition = (program) => {
             program,
             getHostClient(program).sendNamedData(
                 topicName,
-                await getReadStreamFromFile(filename) || process.stdin,
+                filename ? await getReadStreamFromFile(filename) : process.stdin,
                 contentType,
                 end)
         ));


### PR DESCRIPTION
Should fix: https://github.com/scramjetorg/transform-hub/issues/310
The fix is based on a similar issue, which we had with sending the input: https://github.com/scramjetorg/transform-hub/pull/177

To verify:
1. Run the STH.
2. In one terminal window, get the topic:
`curl http://127.0.0.1:8000/api/v1/topic/test`
3. In another terminal window, send the topic via stdin:
`ts-node /home/agruzdz/code/transform-hub/packages/cli/src/bin/index.ts topic send test` [enter], type something and press [enter] again.