### PR TITLE
Add missing data during handshake

### DIFF
--- a/packages/python-runner/runner.py
+++ b/packages/python-runner/runner.py
@@ -107,6 +107,9 @@ class Runner:
         self.logger.info(f'Got message: {message}')
         code, data = json.loads(message.decode())
 
+        if not data:
+            data = {"appConfig":{},"args":[]}
+
         self.logger.info(f'Sending PANG')
         pang_requires_data = {
             'requires': '',


### PR DESCRIPTION
Starting Python Sequence with curl command returns with error during handshake, as we are trying to return from None object 'appConfig' and 'args' keys.

1. Send Python sequence to Host
`si seq send python/reference-apps/python-alice.tar.gz`
2. Run sequence with CLI
`si seq start -`

3. It will work. To get error, you need to use curl:

```
curl --location --request POST 'http://localhost:8000/api/v1/sequence/{_id}/start' \
--header 'Content-Type: application/json'
```

Error visible in logs:

```
Traceback (most recent call last):
  File "/home/mpiotrowski/Repository/transform-hub/packages/python-runner/runner.py", line 298, in <module>
    asyncio.run(runner.main(server_host, server_port))
  File "/usr/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/home/mpiotrowski/Repository/transform-hub/packages/python-runner/runner.py", line 46, in main
    config, args = await self.handshake()
  File "/home/mpiotrowski/Repository/transform-hub/packages/python-runner/runner.py", line 119, in handshake
    return data['appConfig'], data['args']
KeyError: 'appConfig'
```

