### PR TITLE
Add configurable 'cpmId' to host

### DIFF
--- a/packages/host/src/lib/cpm-connector.ts
+++ b/packages/host/src/lib/cpm-connector.ts
@@ -183,7 +183,6 @@ export class CPMConnector extends TypedEmitter<Events> {
         this.verserClient = new VerserClient({
             verserUrl: `http://${cpmHostname}/verser`,
             headers: {
-                "x-host-id": config.id,
                 "x-manager-id": cpmId
             },
             server

--- a/packages/host/src/lib/cpm-connector.ts
+++ b/packages/host/src/lib/cpm-connector.ts
@@ -147,6 +147,13 @@ export class CPMConnector extends TypedEmitter<Events> {
     cpmURL: string;
 
     /**
+     * Id of Manager (e.g. "cpm-1").
+     *
+     * @type {string}
+     */
+    cpmId: string;
+
+    /**
      * VerserClient instance used for connecting with Verser.
      *
      * @type {VerserClient}
@@ -163,17 +170,22 @@ export class CPMConnector extends TypedEmitter<Events> {
     /**
      * @constructor
      * @param {string} cpmHostname CPM hostname to connect to. (e.g. "localhost:8080").
+     * @param {string} cpmId CPM id to connect to. (e.g. "CPM1").
      * @param {CPMConnectorOptions} config CPM connector configuration.
      * @param {Server} server API server to handle incoming requests.
      */
-    constructor(cpmHostname: string, config: CPMConnectorOptions, server: Server) {
+    constructor(cpmHostname: string, cpmId: string, config: CPMConnectorOptions, server: Server) {
         super();
         this.cpmURL = cpmHostname;
+        this.cpmId = cpmId;
         this.config = config;
 
         this.verserClient = new VerserClient({
             verserUrl: `http://${cpmHostname}/verser`,
-            headers: {},
+            headers: {
+                "x-host-id": config.id,
+                "x-manager-id": cpmId
+            },
             server
         });
 
@@ -311,7 +323,7 @@ export class CPMConnector extends TypedEmitter<Events> {
         let connection;
 
         try {
-            this.logger.trace("Connecting to Manager", this.cpmURL);
+            this.logger.trace("Connecting to Manager", this.cpmURL, this.cpmId);
             connection = await this.verserClient.connect();
         } catch (err) {
             this.logger.error("Can not connect to Manager", err);

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -145,6 +145,7 @@ export class Host implements IComponent {
 
             this.cpmConnector = new CPMConnector(
                 this.config.cpmUrl,
+                this.config.cpmId,
                 { id: this.config.host.id, infoFilePath: this.config.host.infoFilePath },
                 this.api.server
             );

--- a/packages/sth-config/src/config-service.ts
+++ b/packages/sth-config/src/config-service.ts
@@ -9,6 +9,7 @@ const _defaultConfig: STHConfiguration = {
     logLevel: "TRACE",
     logColors: true,
     cpmUrl: "",
+    cpmId: "",
     docker: {
         prerunner: {
             image: "",

--- a/packages/sth/src/bin/hub.ts
+++ b/packages/sth/src/bin/hub.ts
@@ -12,6 +12,7 @@ const options: STHCommandOptions = program
     .option("-E, --identify-existing", "Index existing volumes as sequences", false)
     .option("-C, --cpm-url <host:ip>")
     .option("-I, --id <id>")
+    .option("--cpm-id <id>")
     .option("--runtime-adapter <adapter>", "Determines adapters used for loading and starting sequence. One of 'docker', 'process', 'kubernetes'")
     .option("--runner-image <image name>", "Image used by runner")
     .option("--runner-max-mem <mb>", "Maximum mem used by runner")
@@ -33,6 +34,7 @@ const configService = new ConfigService();
 
 configService.update({
     cpmUrl: options.cpmUrl,
+    cpmId: options.cpmId,
     docker: {
         prerunner: {
             image: options.prerunnerImage,

--- a/packages/types/src/sth-command-options.ts
+++ b/packages/types/src/sth-command-options.ts
@@ -6,6 +6,7 @@ export type STHCommandOptions = {
     hostname: string;
     identifyExisting: boolean;
     cpmUrl?: string;
+    cpmId?: string;
     id?: string;
     runtimeAdapter: string;
     runnerImage: string;

--- a/packages/types/src/sth-configuration.ts
+++ b/packages/types/src/sth-configuration.ts
@@ -94,6 +94,11 @@ export type STHConfiguration = {
     cpmUrl: string;
 
     /**
+     * CPM id.
+     */
+    cpmId: string;
+
+    /**
      * Docker related configuration.
      */
     docker: {


### PR DESCRIPTION
Since `Host` now connects to `MultiManager` directly, it needs to pass `Manager` id in a "flight" request header to tell `MM` to which `Manager` it should be connected. This implies that such id also may be passed as cmd arg. This PR introduces support for both.

See related PR for more details https://github.com/scramjetorg/scramjet-cpm-dev/pull/167.