### PR TITLE
Replace deprecated rmdir with rm

### DIFF
--- a/packages/cli/src/lib/paths.ts
+++ b/packages/cli/src/lib/paths.ts
@@ -1,6 +1,6 @@
 import { homedir, tmpdir } from "os";
 import { resolve } from "path";
-import { existsSync, mkdirSync, readdirSync, rmdirSync } from "fs";
+import { existsSync, mkdirSync, readdirSync, rmSync } from "fs";
 import { sessionId } from "../utils/sessionId";
 
 export const configFileExt = ".json";
@@ -38,7 +38,7 @@ const clearUnusedSessionDirs = () => {
 
     existingSessions
         .filter((sessionPID) => !currentPids.includes(sessionPID))
-        .forEach((unusedSession: string) => rmdirSync(resolve(siTempDir, `./${unusedSession}`), { recursive: true }));
+        .forEach((unusedSession: string) => rmSync(resolve(siTempDir, `./${unusedSession}`), { recursive: true }));
 };
 
 /**


### PR DESCRIPTION
It should fix this error:

(node:291420) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
    at emitRecursiveRmdirWarning (node:internal/fs/utils:816:13)
    at rmdirSync (node:fs:1155:5)
    at /home/jan/src/transform-hub/dist/cli/lib/paths.js:33:56
    at Array.forEach (<anonymous>)
    at clearUnusedSessionDirs (/home/jan/src/transform-hub/dist/cli/lib/paths.js:33:10)
    at initPaths (/home/jan/src/transform-hub/dist/cli/lib/paths.js:36:5)
    at /home/jan/src/transform-hub/dist/cli/bin/index.js:40:27
    at Object.<anonymous> (/home/jan/src/transform-hub/dist/cli/bin/index.js:59:3)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)