### PR TITLE
Add a feature that allows to color logs from stdin

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -1,8 +1,6 @@
 name: Release test
 
-on:
-  pull_request:
-    branches: [ release/*, main ]
+on: workflow_run
 
 jobs:
   test-npm-sth:

--- a/bdd/data/sample-log.log.ansi
+++ b/bdd/data/sample-log.log.ansi
@@ -1,0 +1,5 @@
+[2m2022-03-24T18:26:34.823Z[0m [2mTRACE[0m [35mProcessInstanceAdapter[0m Runner process is running [2m[ [33m484[39m ][0m
+[2m2022-03-24T18:26:34.923Z[0m [2mTRACE[0m [35mProcessInstanceAdapter[0m Runner process exited [2m[ [33m484[39m ][0m
+[2m2022-03-24T18:26:34.924Z[0m [34mDEBUG[0m [35mProcessInstanceAdapter[0m Process returned non-zero status code [2m[ [33m1[39m ][0m
+[2m2022-03-24T18:26:34.924Z[0m [2mTRACE[0m [35mCSIController[0m Sequence finished with status [2m[ [33m1[39m ][0m
+[2m2022-03-24T18:26:34.924Z[0m [31mERROR[0m [35mCSIController[0m Sequence finished with error [2m[ [33m1[39m ][0m

--- a/bdd/data/sample-log.log.plain
+++ b/bdd/data/sample-log.log.plain
@@ -1,0 +1,5 @@
+1648146394823 TRACE ProcessInstanceAdapter Runner process is running [ 484 ]
+1648146394923 TRACE ProcessInstanceAdapter Runner process exited [ 484 ]
+1648146394924 DEBUG ProcessInstanceAdapter Process returned non-zero status code [ 1 ]
+1648146394924 TRACE CSIController Sequence finished with status [ 1 ]
+1648146394924 ERROR CSIController Sequence finished with error [ 1 ]

--- a/bdd/data/sample-log.log.source
+++ b/bdd/data/sample-log.log.source
@@ -1,0 +1,5 @@
+{"level":"TRACE","msg":"Runner process is running","ts":1648146394823,"from":"ProcessInstanceAdapter","Host":{},"data":[484]}
+{"level":"TRACE","msg":"Runner process exited","ts":1648146394923,"from":"ProcessInstanceAdapter","Host":{},"data":[484]}
+{"level":"DEBUG","msg":"Process returned non-zero status code","ts":1648146394924,"from":"ProcessInstanceAdapter","Host":{},"data":[1]}
+{"level":"TRACE","msg":"Sequence finished with status","ts":1648146394924,"from":"CSIController","Host":{},"data":[1]}
+{"level":"ERROR","msg":"Sequence finished with error","ts":1648146394924,"from":"CSIController","Host":{},"data":[1]}

--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -225,3 +225,14 @@ Feature: CLI tests
         And wait for "1000" ms
         And I execute CLI with "seq rm -" arguments
         And host is still running
+
+    @ci @cli @no-parallel
+    Scenario: E2E-010 TC-024 Check log coloring
+        When I execute CLI with bash command "cat ./data/sample-log.log | $SI util log-color"
+        Then stdout contents are the same as in file "./data/sample-log.log.ansi"
+
+    @ci @cli @no-parallel
+    Scenario: E2E-010 TC-025 Check log no-coloring
+        When I execute CLI with bash command "cat ./data/sample-log.log | $SI util log-color --no-color"
+        Then stdout contents are the same as in file "./data/sample-log.log.plain"
+

--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -228,11 +228,11 @@ Feature: CLI tests
 
     @ci @cli @no-parallel
     Scenario: E2E-010 TC-024 Check log coloring
-        When I execute CLI with bash command "cat ./data/sample-log.log | $SI util log-color"
+        When I execute CLI with bash command "cat ./data/sample-log.log.source | $SI util log-color"
         Then stdout contents are the same as in file "./data/sample-log.log.ansi"
 
     @ci @cli @no-parallel
     Scenario: E2E-010 TC-025 Check log no-coloring
-        When I execute CLI with bash command "cat ./data/sample-log.log | $SI util log-color --no-color"
+        When I execute CLI with bash command "cat ./data/sample-log.log.source | $SI util log-color --no-color"
         Then stdout contents are the same as in file "./data/sample-log.log.plain"
 

--- a/bdd/step-definitions/e2e/cli.ts
+++ b/bdd/step-definitions/e2e/cli.ts
@@ -8,6 +8,8 @@ import { STHRestAPI } from "@scramjet/types";
 import { getStreamsFromSpawn, defer } from "../../lib/utils";
 import { expectedResponses } from "./expectedResponses";
 import { CustomWorld } from "../world";
+import { promisify } from "util";
+import { resolve } from "path";
 
 // eslint-disable-next-line no-nested-ternary
 const si = process.env.SCRAMJET_SPAWN_JS
@@ -55,6 +57,16 @@ Then("the exit status is {int}", function(status: number) {
         assert.equal(stdio[2], status);
     }
     assert.ok(true);
+});
+
+Then("stdout contents are the same as in file {string}", async function(filepath: string) {
+    const res = (this as CustomWorld).cliResources;
+    const fileContents = await promisify(fs.readFile)(
+        resolve(process.cwd(), filepath),
+        { encoding: "utf-8" }
+    );
+
+    assert.equal(fileContents, res.stdio && res.stdio[0]);
 });
 
 Then("I get location {string} of compressed directory", function(filepath: string) {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,6 +23,7 @@
     "@scramjet/api-client": "^0.18.7",
     "@scramjet/client-utils": "^0.18.7",
     "@scramjet/middleware-api-client": "^0.18.7",
+    "@scramjet/obj-logger": "^0.19.0",
     "commander": "^8.3.0",
     "commander-completion": "^1.0.1",
     "minimatch": "^3.1.2",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,4 +12,5 @@ export * from "./lib/commands/space";
 export * from "./lib/commands/topic";
 export * from "./lib/commands/completion";
 export * from "./lib/commands/template";
+export * from "./lib/commands/util";
 export * from "./types/index";

--- a/packages/cli/src/lib/commands/index.ts
+++ b/packages/cli/src/lib/commands/index.ts
@@ -11,6 +11,7 @@ import { space } from "./space";
 import { topic } from "./topic";
 import { completion } from "./completion";
 import { template } from "./template";
+import { util } from "./util";
 
 export const commands: CommandDefinition[] = [
     auth,
@@ -27,4 +28,5 @@ export const commands: CommandDefinition[] = [
     template,
     // TODO: completion check with version of draft 2.0
     completion,
+    util
 ];

--- a/packages/cli/src/lib/commands/util.ts
+++ b/packages/cli/src/lib/commands/util.ts
@@ -20,8 +20,8 @@ export const util: CommandDefinition = (program) => {
      * {@link defaultConfig}
      */
     configCmd
-        .command("log-color")
-        .alias("lc")
+        .command("log-format")
+        .alias("lf")
         .option("--no-color", "dont colorize the values")
         .description("colorifies and prints out nice colorful log files")
         .action(({ color }) => {

--- a/packages/cli/src/lib/commands/util.ts
+++ b/packages/cli/src/lib/commands/util.ts
@@ -1,0 +1,43 @@
+import { prettyPrint } from "@scramjet/obj-logger";
+import { StringStream } from "scramjet";
+import { CommandDefinition } from "../../types";
+import { displayStream } from "../output";
+
+/**
+ * Initializes `config` command.
+ *
+ * @param {Command} program Commander object.
+ */
+export const util: CommandDefinition = (program) => {
+    /**
+     * Set custom value for config and write it to JSON file.
+     */
+    const configCmd = program.command("util").alias("u").description("various utilities");
+
+    /**
+     * Command: `si config print`
+     * Log: configVersion, apiUrl, logLevel, format
+     * {@link defaultConfig}
+     */
+    configCmd
+        .command("log-color")
+        .alias("lc")
+        .option("--no-color", "dont colorize the values")
+        .description("colorifies and prints out nice colorful log files")
+        .action(({ color }) => {
+            const parser = prettyPrint({ colors: color });
+
+            const out = StringStream.from(process.stdin)
+                .lines()
+                .parse(x => {
+                    try {
+                        return JSON.parse(x);
+                    } catch {
+                        return undefined;
+                    }
+                })
+                .stringify(parser);
+
+            return displayStream(program, out);
+        });
+};

--- a/packages/cli/src/lib/output.ts
+++ b/packages/cli/src/lib/output.ts
@@ -42,7 +42,7 @@ export async function displayObject(_program: Command, object: any) {
  */
 export async function displayStream(
     _program: Command,
-    response: Promise<Stream | ReadableStream<any>>,
+    response: Stream | ReadableStream<any> | Promise<Stream | ReadableStream<any>>,
     output: Writable = process.stdout
 ): Promise<void> {
     try {


### PR DESCRIPTION
This allows devs to run a simple command that pretty prints JSON logs (from file or stdin).

Usage:

```
cat logfile | si util log-color
```﻿

We can leave this undocumented (meaning no special info in docs) - there's help in `cli`.
