### PR TITLE
Append newline char to topic json upstreams

### DIFF
--- a/bdd/features/e2e/E2E-013-topic.feature
+++ b/bdd/features/e2e/E2E-013-topic.feature
@@ -86,3 +86,12 @@ Feature: E2E test, where we send and receive data from /topic/:name endpoint by 
         Then confirm data defined as "hello-input-out-10" will be received
         * stop host
 
+    @ci @starts-host
+    Scenario: E2E-013 TC-008 Send data json data from sequence, get it via API 
+        When start host
+        And sequence "../packages/reference-apps/avengers-names-output.tar.gz" loaded
+        And instance started
+        And get data named "avengers" without waiting for the end
+        Then confirm data defined as "hulk-nl" will be received
+        * stop host
+        

--- a/bdd/step-definitions/e2e/expectedResponses.ts
+++ b/bdd/step-definitions/e2e/expectedResponses.ts
@@ -4,6 +4,7 @@ export const expectedResponses: { [key:string]: any} = {
     "endless-names-10": `{"name":"Alice"}\n{"name":"Ada"}\n{"name":"Aga"}\n{"name":"Michał"}\n{"name":"Patryk"}\n{"name":"Rafał"}\n{"name":"Aida"}\n{"name":"Basia"}\n{"name":"Natalia"}\n{"name":"Monika"}\n{"name":"Wojtek"}\n`,
     "nyc-city-nl": `{ \"city\": \"New York\" }\n`,
     "hulkName": "Name is: Hulk\n",
+    "hulk-nl": "{\"name\":\"Hulk\"}\n",
     "hello-avengers":
         'Name is: Ant-Man\n' +
         'Name is: Iron Man\n' +

--- a/bdd/step-definitions/e2e/host-steps.ts
+++ b/bdd/step-definitions/e2e/host-steps.ts
@@ -727,7 +727,7 @@ Then("send json data {string} named {string}", async (data: any, topic: string) 
     const ps = new Readable();
     const sendDataP = hostClient.sendNamedData<Stream>(topic, ps, "application/x-ndjson", true);
 
-    ps.push(data + "\n");
+    ps.push(data);
     ps.push(null);
 
     const sendData = await sendDataP;

--- a/packages/reference-apps/avengers-names-output/index.ts
+++ b/packages/reference-apps/avengers-names-output/index.ts
@@ -1,21 +1,16 @@
 import { ReadableApp, SynchronousStreamable } from "@scramjet/types";
-// import { resolve } from "path";
 import { PassThrough } from "stream";
-// import { createReadStream } from "fs";
 
 export = async function(_stream) {
-    // eslint-disable-next-line no-console
-    console.log("Avengers sequence started");
+    this.logger.trace("Avengers sequence started");
 
-    const ps = new PassThrough();
-    // const readFile = createReadStream(resolve(__dirname, "avengers.json"));
+    const ps = new PassThrough({ objectMode: true }) as PassThrough & SynchronousStreamable<any>;
 
-    ps.write("{ \"name\": \"Hulk\" }\n");
+    ps.write({ name: "Hulk" });
+    ps.end();
 
-    // eslint-disable-next-line no-extra-parens
-    (ps as SynchronousStreamable<any>).topic = "avengers";
-    // eslint-disable-next-line no-extra-parens
-    (ps as SynchronousStreamable<any>).contentType = "application/x-ndjson";
+    ps.topic = "avengers";
+    ps.contentType = "application/x-ndjson";
 
     return ps;
 } as ReadableApp<any>;


### PR DESCRIPTION
After implementing #370 the string encoded json streams need to always have the newline char at the end of each payload. Before this could be omitted for the last chunk. To improve the experience we are automatically appending this char if needed.

### Verify
The existing tests ***E2E-013 TC-001*** and ***E2E-013 TC-003***  should be passing [after removing hardcoded newline](https://github.com/scramjetorg/transform-hub/compare/fix/add-newline-to-json-streams-if-needed?expand=1#diff-f043ebedecfbf7d5eac41ac4b05fafbbfcce66bab3e283385d244b52bdb4ee05L730) in the tests steps.
Additionally I added the test ***E2E-013 TC-008*** to verify that sequence that provides json to topic will also correctly pass newline char