### PR TITLE
Pipe missing logs Runner -> ServerSocket -> Host

### DIFF
--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -137,6 +137,8 @@ export class Host implements IComponent {
         this.loadCheck = new LoadCheck({ safeOperationLimit, instanceRequirements });
 
         this.socketServer = socketServer;
+        this.socketServer.logger.pipe(this.logger);
+
         this.api = apiServer;
 
         this.apiBase = this.config.host.apiBase;
@@ -296,8 +298,6 @@ export class Host implements IComponent {
             }
 
             req.url = req.url?.substring(this.instanceBase.length + 1 + params.id.length);
-
-            this.logger.debug(req.method!, req.url);
 
             return instance.router.lookup(req, res, next);
         }

--- a/packages/host/src/lib/socket-server.ts
+++ b/packages/host/src/lib/socket-server.ts
@@ -4,6 +4,7 @@ import net from "net";
 
 import { isDefined, TypedEmitter } from "@scramjet/utility";
 import { ObjLogger } from "@scramjet/obj-logger";
+import { CommunicationChannel } from "@scramjet/symbols";
 
 type MaybeSocket = net.Socket | null
 type RunnerConnectionsInProgress = [
@@ -81,6 +82,7 @@ export class SocketServer extends TypedEmitter<Events> implements IComponent {
                 if (runner.every(isDefined)) {
                     this.runnerConnectionsInProgress.delete(id);
 
+                    runner[CommunicationChannel.LOG]!.pipe(this.logger.inputStringifiedLogStream);
                     this.emit("connect", id, runner as RunnerOpenConnections);
                 }
             });

--- a/packages/runner/src/host-client.ts
+++ b/packages/runner/src/host-client.ts
@@ -52,6 +52,7 @@ class HostClient implements IHostClient {
         );
 
         this._streams = openConnections as HostOpenConnections;
+        this.logger.debug("Connected to host");
     }
 
     async disconnect() {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -90,6 +90,7 @@ export class Runner<X extends AppConfig> implements IComponent {
         this.emitter = new EventEmitter();
 
         this.logger = new ObjLogger(this, { id: instanceId });
+        hostClient.logger.pipe(this.logger);
 
         if (process.env.PRINT_TO_STDOUT) {
             this.logger.addOutput(process.stdout);
@@ -272,7 +273,7 @@ export class Runner<X extends AppConfig> implements IComponent {
     private exit(exitCode?: number) {
         if (typeof exitCode !== undefined) process.exitCode = exitCode;
         // TODO: why we need this?
-        setTimeout(() => process.exit());
+        setTimeout(() => process.exit(), 100);
     }
 
     async main() {


### PR DESCRIPTION
Now:
```
2022-03-22T22:18:27.307Z DEBUG Host Request [
  'date: 2022-03-22T22:18:27.305Z, method: OPTIONS, url: /api/v1/sequence/0cc859e1-1dd1-4423-be0b-1c30b6e9ac49/start, status: 200'
]
2022-03-22T22:18:27.368Z INFO  Host Start sequence [
  '0cc859e1-1dd1-4423-be0b-1c30b6e9ac49',
  '@scramjet/alice-in-browserland'
]
2022-03-22T22:18:27.381Z TRACE Host CSIController created [ '22ae6bf8-e927-4d85-b27d-2bc8e206542a' ]
2022-03-22T22:18:27.376Z TRACE CommunicationHandler CommunicationHandler created 
2022-03-22T22:18:27.380Z DEBUG CSIController Constructor executed 
2022-03-22T22:18:27.397Z TRACE CSIController Streams hooked and routed 
2022-03-22T22:18:27.418Z TRACE CSIController Sequence initialized 
2022-03-22T22:18:27.400Z INFO  ProcessInstanceAdapter Instance preparation done 
2022-03-22T22:18:27.400Z TRACE ProcessInstanceAdapter Starting Runner [ '0cc859e1-1dd1-4423-be0b-1c30b6e9ac49' ]
2022-03-22T22:18:27.401Z DEBUG ProcessInstanceAdapter Spawning Runner process with command [
  [
    'ts-node',
    '/home/pfalba/github/scramjet-cpm-dev/sth/packages/runner/src/bin/start-runner.ts'
  ],
  'and envs: ',
  {
    DEVELOPMENT: '1',
    PRODUCTION: undefined,
    SEQUENCE_PATH: '/home/pfalba/.scramjet_sequences/0cc859e1-1dd1-4423-be0b-1c30b6e9ac49/index.js',
    INSTANCES_SERVER_PORT: 8001,
    INSTANCE_ID: '22ae6bf8-e927-4d85-b27d-2bc8e206542a'
  }
]
2022-03-22T22:18:27.418Z TRACE ProcessInstanceAdapter Runner process is running [ 840435 ]
2022-03-22T22:18:30.208Z DEBUG Host Instance connected [ '22ae6bf8-e927-4d85-b27d-2bc8e206542a' ]
2022-03-22T22:18:30.212Z TRACE CSIController Hookup streams 
2022-03-22T22:18:30.228Z TRACE CSIController Instance started 
2022-03-22T22:18:30.231Z TRACE Host CSIController started [ '22ae6bf8-e927-4d85-b27d-2bc8e206542a' ]
2022-03-22T22:18:30.240Z DEBUG Host Request [
  'date: 2022-03-22T22:18:27.340Z, method: POST, url: /api/v1/sequence/0cc859e1-1dd1-4423-be0b-1c30b6e9ac49/start, status: 200'
]
2022-03-22T22:18:30.244Z DEBUG CSIController PING received [ [ 3000, {} ] ]
2022-03-22T22:18:30.248Z TRACE CSIController Received a PING message but didn't receive ports config 
2022-03-22T22:18:30.254Z INFO  CSIController Instance started [
  {
    created: 2022-03-22T22:18:27.381Z,
    ports: undefined,
    started: 2022-03-22T22:18:30.254Z
  }
]
2022-03-22T22:18:30.453Z TRACE Host PANG received [ { requires: '' } ]
2022-03-22T22:18:30.462Z TRACE Host PANG received [ { provides: '', contentType: '' } ]
```
And with this patch:
```
2022-03-22T22:38:27.337Z DEBUG Host Request [
  'date: 2022-03-22T22:38:27.334Z, method: OPTIONS, url: /api/v1/sequence/0d074f30-4e1b-4443-8330-f2dc5c407cfc/start, status: 200'
]
2022-03-22T22:38:27.395Z INFO  Host Start sequence [
  '0d074f30-4e1b-4443-8330-f2dc5c407cfc',
  '@scramjet/alice-in-browserland'
]
2022-03-22T22:38:27.410Z TRACE Host CSIController created [ '67c547cf-4a2c-41a4-a11d-6108ba3f8665' ]
2022-03-22T22:38:27.403Z TRACE CommunicationHandler CommunicationHandler created 
2022-03-22T22:38:27.410Z DEBUG CSIController Constructor executed 
2022-03-22T22:38:27.421Z TRACE CSIController Streams hooked and routed 
2022-03-22T22:38:27.441Z TRACE CSIController Sequence initialized 
2022-03-22T22:38:27.423Z INFO  ProcessInstanceAdapter Instance preparation done 
2022-03-22T22:38:27.424Z TRACE ProcessInstanceAdapter Starting Runner [ '0d074f30-4e1b-4443-8330-f2dc5c407cfc' ]
2022-03-22T22:38:27.424Z DEBUG ProcessInstanceAdapter Spawning Runner process with command [
  [
    'ts-node',
    '/home/pfalba/github/scramjet-cpm-dev/sth/packages/runner/src/bin/start-runner.ts'
  ],
  'and envs: ',
  {
    DEVELOPMENT: undefined,
    PRODUCTION: undefined,
    SEQUENCE_PATH: '/home/pfalba/.scramjet_sequences/0d074f30-4e1b-4443-8330-f2dc5c407cfc/index.js',
    INSTANCES_SERVER_PORT: 8001,
    INSTANCE_ID: '67c547cf-4a2c-41a4-a11d-6108ba3f8665'
  }
]
2022-03-22T22:38:27.441Z TRACE ProcessInstanceAdapter Runner process is running [ 852121 ]
2022-03-22T22:38:30.165Z INFO  SocketServer New incoming Runner connection to SocketServer 
2022-03-22T22:38:30.174Z INFO  SocketServer New incoming Runner connection to SocketServer 
2022-03-22T22:38:30.181Z INFO  SocketServer New incoming Runner connection to SocketServer 
2022-03-22T22:38:30.191Z INFO  SocketServer New incoming Runner connection to SocketServer 
2022-03-22T22:38:30.198Z INFO  SocketServer New incoming Runner connection to SocketServer 
2022-03-22T22:38:30.206Z INFO  SocketServer New incoming Runner connection to SocketServer 
2022-03-22T22:38:30.213Z INFO  SocketServer New incoming Runner connection to SocketServer 
2022-03-22T22:38:30.220Z INFO  SocketServer New incoming Runner connection to SocketServer 
2022-03-22T22:38:30.227Z INFO  SocketServer Connection from instance [ '67c547cf-4a2c-41a4-a11d-6108ba3f8665' ]
2022-03-22T22:38:30.234Z INFO  SocketServer Connection on channel [ 0 ]
2022-03-22T22:38:30.241Z INFO  SocketServer Connection from instance [ '67c547cf-4a2c-41a4-a11d-6108ba3f8665' ]
2022-03-22T22:38:30.248Z INFO  SocketServer Connection on channel [ 1 ]
2022-03-22T22:38:30.255Z INFO  SocketServer Connection from instance [ '67c547cf-4a2c-41a4-a11d-6108ba3f8665' ]
2022-03-22T22:38:30.262Z INFO  SocketServer Connection on channel [ 2 ]
2022-03-22T22:38:30.269Z INFO  SocketServer Connection from instance [ '67c547cf-4a2c-41a4-a11d-6108ba3f8665' ]
2022-03-22T22:38:30.275Z INFO  SocketServer Connection on channel [ 3 ]
2022-03-22T22:38:30.282Z INFO  SocketServer Connection from instance [ '67c547cf-4a2c-41a4-a11d-6108ba3f8665' ]
2022-03-22T22:38:30.289Z INFO  SocketServer Connection on channel [ 4 ]
2022-03-22T22:38:30.296Z INFO  SocketServer Connection from instance [ '67c547cf-4a2c-41a4-a11d-6108ba3f8665' ]
2022-03-22T22:38:30.303Z INFO  SocketServer Connection on channel [ 5 ]
2022-03-22T22:38:30.309Z INFO  SocketServer Connection from instance [ '67c547cf-4a2c-41a4-a11d-6108ba3f8665' ]
2022-03-22T22:38:30.316Z INFO  SocketServer Connection on channel [ 6 ]
2022-03-22T22:38:30.323Z INFO  SocketServer Connection from instance [ '67c547cf-4a2c-41a4-a11d-6108ba3f8665' ]
2022-03-22T22:38:30.333Z DEBUG Host Instance connected [ '67c547cf-4a2c-41a4-a11d-6108ba3f8665' ]
2022-03-22T22:38:30.329Z INFO  SocketServer Connection on channel [ 7 ]
2022-03-22T22:38:30.336Z TRACE CSIController Hookup streams 
2022-03-22T22:38:30.351Z TRACE CSIController Instance started 
2022-03-22T22:38:30.354Z TRACE Host CSIController started [ '67c547cf-4a2c-41a4-a11d-6108ba3f8665' ]
2022-03-22T22:38:30.367Z DEBUG Host Request [
  'date: 2022-03-22T22:38:27.371Z, method: POST, url: /api/v1/sequence/0d074f30-4e1b-4443-8330-f2dc5c407cfc/start, status: 200'
]
2022-03-22T22:38:30.371Z DEBUG CSIController PING received [ [ 3000, {} ] ]
2022-03-22T22:38:30.376Z TRACE CSIController Received a PING message but didn't receive ports config 
2022-03-22T22:38:30.383Z INFO  CSIController Instance started [
  {
    created: 2022-03-22T22:38:27.410Z,
    ports: undefined,
    started: 2022-03-22T22:38:30.383Z
  }
]
2022-03-22T22:38:30.168Z DEBUG Runner Streams initialized 
2022-03-22T22:38:30.169Z TRACE Runner Handshake sent 
2022-03-22T22:38:30.404Z DEBUG Runner Control message received [ 4000, {} ]
2022-03-22T22:38:30.588Z TRACE Host PANG received [ { requires: '' } ]
2022-03-22T22:38:30.596Z TRACE Host PANG received [ { provides: '', contentType: '' } ]
2022-03-22T22:38:30.404Z DEBUG Runner Handshake received 
2022-03-22T22:38:30.584Z DEBUG Runner Sequence [ [ null ] ]
2022-03-22T22:38:30.584Z INFO  Runner Sequence loaded, functions count [ 1 ]
2022-03-22T22:38:30.584Z DEBUG Runner Processing function on index [ 0 ]
2022-03-22T22:38:30.585Z DEBUG Runner Function called [ 0 ]
2022-03-22T22:38:30.585Z INFO  Runner All sequences processed. 
2022-03-22T22:38:30.585Z DEBUG Runner Stream type is [ 'object' ]
2022-03-22T22:38:30.585Z TRACE Runner Piping sequence output [ 'object' ]
```