### PR TITLE
Add config endpoint

### DIFF
--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -253,6 +253,7 @@ export class Host implements IComponent {
 
         this.api.get(`${this.apiBase}/load-check`, () => this.loadCheck.getLoadCheck());
         this.api.get(`${this.apiBase}/version`, () => ({ version }));
+        this.api.get(`${this.apiBase}/config`, () => this.config);
 
         this.api.get(`${this.apiBase}/topics`, () => this.serviceDiscovery.getTopics());
         this.api.downstream(`${this.apiBase}/topic/:name`, async (req) => {

--- a/packages/sth-config/src/config-service.ts
+++ b/packages/sth-config/src/config-service.ts
@@ -1,4 +1,4 @@
-import { DeepPartial, STHConfiguration } from "@scramjet/types";
+import { DeepPartial, PublicSTHConfiguration, STHConfiguration } from "@scramjet/types";
 import { merge } from "@scramjet/utility";
 import path from "path";
 import { homedir } from "os";
@@ -82,5 +82,13 @@ export class ConfigService {
 
     update(config: DeepPartial<STHConfiguration>) {
         merge(this.config, config);
+    }
+
+    static getConfigInfo(config: STHConfiguration): PublicSTHConfiguration {
+        const { kubernetes: kubeFull, cpmSslCaPath: optionsCpmSslCaPath, ...safe } = config;
+
+        const { authConfigPath: optionsAuthConfigPath, ...kubernetes } = kubeFull;
+
+        return { ...safe, kubernetes };
     }
 }

--- a/packages/sth-config/src/config-service.ts
+++ b/packages/sth-config/src/config-service.ts
@@ -85,9 +85,14 @@ export class ConfigService {
     }
 
     static getConfigInfo(config: STHConfiguration): PublicSTHConfiguration {
-        const { kubernetes: kubeFull, cpmSslCaPath: optionsCpmSslCaPath, ...safe } = config;
+        const {
+            kubernetes: kubeFull,
+            sequencesRoot: optionsSequencesRoot2,
+            cpmSslCaPath: optionsCpmSslCaPath,
+            ...safe
+        } = config;
 
-        const { authConfigPath: optionsAuthConfigPath, ...kubernetes } = kubeFull;
+        const { authConfigPath: optionsAuthConfigPath, sequencesRoot: optionsSequencesRoot, ...kubernetes } = kubeFull;
 
         return { ...safe, kubernetes };
     }

--- a/packages/types/src/sth-configuration.ts
+++ b/packages/types/src/sth-configuration.ts
@@ -94,7 +94,7 @@ export type STHConfiguration = {
     cpmUrl: string;
 
     /**
-     * Path to the certficate authority file for verifying self-signed CPM certs 
+     * Path to the certficate authority file for verifying self-signed CPM certs
      */
     cpmSslCaPath?: string;
 
@@ -177,3 +177,7 @@ export type STHConfiguration = {
 
     kubernetes: Partial<K8SAdapterConfiguration>
 }
+
+export type PublicSTHConfiguration = Omit<Omit<STHConfiguration, "cpmSslCaPath">, "kubernetes"> & {
+    kubernetes: Omit<Partial<K8SAdapterConfiguration>, "authConfigPath">
+};

--- a/packages/types/src/sth-configuration.ts
+++ b/packages/types/src/sth-configuration.ts
@@ -178,6 +178,6 @@ export type STHConfiguration = {
     kubernetes: Partial<K8SAdapterConfiguration>
 }
 
-export type PublicSTHConfiguration = Omit<Omit<STHConfiguration, "cpmSslCaPath">, "kubernetes"> & {
-    kubernetes: Omit<Partial<K8SAdapterConfiguration>, "authConfigPath">
+export type PublicSTHConfiguration = Omit<Omit<Omit<STHConfiguration, "sequencesRoot">, "cpmSslCaPath">, "kubernetes"> & {
+    kubernetes: Omit<Omit<Partial<K8SAdapterConfiguration>, "authConfigPath">, "sequencesRoot">
 };


### PR DESCRIPTION
For debugging purposes it's worth to see the STH/Host config. This endpoint shows the safe to show values.

```
/api/v1/config
```

Verify:

```
yarn && yarn build
yarn start
```

And then in another terminal:

```
curl http://localhost:8000/api/v1/config
```

Config should be missing `authConfigPath` in Kubernetes and `cpmSslCaPath` on config level and sequencesRoot on both levels.
