### PR TITLE
Never close topics

### DIFF
--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -195,8 +195,8 @@ Feature: CLI tests
         And wait for "6000" ms
         Then I start the second sequence
         And wait for "4000" ms
-        And I get the second instance output
-        Then confirm data named "hello-input-out-10" received
+        And I get the second instance output without waiting for the end
+        Then confirm data named "hello-input-out-10" will be received
         * stop host
 
     # This tests writes and uses shared config file so it may fail if run in parallel

--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -174,14 +174,14 @@ Feature: CLI tests
     @ci @cli @starts-host
     Scenario: E2E-010 TC-020 API to instance
         Given start host
-        When I execute CLI with "topic send names features/e2e/data.json --end" arguments
+        When I execute CLI with "topic send names features/e2e/data.json" arguments
         When I execute CLI with "seq send ../packages/reference-apps/hello-input-out.tar.gz --format json" arguments
         Then I get Sequence id
         Then I start Sequence
         Then I get instance health
         Then I get instance id
-        And I get instance output
-        Then confirm data named "hello-avengers" received
+        And I get instance output without waiting for the end
+        Then confirm data named "hello-avengers" will be received
         * stop host
 
     @ci @cli @starts-host

--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -155,7 +155,7 @@ Feature: CLI tests
     @ci @cli @starts-host
     Scenario: E2E-010 TC-018 API to API
         Given start host
-        When I execute CLI with "topic send cities features/e2e/cities.json --end" arguments
+        When I execute CLI with "topic send cities features/e2e/cities.json" arguments
         Then I execute CLI with "topic get cities" arguments without waiting for the end
         Then confirm data named "nyc-city-nl" will be received
         * stop host

--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -156,8 +156,8 @@ Feature: CLI tests
     Scenario: E2E-010 TC-018 API to API
         Given start host
         When I execute CLI with "topic send cities features/e2e/cities.json --end" arguments
-        Then I execute CLI with "topic get cities" arguments
-        Then confirm data named "nyc-city-nl" received
+        Then I execute CLI with "topic get cities" arguments without waiting for the end
+        Then confirm data named "nyc-city-nl" will be received
         * stop host
 
     @ci @cli @starts-host
@@ -167,8 +167,8 @@ Feature: CLI tests
         Then I get Sequence id
         Then I start Sequence
         Then I get instance health
-        Then I execute CLI with "topic get names" arguments
-        Then confirm data named "endless-names-10" received
+        Then I execute CLI with "topic get names" arguments without waiting for the end
+        Then confirm data named "endless-names-10" will be received
         * stop host
 
     @ci @cli @starts-host

--- a/bdd/features/e2e/E2E-013-topic.feature
+++ b/bdd/features/e2e/E2E-013-topic.feature
@@ -3,9 +3,9 @@ Feature: E2E test, where we send and receive data from /topic/:name endpoint by 
     @ci @starts-host
     Scenario: E2E-013 TC-001 Send and get data from API STH
         When start host
-        Then send data "{ \"city\": \"New York\" }" named "cities"
+        Then send json data "{ \"city\": \"New York\" }" named "cities"
         And get data named "cities" without waiting for the end
-        Then confirm data defined as "nyc-city" will be received
+        Then confirm data defined as "nyc-city-nl" will be received
         * stop host
 
     @ci @starts-host
@@ -13,7 +13,7 @@ Feature: E2E test, where we send and receive data from /topic/:name endpoint by 
         When start host
         And sequence "../packages/reference-apps/hello-input-out.tar.gz" loaded
         And instance started
-        Then send data "{ \"name\": \"Hulk\" }" named "names"
+        Then send json data "{ \"name\": \"Hulk\" }" named "names"
         And wait for "1000" ms
         And get output without waiting for the end
         Then confirm data defined as "hulkName" will be received

--- a/bdd/features/e2e/E2E-013-topic.feature
+++ b/bdd/features/e2e/E2E-013-topic.feature
@@ -46,3 +46,19 @@ Feature: E2E test, where we send and receive data from /topic/:name endpoint by 
         And get data named "marvel" without waiting for the end
         * stop host
 
+    @ci @starts-host
+    Scenario: E2E-013 TC-006 Send data from multiple instances to another instance on the same host
+        When start host
+        And sequence "../packages/reference-apps/endless-names-output.tar.gz" loaded
+        And instance started with arguments "5"
+        And wait for "4000" ms
+        And instance is finished
+        Then send data from file "../dist/reference-apps/avengers-names-output/avengers.json" named "names"
+        And instance started with arguments "5"
+        And wait for "4000" ms
+        And instance is finished
+        And sequence "../packages/reference-apps/hello-input-out.tar.gz" loaded
+        And instance started
+        And get output without waiting for the end
+        Then confirm data defined as "multiple-names-sources" will be received
+        * stop host

--- a/bdd/features/e2e/E2E-013-topic.feature
+++ b/bdd/features/e2e/E2E-013-topic.feature
@@ -62,3 +62,27 @@ Feature: E2E test, where we send and receive data from /topic/:name endpoint by 
         And get output without waiting for the end
         Then confirm data defined as "multiple-names-sources" will be received
         * stop host
+
+    
+    @ci @starts-host
+    Scenario: E2E-013 TC-007 Send and read data two times 
+        When start host
+        And sequence "../packages/reference-apps/endless-names-output.tar.gz" loaded
+        And instance started with arguments "5"
+        And sequence "../packages/reference-apps/hello-input-out.tar.gz" loaded
+        And instance started
+        And get output without waiting for the end
+        Then confirm data defined as "hello-input-out-5" will be received
+        When send kill message to instance
+        And wait for "1000" ms
+        And instance is finished
+        And sequence "../packages/reference-apps/endless-names-output.tar.gz" loaded
+        And instance started with arguments "10"
+        # We want to verify that nothing else is reading the topic
+        And wait for "2000" ms
+        And sequence "../packages/reference-apps/hello-input-out.tar.gz" loaded
+        And instance started
+        And get output without waiting for the end
+        Then confirm data defined as "hello-input-out-10" will be received
+        * stop host
+

--- a/bdd/features/e2e/E2E-013-topic.feature
+++ b/bdd/features/e2e/E2E-013-topic.feature
@@ -4,8 +4,8 @@ Feature: E2E test, where we send and receive data from /topic/:name endpoint by 
     Scenario: E2E-013 TC-001 Send and get data from API STH
         When start host
         Then send data "{ \"city\": \"New York\" }" named "cities"
-        And get data named "cities"
-        Then confirm data defined as "nyc-city" received
+        And get data named "cities" without waiting for the end
+        Then confirm data defined as "nyc-city" will be received
         * stop host
 
     @ci @starts-host
@@ -15,8 +15,8 @@ Feature: E2E test, where we send and receive data from /topic/:name endpoint by 
         And instance started
         Then send data "{ \"name\": \"Hulk\" }" named "names"
         And wait for "1000" ms
-        And get output
-        Then confirm data defined as "hulkName" received
+        And get output without waiting for the end
+        Then confirm data defined as "hulkName" will be received
         * stop host
 
     @ci @starts-host
@@ -24,8 +24,8 @@ Feature: E2E test, where we send and receive data from /topic/:name endpoint by 
         When start host
         And sequence "../packages/reference-apps/endless-names-output.tar.gz" loaded
         And instance started with arguments "10"
-        And get data named "names"
-        Then confirm data defined as "endless-names-10" received
+        And get data named "names" without waiting for the end
+        Then confirm data defined as "endless-names-10" will be received
         * stop host
 
     @ci @starts-host
@@ -35,14 +35,14 @@ Feature: E2E test, where we send and receive data from /topic/:name endpoint by 
         And instance started with arguments "10"
         And sequence "../packages/reference-apps/hello-input-out.tar.gz" loaded
         And instance started
-        And get output
-        Then confirm data defined as "hello-input-out-10" received
+        And get output without waiting for the end
+        Then confirm data defined as "hello-input-out-10" will be received
         * stop host
 
     @ci @starts-host
     Scenario: E2E-013 TC-005 Send data from file to STH SD API and get it from STH SD API
         When start host
         Then send data from file "../dist/reference-apps/avengers-names-output/avengers.json" named "marvel"
-        And get data named "marvel"
+        And get data named "marvel" without waiting for the end
         * stop host
 

--- a/bdd/features/e2e/E2E-014-python.feature
+++ b/bdd/features/e2e/E2E-014-python.feature
@@ -101,7 +101,7 @@ Feature: Test our shiny new Python runner
         And send "topic test input" to input
         And sequence "../python/reference-apps/python-topic-consumer.tar.gz" loaded
         And instance started
-        Then "output" is "consumer got: producer got: topic test input"
+        Then "output" will be "consumer got: producer got: topic test input"
         And host is still running
 
     @ci @python

--- a/bdd/features/e2e/E2E-014-python.feature
+++ b/bdd/features/e2e/E2E-014-python.feature
@@ -101,7 +101,7 @@ Feature: Test our shiny new Python runner
         And send "topic test input" to input
         And sequence "../python/reference-apps/python-topic-consumer.tar.gz" loaded
         And instance started
-        Then "output" will be "consumer got: producer got: topic test input"
+        Then "output" will be data named "python-topics"
         And host is still running
 
     @ci @python

--- a/bdd/lib/host-utils.ts
+++ b/bdd/lib/host-utils.ts
@@ -47,11 +47,9 @@ export class HostUtils {
             console.error("Host is supposedly running at", this.hostUrl);
             const hostClient = new HostClient(this.hostUrl);
 
-            assert.equal(
-                (await hostClient.getLoadCheck()).currentLoad, // TODO: change to version and log it
-                200,
-                "Remote host doesn't respond"
-            );
+            const { version } = await hostClient.getVersion();
+
+            assert.ok(typeof version === "string");
 
             return Promise.resolve();
         }

--- a/bdd/lib/utils.ts
+++ b/bdd/lib/utils.ts
@@ -167,3 +167,53 @@ export function removeBoundaryQuotes(str: string) {
     }
     return str;
 }
+
+export function loopStream<T extends unknown>(
+    stream: Readable,
+    iter: (chunk: string | Buffer) => { action: "continue" } | { action: "end"; data: T; unconsumedData?: Buffer }
+): Promise<T> {
+    return new Promise((res, rej) => {
+        const onReadable = () => {
+            let chunk;
+
+            while ((chunk = stream.read()) !== null) {
+                const result = iter(chunk);
+
+                if (result.action === "continue") {
+                    continue;
+                }
+
+                stream.off("error", rej);
+                stream.off("readable", onReadable);
+                if (result.unconsumedData?.length) {
+                    stream.unshift(result.unconsumedData);
+                }
+
+                res(result.data);
+                break;
+            }
+        };
+
+        stream.on("error", rej);
+
+        // run it in case readable was already triggered
+        onReadable();
+        stream.on("readable", onReadable);
+    });
+}
+
+export async function waitForValueInStream(stream: Readable, expected: string): Promise<string> {
+    let response = '';
+    await loopStream(
+        stream,
+        (chunk) => {
+            response += chunk.toString()
+            if(response === expected) {
+                return { action: 'end', data: response }
+            }
+            return { action: 'continue' }
+        }
+    )
+
+    return response;
+}

--- a/bdd/lib/utils.ts
+++ b/bdd/lib/utils.ts
@@ -203,17 +203,18 @@ export function loopStream<T extends unknown>(
 }
 
 export async function waitForValueInStream(stream: Readable, expected: string): Promise<string> {
-    let response = '';
+    let response = "";
+
     await loopStream(
         stream,
         (chunk) => {
-            response += chunk.toString()
-            if(response === expected) {
-                return { action: 'end', data: response }
+            response += chunk.toString();
+            if (response === expected) {
+                return { action: "end", data: response };
             }
-            return { action: 'continue' }
+            return { action: "continue" };
         }
-    )
+    );
 
     return response;
 }

--- a/bdd/lib/utils.ts
+++ b/bdd/lib/utils.ts
@@ -202,7 +202,7 @@ export function loopStream<T extends unknown>(
     });
 }
 
-export async function waitForValueInStream(stream: Readable, expected: string, timeout = 1000): Promise<string> {
+export async function waitForValueInStream(stream: Readable, expected: string, timeout = 10000): Promise<string> {
     let response = "";
 
     await Promise.race([

--- a/bdd/step-definitions/e2e/cli.ts
+++ b/bdd/step-definitions/e2e/cli.ts
@@ -289,6 +289,12 @@ Then("I get instance output", { timeout: 30000 }, async function() {
     assert.equal(res.stdio[2], 0);
 });
 
+Then("I get instance output without waiting for the end", { timeout: 30000 }, async function(this: CustomWorld) {
+    const cmdProcess = await spawn("/usr/bin/env", [...si, "inst", "output", this.cliResources.instanceId || "", ...connectionFlags()]);
+
+    this.cliResources.commandInProgress = cmdProcess;
+});
+
 Then("I get the second instance output", { timeout: 30000 }, async function() {
     const res = (this as CustomWorld).cliResources;
 

--- a/bdd/step-definitions/e2e/cli.ts
+++ b/bdd/step-definitions/e2e/cli.ts
@@ -41,13 +41,13 @@ When("I execute CLI with {string} arguments", { timeout: 30000 }, async function
 });
 
 When("I execute CLI with {string} arguments without waiting for the end", { timeout: 30000 }, async function(this: CustomWorld, args: string) {
-    const cmdProcess = spawn("/usr/bin/env", [...si, ...args.split(" "), ...connectionFlags()])
+    const cmdProcess = spawn("/usr/bin/env", [...si, ...args.split(" "), ...connectionFlags()]);
 
     if (process.env.SCRAMJET_TEST_LOG) {
-        cmdProcess.stdout.pipe(process.stdout)
-        cmdProcess.stderr.pipe(process.stdout)
+        cmdProcess.stdout.pipe(process.stdout);
+        cmdProcess.stderr.pipe(process.stdout);
     }
-    this.cliResources.commandInProgress = cmdProcess
+    this.cliResources.commandInProgress = cmdProcess;
 });
 
 Then("I get a help information", function() {
@@ -296,6 +296,12 @@ Then("I get the second instance output", { timeout: 30000 }, async function() {
     assert.equal(res.stdio[2], 0);
 });
 
+Then("I get the second instance output without waiting for the end", { timeout: 30000 }, async function(this: CustomWorld) {
+    const cmdProcess = await spawn("/usr/bin/env", [...si, "inst", "output", this.cliResources.instance2Id || "", ...connectionFlags()]);
+
+    this.cliResources.commandInProgress = cmdProcess;
+});
+
 Then("I send input data {string}", async function(pathToFile: string) {
     const res = (this as CustomWorld).cliResources;
 
@@ -367,12 +373,12 @@ Then("confirm data named {string} received", async function(data) {
     assert.equal(stdio[0], expectedResponses[data]);
 });
 
-Then("confirm data named {string} will be received", {timeout: 10000} ,async function(this: CustomWorld, data) {
-    const expected = expectedResponses[data]
+Then("confirm data named {string} will be received", { timeout: 10000 }, async function(this: CustomWorld, data) {
+    const expected = expectedResponses[data];
 
-    const { stdout } = this.cliResources!.commandInProgress!
+    const { stdout } = this.cliResources!.commandInProgress!;
 
-    const response = await waitForValueInStream(stdout, expected)
+    const response = await waitForValueInStream(stdout, expected);
 
-    assert.equal(response, expected)
+    assert.equal(response, expected);
 });

--- a/bdd/step-definitions/e2e/cli.ts
+++ b/bdd/step-definitions/e2e/cli.ts
@@ -373,7 +373,7 @@ Then("confirm data named {string} received", async function(data) {
     assert.equal(stdio[0], expectedResponses[data]);
 });
 
-Then("confirm data named {string} will be received", { timeout: 10000 }, async function(this: CustomWorld, data) {
+Then("confirm data named {string} will be received", async function(this: CustomWorld, data) {
     const expected = expectedResponses[data];
 
     const { stdout } = this.cliResources!.commandInProgress!;

--- a/bdd/step-definitions/e2e/expectedResponses.ts
+++ b/bdd/step-definitions/e2e/expectedResponses.ts
@@ -3,7 +3,6 @@
 export const expectedResponses: { [key:string]: any} = {
     "endless-names-10": `{"name":"Alice"}\n{"name":"Ada"}\n{"name":"Aga"}\n{"name":"Michał"}\n{"name":"Patryk"}\n{"name":"Rafał"}\n{"name":"Aida"}\n{"name":"Basia"}\n{"name":"Natalia"}\n{"name":"Monika"}\n{"name":"Wojtek"}\n`,
     "nyc-city-nl": `{ \"city\": \"New York\" }\n`,
-    "nyc-city": `{ \"city\": \"New York\" }`,
     "hulkName": "Name is: Hulk\n",
     "hello-avengers":
         'Name is: Ant-Man\n' +

--- a/bdd/step-definitions/e2e/expectedResponses.ts
+++ b/bdd/step-definitions/e2e/expectedResponses.ts
@@ -26,6 +26,13 @@ export const expectedResponses: { [key:string]: any} = {
         'Name is: Natalia\n' +
         'Name is: Monika\n' +
         'Name is: Wojtek\n',
+    "hello-input-out-5":
+        'Name is: Alice\n' +
+        'Name is: Ada\n' +
+        'Name is: Aga\n' +
+        'Name is: Michał\n' +
+        'Name is: Patryk\n' +
+        'Name is: Rafał\n',
     "multiple-names-sources":
         'Name is: Alice\n' +
         'Name is: Ada\n' +

--- a/bdd/step-definitions/e2e/expectedResponses.ts
+++ b/bdd/step-definitions/e2e/expectedResponses.ts
@@ -25,5 +25,6 @@ export const expectedResponses: { [key:string]: any} = {
         'Name is: Basia\n' +
         'Name is: Natalia\n' +
         'Name is: Monika\n' +
-        'Name is: Wojtek\n'
+        'Name is: Wojtek\n',
+    "python-topics":  "consumer got: producer got: topic test input\n"
 };

--- a/bdd/step-definitions/e2e/expectedResponses.ts
+++ b/bdd/step-definitions/e2e/expectedResponses.ts
@@ -26,5 +26,26 @@ export const expectedResponses: { [key:string]: any} = {
         'Name is: Natalia\n' +
         'Name is: Monika\n' +
         'Name is: Wojtek\n',
+    "multiple-names-sources":
+        'Name is: Alice\n' +
+        'Name is: Ada\n' +
+        'Name is: Aga\n' +
+        'Name is: Michał\n' +
+        'Name is: Patryk\n' +
+        'Name is: Rafał\n' +
+        'Name is: Ant-Man\n' +
+        'Name is: Iron Man\n' +
+        'Name is: Hulk\n' +
+        'Name is: Hawkeye\n' +
+        'Name is: Black Widow\n' +
+        'Name is: Thor\n' +
+        'Name is: Captain America\n' +
+        'Name is: Spider-Man\n' +
+        'Name is: Alice\n' +
+        'Name is: Ada\n' +
+        'Name is: Aga\n' +
+        'Name is: Michał\n' +
+        'Name is: Patryk\n' +
+        'Name is: Rafał\n',
     "python-topics":  "consumer got: producer got: topic test input\n"
 };

--- a/bdd/step-definitions/e2e/host-steps.ts
+++ b/bdd/step-definitions/e2e/host-steps.ts
@@ -675,6 +675,13 @@ Then("{string} is {string}", async function(this: CustomWorld, stream, text) {
     assert.equal(text, await streamToString(result));
 });
 
+Then("{string} will be {string}", async function(this: CustomWorld, streamName, text) {
+    const stream = await this.resources.instance!.getStream(streamName);
+
+    const response = await waitForValueInStream(stream, text)
+    assert.equal(response, text);
+});
+
 Then("output is {string}", async function(this: CustomWorld, str) {
     const output = await this.resources.instance?.getStream("output");
 

--- a/bdd/step-definitions/e2e/host-steps.ts
+++ b/bdd/step-definitions/e2e/host-steps.ts
@@ -675,12 +675,11 @@ Then("{string} is {string}", async function(this: CustomWorld, stream, text) {
     assert.equal(text, await streamToString(result));
 });
 
-Then("{string} will be {string}", async function(this: CustomWorld, streamName, text) {
+Then("{string} will be data named {string}", async function(this: CustomWorld, streamName, dataName) {
     const stream = await this.resources.instance!.getStream(streamName);
+    const response = await waitForValueInStream(stream, expectedResponses[dataName]);
 
-    const response = await waitForValueInStream(stream, text);
-
-    assert.equal(response, text);
+    assert.equal(response, expectedResponses[dataName]);
 });
 
 Then("output is {string}", async function(this: CustomWorld, str) {

--- a/bdd/step-definitions/e2e/host-steps.ts
+++ b/bdd/step-definitions/e2e/host-steps.ts
@@ -770,6 +770,7 @@ Then("confirm data defined as {string} received", async function(this: CustomWor
 
 Then("confirm data defined as {string} will be received", async function(this: CustomWorld, data) {
     const response = await waitForValueInStream(this.resources.outStream!, expectedResponses[data]);
+
     assert.equal(response, expectedResponses[data]);
 });
 

--- a/bdd/step-definitions/e2e/host-steps.ts
+++ b/bdd/step-definitions/e2e/host-steps.ts
@@ -723,11 +723,11 @@ Then(
     }
 );
 
-Then("send data {string} named {string}", async (data: any, topic: string) => {
+Then("send json data {string} named {string}", async (data: any, topic: string) => {
     const ps = new Readable();
     const sendDataP = hostClient.sendNamedData<Stream>(topic, ps, "application/x-ndjson", true);
 
-    ps.push(data);
+    ps.push(data + "\n");
     ps.push(null);
 
     const sendData = await sendDataP;

--- a/bdd/step-definitions/e2e/host-steps.ts
+++ b/bdd/step-definitions/e2e/host-steps.ts
@@ -678,7 +678,8 @@ Then("{string} is {string}", async function(this: CustomWorld, stream, text) {
 Then("{string} will be {string}", async function(this: CustomWorld, streamName, text) {
     const stream = await this.resources.instance!.getStream(streamName);
 
-    const response = await waitForValueInStream(stream, text)
+    const response = await waitForValueInStream(stream, text);
+
     assert.equal(response, text);
 });
 

--- a/bdd/step-definitions/world.ts
+++ b/bdd/step-definitions/world.ts
@@ -1,6 +1,7 @@
 import { setWorldConstructor, World, setDefaultTimeout } from "@cucumber/cucumber";
 import { ICreateAttachment, ICreateLog } from "@cucumber/cucumber/lib/runtime/attachment_manager";
 import { InstanceClient, SequenceClient } from "@scramjet/api-client";
+import { ChildProcessWithoutNullStreams } from "child_process";
 
 const DEFAULT_TIMEOUT = 20000;
 
@@ -30,6 +31,7 @@ export class CustomWorld implements World {
         instance1Id?: string;
         instance2Id?: string;
         sequences?: any;
+        commandInProgress?: ChildProcessWithoutNullStreams
     } = {};
 
     constructor({ attach, log, parameters }: any) {

--- a/bdd/step-definitions/world.ts
+++ b/bdd/step-definitions/world.ts
@@ -2,6 +2,7 @@ import { setWorldConstructor, World, setDefaultTimeout } from "@cucumber/cucumbe
 import { ICreateAttachment, ICreateLog } from "@cucumber/cucumber/lib/runtime/attachment_manager";
 import { InstanceClient, SequenceClient } from "@scramjet/api-client";
 import { ChildProcessWithoutNullStreams } from "child_process";
+import { Readable } from "stream";
 
 const DEFAULT_TIMEOUT = 20000;
 
@@ -17,7 +18,8 @@ export class CustomWorld implements World {
         instance2?: InstanceClient,
         sequence?: SequenceClient,
         sequence1?: SequenceClient,
-        sequence2?: SequenceClient
+        sequence2?: SequenceClient,
+        outStream?: Readable;
     } = {}
 
     cliResources: {

--- a/packages/api-server/src/handlers/stream.ts
+++ b/packages/api-server/src/handlers/stream.ts
@@ -40,7 +40,7 @@ function checkAccepts(acc: string | undefined, text: boolean, json: boolean) {
  * @param {boolean} _default Value to be retured if x-end-stream header is not present.
  * @returns True if x-end-stream header is present or a given value.
  */
-function checkEndHeader(req: IncomingMessage, _default?: boolean) {
+function shouldEndTargetStream(req: IncomingMessage, _default?: boolean) {
     if (typeof req.headers["x-end-stream"] === "string" && ["true", "false", "success"].includes(req.headers["x-end-stream"])) {
         return req.headers["x-end-stream"] === "true";
     }
@@ -105,7 +105,7 @@ export function createStreamHandlers(router: SequentialCeroRouter) {
     const downstream = (
         path: string | RegExp,
         stream: StreamOutput,
-        { json = false, text = false, end: _end = false, encoding = "utf-8", checkContentType = true }: StreamConfig = {}
+        { json = false, text = false, end: _end = false, encoding = "utf-8", checkContentType = true, checkEndHeader = true }: StreamConfig = {}
     ): void => {
         router.post(path, async (req, res, next) => {
             try {
@@ -117,7 +117,7 @@ export function createStreamHandlers(router: SequentialCeroRouter) {
                     res.writeContinue();
                 }
 
-                const end = checkEndHeader(req, _end);
+                const end = checkEndHeader ? shouldEndTargetStream(req, _end) : _end;
                 const data = await getWritable(stream, req, res);
 
                 // eslint-disable-next-line no-extra-parens

--- a/packages/cli/src/lib/commands/topic.ts
+++ b/packages/cli/src/lib/commands/topic.ts
@@ -14,15 +14,14 @@ export const topic: CommandDefinition = (program) => {
 
     topicCmd.command("send <topic> [<file>]")
         .option("-t, --content-type <value>", "Content-Type", "text/plain")
-        .option("-e, --end", "x-end-stream", false)
         .description("send data to topic")
-        .action(async (topicName, filename, { contentType, end }) => displayEntity(
+        .action(async (topicName, filename, { contentType }) => displayEntity(
             program,
             getHostClient(program).sendNamedData(
                 topicName,
                 filename ? await getReadStreamFromFile(filename) : process.stdin,
                 contentType,
-                end)
+                false)
         ));
 
     topicCmd.command("get <topic>")

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -272,7 +272,7 @@ export class Host implements IComponent {
             );
 
             return this.serviceDiscovery.getByTopic(params.name)?.stream;
-        }, { checkContentType: false, end: false });
+        }, { checkContentType: false, end: false, checkEndHeader: false });
 
         this.api.upstream(`${this.apiBase}/topic/:name`, (req: ParsedMessage, _res: ServerResponse) => {
             const params = req.params || {};
@@ -540,6 +540,7 @@ export class Host implements IComponent {
             let notifyCPM = false;
 
             if (data.requires) {
+                csic.requires = data.requires;
                 notifyCPM = true;
 
                 this.serviceDiscovery.getData(
@@ -559,6 +560,7 @@ export class Host implements IComponent {
             }
 
             if (data.provides) {
+                csic.provides = data.provides;
                 notifyCPM = true;
 
                 this.logger.debug("Sequence provides data", data);
@@ -589,14 +591,21 @@ export class Host implements IComponent {
             }, InstanceMessageCode.INSTANCE_ENDED);
 
             if (csic.provides && csic.provides !== "") {
-                // @TODO not sure why we need that
                 csic.getOutputStream()!.unpipe(this.serviceDiscovery.getData(
                     {
                         topic: csic.provides,
                         contentType: ""
                     }
                 ) as Writable);
-                //this.serviceDiscovery.removeLocalProvider(cssic.provides);
+            }
+
+            if (csic.requires && csic.requires !== "") {
+                (this.serviceDiscovery.getData(
+                    {
+                        topic: csic.requires,
+                        contentType: ""
+                    }
+                ) as Readable).unpipe(csic.getInputStream()!);
             }
         });
 

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -568,7 +568,7 @@ export class Host implements IComponent {
                     csic.id
                 );
 
-                csic.getOutputStream()!.pipe(topic.stream as Writable);
+                csic.getOutputStream()!.pipe(topic.stream as Writable, { end: false });
             }
 
             if (notifyCPM) {

--- a/packages/reference-apps/avengers-names-output/avengers.json
+++ b/packages/reference-apps/avengers-names-output/avengers.json
@@ -6,4 +6,3 @@
 { "name": "Thor" }
 { "name": "Captain America" }
 { "name": "Spider-Man" }
-

--- a/packages/types/src/api-expose.ts
+++ b/packages/types/src/api-expose.ts
@@ -44,6 +44,12 @@ export type StreamConfig = {
      * Perform stream content-type type checks
      */
     checkContentType?: boolean;
+
+    /**
+     * Should consider x-end-stream header or just use the 'end'
+     *  @default true
+     */
+    checkEndHeader?: boolean;
 };
 
 export interface APIError extends Error {

--- a/python/reference-apps/python-topic-producer/main.py
+++ b/python/reference-apps/python-topic-producer/main.py
@@ -4,4 +4,4 @@ provides = {
 }
 
 def run(context, input):
-    return input.map(lambda s: f'producer got: {s}').each(print)
+    return input.map(lambda s: f'producer got: {s}' + "\n").each(print)


### PR DESCRIPTION
This PR is introducing topics that are always open which effectively makes them reusable.
What we're gaining:
* Topics will always be available for writing/reading, meaning better predictability/reliability of the usage. For example now multiple instances can write to a topic, close the producing stream in any moment and the topic will remain open for further reads/writes even if all data is read.

What we're loosing:
* Now a sequence cannot close the topic, so if some sequence/client behavior depends on its input stream (coming from topic) being ended  these sequences will run indefinitely. For many sequences that might not be a problem. However if needed, "closing" a data stream can be simulated on the data layer. Imagine you want to finish processing, and close some instances that are reading data. You could write a special message to the topic that the reading sequences could react to and close themselves. This has a risk of some unconsumed data remaining in the stream after the end message was sent (imagine one sequence "ends" the topic and the other keeps writing to it). So we might want to revisit this issue and maybe in the future introduce some ways of pausing the topic, or resetting on the topics implementation level.

This is by all means a ***breaking*** change and should be treated accordingly in a release.

### Verify
I added 2 CI tests:
*  ***E2E-013 TC-006 Send data from multiple instances to another instance on the same host***
* ***E2E-013 TC-007 Send and read data two times***