### PR TITLE
dependencies upgrade

### DIFF
--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -27,7 +27,7 @@
     "dockerode": "^3.3.1",
     "scramjet": "^4.36.6",
     "shell-escape": "^0.2.0",
-    "systeminformation": "^5.11.4",
+    "systeminformation": "^5.11.6",
     "ts.data.json": "^2.1.0"
   },
   "devDependencies": {
@@ -36,9 +36,9 @@
     "@types/node": "15.12.5",
     "@types/shell-escape": "^0.2.0",
     "ava": "^3.15.0",
-    "ts-node": "^10.5.0",
-    "typedoc": "0.22.11",
-    "typedoc-plugin-markdown": "3.11.12",
+    "ts-node": "^10.7.0",
+    "typedoc": "^0.22.12",
+    "typedoc-plugin-markdown": "^3.11.14",
     "typescript": "^4.5.5"
   },
   "ava": {

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -25,9 +25,9 @@
     "@scramjet/types": "^0.18.5",
     "@types/node": "15.12.5",
     "ava": "^3.15.0",
-    "ts-node": "^10.5.0",
-    "typedoc": "0.22.11",
-    "typedoc-plugin-markdown": "3.11.12",
+    "ts-node": "^10.7.0",
+    "typedoc": "^0.22.12",
+    "typedoc-plugin-markdown": "^3.11.14",
     "typescript": "^4.5.5"
   },
   "ava": {

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -30,9 +30,9 @@
     "ava": "^3.15.0",
     "sinon": "^11.1.2",
     "trouter": "^3.2.0",
-    "ts-node": "^10.5.0",
-    "typedoc": "0.22.11",
-    "typedoc-plugin-markdown": "3.11.12",
+    "ts-node": "^10.7.0",
+    "typedoc": "^0.22.12",
+    "typedoc-plugin-markdown": "^3.11.14",
     "typescript": "^4.5.5"
   },
   "ava": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,9 +32,9 @@
     "@types/node": "15.12.5",
     "@types/tar": "^4.0.5",
     "ava": "^3.15.0",
-    "ts-node": "^10.5.0",
-    "typedoc": "0.22.11",
-    "typedoc-plugin-markdown": "3.11.12",
+    "ts-node": "^10.7.0",
+    "typedoc": "^0.22.12",
+    "typedoc-plugin-markdown": "^3.11.14",
     "typescript": "^4.5.5"
   },
   "ava": {

--- a/packages/client-utils/package.json
+++ b/packages/client-utils/package.json
@@ -21,7 +21,7 @@
     "@scramjet/sth-config": "^0.18.5",
     "@scramjet/symbols": "^0.18.5",
     "n-readlines": "^1.0.1",
-    "node-fetch": "2.6.1",
+    "node-fetch": "^2.6.1",
     "scramjet": "^4.36.6"
   },
   "devDependencies": {

--- a/packages/client-utils/package.json
+++ b/packages/client-utils/package.json
@@ -21,17 +21,17 @@
     "@scramjet/sth-config": "^0.18.5",
     "@scramjet/symbols": "^0.18.5",
     "n-readlines": "^1.0.1",
-    "node-fetch": "^2.6.1",
+    "node-fetch": "^2.6.7",
     "scramjet": "^4.36.6"
   },
   "devDependencies": {
     "@scramjet/types": "^0.18.5",
     "@types/node": "15.12.5",
-    "@types/node-fetch": "^2.5.11",
+    "@types/node-fetch": "^2.6.1",
     "ava": "^3.15.0",
-    "ts-node": "^10.5.0",
-    "typedoc": "0.22.11",
-    "typedoc-plugin-markdown": "3.11.12",
+    "ts-node": "^10.7.0",
+    "typedoc": "^0.22.12",
+    "typedoc-plugin-markdown": "^3.11.14",
     "typescript": "^4.5.5"
   },
   "ava": {

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -32,16 +32,16 @@
     "minimist": "^1.2.5",
     "rereadable-stream": "^1.4.13",
     "scramjet": "^4.36.6",
-    "systeminformation": "^5.11.4"
+    "systeminformation": "^5.11.6"
   },
   "devDependencies": {
     "@scramjet/types": "^0.18.5",
     "@types/find-package-json": "^1.2.2",
     "@types/node": "15.12.5",
     "ava": "^3.15.0",
-    "ts-node": "^10.5.0",
-    "typedoc": "0.22.11",
-    "typedoc-plugin-markdown": "3.11.12",
+    "ts-node": "^10.7.0",
+    "typedoc": "^0.22.12",
+    "typedoc-plugin-markdown": "^3.11.14",
     "typescript": "^4.5.5"
   },
   "ava": {

--- a/packages/load-check/package.json
+++ b/packages/load-check/package.json
@@ -19,7 +19,7 @@
     "@scramjet/obj-logger": "^0.18.5",
     "@scramjet/utility": "^0.18.5",
     "scramjet": "^4.36.6",
-    "systeminformation": "^5.11.4",
+    "systeminformation": "^5.11.6",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
@@ -27,9 +27,9 @@
     "@types/node": "15.12.5",
     "@types/uuid": "^8.3.4",
     "ava": "^3.15.0",
-    "ts-node": "^10.5.0",
-    "typedoc": "0.22.11",
-    "typedoc-plugin-markdown": "3.11.12",
+    "ts-node": "^10.7.0",
+    "typedoc": "^0.22.12",
+    "typedoc-plugin-markdown": "^3.11.14",
     "typescript": "^4.5.5"
   },
   "ava": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -20,9 +20,9 @@
     "@types/node": "15.12.5",
     "ava": "^3.15.0",
     "nyc": "^15.1.0",
-    "ts-node": "^10.5.0",
-    "typedoc": "0.22.11",
-    "typedoc-plugin-markdown": "3.11.12",
+    "ts-node": "^10.7.0",
+    "typedoc": "^0.22.12",
+    "typedoc-plugin-markdown": "^3.11.14",
     "typescript": "^4.5.5"
   },
   "dependencies": {

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -25,9 +25,9 @@
     "@types/node": "15.12.5",
     "@types/uuid": "^8.3.4",
     "ava": "^3.15.0",
-    "ts-node": "^10.5.0",
-    "typedoc": "0.22.11",
-    "typedoc-plugin-markdown": "3.11.12",
+    "ts-node": "^10.7.0",
+    "typedoc": "^0.22.12",
+    "typedoc-plugin-markdown": "^3.11.14",
     "typescript": "^4.5.5"
   },
   "ava": {

--- a/packages/obj-logger/package.json
+++ b/packages/obj-logger/package.json
@@ -20,9 +20,9 @@
     "@types/node": "15.12.5",
     "ava": "^3.15.0",
     "nyc": "^15.1.0",
-    "ts-node": "^10.5.0",
-    "typedoc": "0.22.11",
-    "typedoc-plugin-markdown": "3.11.12",
+    "ts-node": "^10.7.0",
+    "typedoc": "^0.22.12",
+    "typedoc-plugin-markdown": "^3.11.14",
     "typescript": "^4.5.5"
   },
   "dependencies": {

--- a/packages/reference-apps/hello-alice-out/package.json
+++ b/packages/reference-apps/hello-alice-out/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@scramjet/types": "^0.18.5",
     "@types/node": "15.12.5",
-    "ts-node": "^10.5.0",
+    "ts-node": "^10.7.0",
     "typescript": "^4.5.5"
   },
   "dependencies": {

--- a/packages/reference-apps/hello-hulk-out/package.json
+++ b/packages/reference-apps/hello-hulk-out/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@scramjet/types": "^0.18.5",
     "@types/node": "15.12.5",
-    "ts-node": "^10.5.0",
+    "ts-node": "^10.7.0",
     "typescript": "^4.5.5"
   },
   "dependencies": {

--- a/packages/reference-apps/hello-input-out/package.json
+++ b/packages/reference-apps/hello-input-out/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@scramjet/types": "^0.18.5",
     "@types/node": "15.12.5",
-    "ts-node": "^10.5.0",
+    "ts-node": "^10.7.0",
     "typescript": "^4.5.5"
   },
   "dependencies": {

--- a/packages/reference-apps/process-not-responding/package.json
+++ b/packages/reference-apps/process-not-responding/package.json
@@ -19,7 +19,7 @@
   "license": "GPL-3.0",
   "devDependencies": {
     "@types/node": "15.12.5",
-    "typescript": "^4.3.4"
+    "typescript": "^4.5.5"
   },
   "repository": {
     "type": "git",

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -33,9 +33,9 @@
     "nyc": "^15.1.0",
     "proxyquire": "^2.1.3",
     "sinon": "^11.1.2",
-    "ts-node": "^10.5.0",
-    "typedoc": "0.22.11",
-    "typedoc-plugin-markdown": "3.11.12",
+    "ts-node": "^10.7.0",
+    "typedoc": "^0.22.12",
+    "typedoc-plugin-markdown": "^3.11.14",
     "typescript": "^4.5.5"
   },
   "ava": {

--- a/packages/sth-config/package.json
+++ b/packages/sth-config/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@scramjet/types": "^0.18.5",
     "ava": "^3.15.0",
-    "typedoc": "0.22.11",
-    "typedoc-plugin-markdown": "3.11.12"
+    "typedoc": "^0.22.12",
+    "typedoc-plugin-markdown": "^3.11.14"
   }
 }

--- a/packages/sth/package.json
+++ b/packages/sth/package.json
@@ -34,8 +34,8 @@
     "@typescript-eslint/parser": "^4.33.0",
     "ava": "^3.15.0",
     "eslint-plugin-import": "^2.25.4",
-    "ts-loader": "^9.2.6",
-    "ts-node": "^10.5.0",
+    "ts-loader": "^9.2.7",
+    "ts-node": "^10.7.0",
     "typedoc": "^0.22.12",
     "typedoc-plugin-markdown": "^3.11.14",
     "typescript": "^4.5.5"

--- a/packages/symbols/package.json
+++ b/packages/symbols/package.json
@@ -15,8 +15,8 @@
   "license": "AGPL-3.0",
   "devDependencies": {
     "@types/node": "15.12.5",
-    "typedoc": "0.22.11",
-    "typedoc-plugin-markdown": "3.11.12",
+    "typedoc": "^0.22.12",
+    "typedoc-plugin-markdown": "^3.11.14",
     "typescript": "^4.5.5"
   },
   "repository": {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -4,7 +4,7 @@
   "devDependencies": {
     "@types/node": "15.12.5",
     "ava": "^3.15.0",
-    "ts-node": "^10.5.0",
+    "ts-node": "^10.7.0",
     "typescript": "^4.5.5"
   },
   "scripts": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -21,8 +21,8 @@
   "devDependencies": {
     "@types/node": "15.12.5",
     "scramjet": "^4.36.6",
-    "typedoc": "0.22.11",
-    "typedoc-plugin-markdown": "3.11.12",
+    "typedoc": "^0.22.12",
+    "typedoc-plugin-markdown": "^3.11.14",
     "typescript": "^4.5.5"
   },
   "repository": {

--- a/packages/utility/package.json
+++ b/packages/utility/package.json
@@ -38,7 +38,7 @@
     "@scramjet/types": "^0.18.5",
     "ava": "^3.15.0",
     "typed-emitter": "^1.4.0",
-    "typedoc": "0.22.11",
-    "typedoc-plugin-markdown": "3.11.12"
+    "typedoc": "^0.22.12",
+    "typedoc-plugin-markdown": "^3.11.14"
   }
 }

--- a/packages/verser/package.json
+++ b/packages/verser/package.json
@@ -23,9 +23,9 @@
     "@scramjet/types": "^0.18.5",
     "@types/node": "15.12.5",
     "ava": "^3.15.0",
-    "ts-node": "^10.5.0",
-    "typedoc": "0.22.11",
-    "typedoc-plugin-markdown": "3.11.12",
+    "ts-node": "^10.7.0",
+    "typedoc": "^0.22.12",
+    "typedoc-plugin-markdown": "^3.11.14",
     "typescript": "^4.5.5"
   },
   "ava": {

--- a/template/package.json
+++ b/template/package.json
@@ -20,9 +20,9 @@
   "devDependencies": {
     "@types/node": "15.12.5",
     "ava": "^3.15.0",
-    "ts-node": "^10.5.0",
-    "typedoc": "0.22.11",
-    "typedoc-plugin-markdown": "3.11.12",
+    "ts-node": "^10.7.0",
+    "typedoc": "^0.22.12",
+    "typedoc-plugin-markdown": "^3.11.14",
     "typescript": "^4.5.5"
   },
   "ava": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1480,7 +1480,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node-fetch@^2.5.11":
+"@types/node-fetch@^2.6.1":
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.1.tgz#8f127c50481db65886800ef496f20bbf15518975"
   integrity sha512-oMqjURCaxoSIsHSr1E47QHzbmzNR5rK8McHuNb11BOM9cHcIK3Avy0s/b2JlXHoQGTYS3NsvWzV1M0iK7l0wbA==
@@ -5564,11 +5564,6 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
-node-fetch@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
-
 node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
@@ -7423,7 +7418,7 @@ syncpack@^5.7.11:
     read-yaml-file "2.1.0"
     semver "7.3.5"
 
-systeminformation@^5.11.4:
+systeminformation@^5.11.6:
   version "5.11.6"
   resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.11.6.tgz#8624cbb2e95e6fa98a4ebb0d10759427c0e88144"
   integrity sha512-7KBXgdnIDxABQ93w+GrPSrK/pup73+fM09VGka4A/+FhgzdlRY0JNGGDFmV8BHnFuzP9zwlI3n64yDbp7emasQ==
@@ -7654,7 +7649,7 @@ ts-dedent@^2.0.0:
   resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.2.0.tgz#39e4bd297cd036292ae2394eb3412be63f563bb5"
   integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
 
-ts-loader@^9.2.3, ts-loader@^9.2.6:
+ts-loader@^9.2.3, ts-loader@^9.2.7:
   version "9.2.7"
   resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-9.2.7.tgz#948654099ca96992b62ec47bd9cee5632006e101"
   integrity sha512-Fxh44mKli9QezgbdCXkEJWxnedQ0ead7DXTH+lfXEPedu+Y9EtMJ2aQ9G3Dj1j7Q612E8931rww8NDZha4Tibg==
@@ -7664,10 +7659,29 @@ ts-loader@^9.2.3, ts-loader@^9.2.6:
     micromatch "^4.0.0"
     semver "^7.3.4"
 
-ts-node@^10.0.0, ts-node@^10.5.0:
+ts-node@^10.0.0:
   version "10.6.0"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.6.0.tgz#c3f4195d5173ce3affdc8f2fd2e9a7ac8de5376a"
   integrity sha512-CJen6+dfOXolxudBQXnVjRVvYTmTWbyz7cn+xq2XTsvnaXbHqr4gXSCNbS2Jj8yTZMuGwUoBESLaOkLascVVvg==
+  dependencies:
+    "@cspotcode/source-map-support" "0.7.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.0"
+    yn "3.1.1"
+
+ts-node@^10.7.0:
+  version "10.7.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.7.0.tgz#35d503d0fab3e2baa672a0e94f4b40653c2463f5"
+  integrity sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==
   dependencies:
     "@cspotcode/source-map-support" "0.7.0"
     "@tsconfig/node10" "^1.0.7"
@@ -7806,30 +7820,12 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typedoc-plugin-markdown@3.11.12:
-  version "3.11.12"
-  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.11.12.tgz#04f4740534d19728696a5c0ccc35f319bcb93b31"
-  integrity sha512-gb/RuzgZ1zCnRUOqUg6firIqU7xDs9s7hq0vlU/gAsFfVCnpl3NTM9vPyPON75nnpfVFCxr/hmKQ01k1CYY/Qg==
-  dependencies:
-    handlebars "^4.7.7"
-
 typedoc-plugin-markdown@^3.11.14:
   version "3.11.14"
   resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.11.14.tgz#2a7a04abd50b8f1e5d46793061d70229d504d2cd"
   integrity sha512-lh47OQvl0079nB18YL9wuTRRhMpjo300SZKfx/xpQY8qG+GINeSxTod95QBELeI0NP81sNtUbemRDrn5nyef4Q==
   dependencies:
     handlebars "^4.7.7"
-
-typedoc@0.22.11:
-  version "0.22.11"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.22.11.tgz#a3d7f4577eef9fc82dd2e8f4e2915e69f884c250"
-  integrity sha512-pVr3hh6dkS3lPPaZz1fNpvcrqLdtEvXmXayN55czlamSgvEjh+57GUqfhAI1Xsuu/hNHUT1KNSx8LH2wBP/7SA==
-  dependencies:
-    glob "^7.2.0"
-    lunr "^2.3.9"
-    marked "^4.0.10"
-    minimatch "^3.0.4"
-    shiki "^0.10.0"
 
 typedoc@^0.22.12:
   version "0.22.12"


### PR DESCRIPTION
* Bump node-fetch version in client-utils: v2.6.1 introduces security vulnerabilities. All versions below 3.0
should be ok.
* Run yarn upgrade:all