### PR TITLE
Fix/csi controller log

### DIFF
--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -205,19 +205,27 @@ export class CSIController extends TypedEmitter<Events> {
                     this.logger.error("Sequence finished with error", exitcode);
                 }
 
+                await this.cleanup();
+
                 return exitcode;
             } catch (error: any) {
                 this.logger.error("Error caught", error.stack);
 
-                await this.instanceAdapter.cleanup();
-
-                this.logger.error("Cleanup done (post error)");
+                await this.cleanup();
 
                 return 213;
             }
         };
 
         this.instancePromise = instanceMain();
+    }
+
+    async cleanup() {
+        await Promise.all([
+            this.instanceAdapter.cleanup(),
+            this.communicationHandler.cleanup()
+        ]);
+        this.logger.error("Cleanup done...");
     }
 
     instanceStopped(): Promise<ExitCode> {

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -221,11 +221,10 @@ export class CSIController extends TypedEmitter<Events> {
     }
 
     async cleanup() {
-        await Promise.all([
-            this.instanceAdapter.cleanup(),
-            this.communicationHandler.cleanup()
-        ]);
-        this.logger.error("Cleanup done...");
+        await this.instanceAdapter.cleanup();
+
+        if (this.upStreams)
+            this.upStreams[CC.LOG].unpipe();
     }
 
     instanceStopped(): Promise<ExitCode> {
@@ -245,8 +244,6 @@ export class CSIController extends TypedEmitter<Events> {
             streams[CC.STDOUT].pipe(process.stdout);
             streams[CC.STDERR].pipe(process.stderr);
         }
-
-        streams[CC.LOG].pipe(this.logger.inputStringifiedLogStream);
 
         this.upStreams = [
             new PassThrough(), new PassThrough(), new PassThrough(), new PassThrough(),

--- a/packages/model/src/stream-handler.ts
+++ b/packages/model/src/stream-handler.ts
@@ -141,6 +141,11 @@ export class CommunicationHandler implements ICommunicationHandler {
         return this;
     }
 
+    cleanup(): this {
+        this.loggerPassThrough.end();
+        return this;
+    }
+
     pipeMessageStreams() {
         if (this._piped) {
             this.logger.error("pipeMessageStreams called twice");

--- a/packages/model/src/stream-handler.ts
+++ b/packages/model/src/stream-handler.ts
@@ -141,11 +141,6 @@ export class CommunicationHandler implements ICommunicationHandler {
         return this;
     }
 
-    cleanup(): this {
-        this.loggerPassThrough.end();
-        return this;
-    }
-
     pipeMessageStreams() {
         if (this._piped) {
             this.logger.error("pipeMessageStreams called twice");
@@ -158,7 +153,7 @@ export class CommunicationHandler implements ICommunicationHandler {
             throw new Error("Streams not hooked");
         }
 
-        this.downstreams[CC.LOG].pipe(this.loggerPassThrough, { end: false }).pipe(this.upstreams[CC.LOG]);
+        this.downstreams[CC.LOG].pipe(this.loggerPassThrough).pipe(this.upstreams[CC.LOG]);
 
         const monitoringOutput = StringStream.from(this.downstreams[CC.MONITORING] as Readable)
             .JSONParse()

--- a/packages/types/src/communication-handler.ts
+++ b/packages/types/src/communication-handler.ts
@@ -54,7 +54,5 @@ export interface ICommunicationHandler {
         stdout: Readable,
         stderr: Readable
     };
-
-    cleanup(): this;
 }
 

--- a/packages/types/src/communication-handler.ts
+++ b/packages/types/src/communication-handler.ts
@@ -54,5 +54,7 @@ export interface ICommunicationHandler {
         stdout: Readable,
         stderr: Readable
     };
+
+    cleanup(): this;
 }
 


### PR DESCRIPTION
Fix for the Instance Log API not ending the log stream after an Instance is successfully killed.
@Tatarinho stumbled across this issue while implementing the BDD test for Instance Log API https://github.com/scramjetorg/transform-hub/pull/308 and since then we have jointly worked on it.

@MichalCz asked to make the CSI Controller logs available in the STH logs, but without the Instance logs themselves (which are private for a given Instance and should only be accessible by the Instance Log API).

To verify:
1. Run the STH.
2. Send and start any Sequence that does not terminate too quickly (e.g. https://github.com/scramjetorg/transform-hub/tree/release/0.18/packages/reference-apps/csv-transform)
3. Get Instance Log by API, e.g. with curl.
4. Kill the Instance.
5. Check if the log stream ended (it can take a couple of seconds).