### PR TITLE
Enable topic assigment on start to sequence input/output stream 

### DIFF
--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -237,7 +237,7 @@ Feature: CLI tests
         Then confirm data named "endless-names-10" will be received
         * stop host
 
-        @ci @cli @starts-host
+    @ci @cli @starts-host
     Scenario: E2E-010 TC-025 Rename topic input
         Given start host
         When I execute CLI with "topic send names3 features/e2e/data.json" arguments

--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -236,3 +236,16 @@ Feature: CLI tests
         Then I execute CLI with "topic get names2" arguments without waiting for the end
         Then confirm data named "endless-names-10" will be received
         * stop host
+
+        @ci @cli @starts-host
+    Scenario: E2E-010 TC-025 Rename topic input
+        Given start host
+        When I execute CLI with "topic send names3 features/e2e/data.json" arguments
+        When I execute CLI with "seq send ../packages/reference-apps/hello-input-out.tar.gz --format json" arguments
+        Then I get Sequence id
+        Then I start Sequence with options "--input-topic names3"
+        Then I get instance health
+        Then I get instance id
+        And I get instance output without waiting for the end
+        Then confirm data named "hello-avengers" will be received
+        * stop host

--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -225,3 +225,14 @@ Feature: CLI tests
         And wait for "1000" ms
         And I execute CLI with "seq rm -" arguments
         And host is still running
+
+    @ci @cli @starts-host
+    Scenario: E2E-010 TC-024 Rename topic output
+        Given start host
+        When I execute CLI with "seq send ../packages/reference-apps/endless-names-output.tar.gz --format json" arguments
+        Then I get Sequence id
+        Then I start Sequence with options "--output-topic names2"
+        Then I get instance health
+        Then I execute CLI with "topic get names2" arguments without waiting for the end
+        Then confirm data named "endless-names-10" will be received
+        * stop host

--- a/bdd/features/e2e/E2E-014-python.feature
+++ b/bdd/features/e2e/E2E-014-python.feature
@@ -125,9 +125,9 @@ Feature: Test our shiny new Python runner
         Then "log" contains "Debug log message"
         And host is still running
 
-    @ci @cli 
+    @ci @python 
     Scenario: E2E-015 TC-014 Rename topic output and input
-        Given start host
+        Given host is running
         When I execute CLI with "seq send ../python/reference-apps/python-topic-producer.tar.gz --format json" arguments
         Then I get Sequence id
         Then I start Sequence with options "--output-topic names3"
@@ -137,4 +137,5 @@ Feature: Test our shiny new Python runner
         Then I start Sequence with options "--input-topic names3"
         And I get instance output without waiting for the end
         Then confirm data named "python-topics" will be received
-        * stop host
+        And host is still running
+        

--- a/bdd/features/e2e/E2E-014-python.feature
+++ b/bdd/features/e2e/E2E-014-python.feature
@@ -124,3 +124,17 @@ Feature: Test our shiny new Python runner
         And send kill message to instance
         Then "log" contains "Debug log message"
         And host is still running
+
+    @ci @cli 
+    Scenario: E2E-015 TC-014 Rename topic output and input
+        Given start host
+        When I execute CLI with "seq send ../python/reference-apps/python-topic-producer.tar.gz --format json" arguments
+        Then I get Sequence id
+        Then I start Sequence with options "--output-topic names3"
+        Then I send input "topic test input"
+        When I execute CLI with "seq send ../python/reference-apps/python-topic-consumer.tar.gz --format json" arguments
+        Then I get Sequence id
+        Then I start Sequence with options "--input-topic names3"
+        And I get instance output without waiting for the end
+        Then confirm data named "python-topics" will be received
+        * stop host

--- a/bdd/step-definitions/e2e/cli.ts
+++ b/bdd/step-definitions/e2e/cli.ts
@@ -215,6 +215,28 @@ Then("I start Sequence", async function() {
     }
 });
 
+Then("I start Sequence with options {string}", async function(optionsStr: string) {
+    const res = (this as CustomWorld).cliResources;
+    const sequenceId: string = res.sequenceId || "";
+    const options = optionsStr.split(" ");
+
+    try {
+        res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "start", sequenceId, ...options, ...formatFlags(), ...connectionFlags()]);
+        assert.equal(res.stdio[2], 0);
+
+        if (process.env.SCRAMJET_TEST_LOG) {
+            console.error(res.stdio[0]);
+        }
+
+        const instance = JSON.parse(res.stdio[0].replace("\n", ""));
+
+        res.instanceId = instance._id;
+    } catch (e: any) {
+        console.error(e.stack, res.stdio);
+        assert.fail("Error occurred");
+    }
+});
+
 Then("I get instance id", function() {
     const res = (this as CustomWorld).cliResources;
 

--- a/bdd/step-definitions/e2e/cli.ts
+++ b/bdd/step-definitions/e2e/cli.ts
@@ -337,6 +337,15 @@ Then("I send input data {string}", async function(pathToFile: string) {
     assert.equal(res.stdio[2], 0);
 });
 
+Then("I send input {string}", async function(input: string) {
+    const res = (this as CustomWorld).cliResources;
+
+    const child = spawn("/usr/bin/env", [...si, "inst", "input", res.instanceId!, ...formatFlags(), ...connectionFlags()]);
+
+    child.stdin.write(input);
+    child.stdin.end();
+});
+
 Then("I stop instance {string} {string}", async function(timeout: string, canCallKeepAlive: string) {
     const res = (this as CustomWorld).cliResources;
 

--- a/bdd/step-definitions/e2e/host-steps.ts
+++ b/bdd/step-definitions/e2e/host-steps.ts
@@ -36,7 +36,9 @@ const testPath = "../dist/reference-apps/hello-alice-out/";
 const dockerode = new Dockerode();
 const actualResponse = () => actualStatusResponse || actualHealthResponse;
 const startWith = async function(this: CustomWorld, instanceArg: string) {
-    this.resources.instance = await this.resources.sequence!.start({}, instanceArg.split(" "));
+    this.resources.instance = await this.resources.sequence!.start({
+        appConfig: {}, args: instanceArg.split(" ")
+    });
 };
 const assetsLocation = process.env.SCRAMJET_ASSETS_LOCATION || "https://assets.scramjet.org/";
 const streamToString = async (stream: Stream): Promise<string> => {
@@ -236,12 +238,12 @@ When("sequence {string} is loaded", { timeout: 15000 }, async function(this: Cus
 });
 
 When("instance started", async function(this: CustomWorld) {
-    this.resources.instance = await this.resources.sequence!.start({}, []);
+    this.resources.instance = await this.resources.sequence!.start({ appConfig: {}, args: [] });
 });
 
 When("instances started", async function(this: CustomWorld) {
-    this.resources.instance1 = await this.resources.sequence1!.start({}, []);
-    this.resources.instance2 = await this.resources.sequence2!.start({}, []);
+    this.resources.instance1 = await this.resources.sequence1!.start({ appConfig: {}, args: [] });
+    this.resources.instance2 = await this.resources.sequence2!.start({ appConfig: {}, args: [] });
 
     console.log("Sequences started.");
 });
@@ -259,7 +261,10 @@ When(
     "instance started with arguments {string} and write stream to {string} and timeout after {int} seconds",
     { timeout: -1 },
     async function(this: CustomWorld, instanceArg: string, fileName: string, timeout: number) {
-        this.resources.instance = await this.resources.sequence!.start({}, instanceArg.split(" "));
+        this.resources.instance = await this.resources.sequence!.start({
+            appConfig: {},
+            args: instanceArg.split(" ")
+        });
 
         const stream: any = await this.resources.instance?.getStream("stdout");
         const writeStream = fs.createWriteStream(fileName);

--- a/bdd/step-definitions/performance-tests/durability.ts
+++ b/bdd/step-definitions/performance-tests/durability.ts
@@ -41,7 +41,7 @@ When("starts at least {int} sequences from file {string}", { timeout: 3600 * 48 
         if ((loadCheck as any).status !== 200 || loadCheck.memFree < 512 << 20) {
             rejected = true;
         } else {
-            const instance = await sequence.start(data.appConfig, data.args);
+            const instance = await sequence.start({ appConfig: data.appConfig, args: data.args });
 
             if (instance) {
                 this.resources.instances.push(instance);

--- a/packages/api-client/src/sequence-client.ts
+++ b/packages/api-client/src/sequence-client.ts
@@ -49,12 +49,13 @@ export class SequenceClient {
      *
      * @param {any} appConfig Configuration to be passed to Instance context.
      * @param {any} args Arguments to be passed to first function in Sequence.
+     * @param {string | undefined} topic to which the output stream should be routed 
      * @returns {Promise<InstanceClient>} Promise resolving to Instance Client.
      */
-    async start(appConfig: any, args: any): Promise<InstanceClient> {
+    async start(payload: STHRestAPI.StartSequencePayload): Promise<InstanceClient> {
         const response = await this.clientUtils.post<STHRestAPI.StartSequenceResponse>(
             `${this.sequenceURL}/start`,
-            { appConfig, args },
+            payload,
             {},
             { json: true, parse: "json" }
         );

--- a/packages/cli/src/lib/commands/sequence.ts
+++ b/packages/cli/src/lib/commands/sequence.ts
@@ -94,14 +94,16 @@ export const sequence: CommandDefinition = (program) => {
         .option("-c, --config <config-path>", "Appconfig path location")
         .option("-C, --config-json <config-string>", "Appconfig as string")
         .option("--output-topic <string>", "topic to which the output stream should be routed")
+        .option("--input-topic <string>", "topic to which the input stream should be routed")
         .action(async (id: string, args: any, opts) => {
-            const { config: configPath, configJson, outputTopic } = opts;
+            const { config: configPath, configJson, outputTopic, inputTopic } = opts;
             const sequenceClient = SequenceClient.from(getSequenceId(id), getHostClient(program));
 
             const instance = await sequenceClient.start({
                 appConfig: await resolveConfigJson(configJson, configPath),
                 args,
-                outputTopic
+                outputTopic,
+                inputTopic
             });
 
             sessionConfig.setLastInstanceId(instance.id);

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -82,6 +82,11 @@ export class CSIController extends TypedEmitter<Events> {
     public outputTopic?: string
 
     /**
+     * Topic to which the input stream should be routed
+     */
+    public inputTopic?: string
+
+    /**
      * Logger.
      *
      * @type {IObjectLogger}
@@ -135,6 +140,7 @@ export class CSIController extends TypedEmitter<Events> {
         this.sthConfig = sthConfig;
         this.sequenceArgs = payload.args;
         this.outputTopic = payload.outputTopic;
+        this.inputTopic = payload.inputTopic;
 
         this.communicationHandler = communicationHandler;
 

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -534,12 +534,6 @@ export class CSIController extends TypedEmitter<Events> {
         return this.upStreams![CC.LOG];
     }
 
-    async confirmInputHook(): Promise<void> {
-        await this.controlDataStream?.whenWrote(
-            [RunnerMessageCode.INPUT_CONTENT_TYPE, { connected: true }]
-        );
-    }
-
     // @TODO discuss this
     async handleSequenceCompleted(message: EncodedMessage<RunnerMessageCode.SEQUENCE_COMPLETED>) {
         this.logger.trace("Got message: SEQUENCE_COMPLETED.");

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -77,6 +77,11 @@ export class CSIController extends TypedEmitter<Events> {
     apiInputEnabled = true;
 
     /**
+     * Topic to which the output stream should be routed
+     */
+    public outputTopic?: string
+
+    /**
      * Logger.
      *
      * @type {IObjectLogger}
@@ -118,8 +123,7 @@ export class CSIController extends TypedEmitter<Events> {
     constructor(
         id: string,
         sequence: SequenceInfo,
-        appConfig: AppConfig,
-        sequenceArgs: any[] | undefined,
+        payload: STHRestAPI.StartSequencePayload,
         communicationHandler: CommunicationHandler,
         sthConfig: STHConfiguration
     ) {
@@ -127,9 +131,10 @@ export class CSIController extends TypedEmitter<Events> {
 
         this.id = id;
         this.sequence = sequence;
-        this.appConfig = appConfig;
+        this.appConfig = payload.appConfig;
         this.sthConfig = sthConfig;
-        this.sequenceArgs = sequenceArgs;
+        this.sequenceArgs = payload.args;
+        this.outputTopic = payload.outputTopic;
 
         this.communicationHandler = communicationHandler;
 

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -298,7 +298,7 @@ export class Runner<X extends AppConfig> implements IComponent {
 
         this.logger.debug("Streams initialized");
 
-        const isInputConnected = await new Promise((res, rej) => {
+        const isInputConnectedPromised = new Promise((res, rej) => {
             this.inputResolver = { res, rej };
         });
 
@@ -330,7 +330,9 @@ export class Runner<X extends AppConfig> implements IComponent {
 
                 this.logger.trace("Waiting for input stream");
 
-                if (isInputConnected) {
+                const connected = await isInputConnectedPromised;
+
+                if (connected) {
                     this.logger.trace("Input stream connected");
 
                     await this.setInputContentType({

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -298,6 +298,10 @@ export class Runner<X extends AppConfig> implements IComponent {
 
         this.logger.debug("Streams initialized");
 
+        const isInputConnected = await new Promise((res, rej) => {
+            this.inputResolver = { res, rej };
+        });
+
         this.sendHandshakeMessage();
 
         const { appConfig, args } = await this.waitForHandshakeResponse();
@@ -326,11 +330,7 @@ export class Runner<X extends AppConfig> implements IComponent {
 
                 this.logger.trace("Waiting for input stream");
 
-                const connected = await new Promise((res, rej) => {
-                    this.inputResolver = { res, rej };
-                });
-
-                if (connected) {
+                if (isInputConnected) {
                     this.logger.trace("Input stream connected");
 
                     await this.setInputContentType({

--- a/packages/types/src/rest-api-sth/start-sequence.ts
+++ b/packages/types/src/rest-api-sth/start-sequence.ts
@@ -1,2 +1,5 @@
+import { AppConfig } from "../app-config";
+
 export type StartSequenceResponse = { id: string }
 
+export type StartSequencePayload = { appConfig: AppConfig, args?: any[], outputTopic?: string }

--- a/packages/types/src/rest-api-sth/start-sequence.ts
+++ b/packages/types/src/rest-api-sth/start-sequence.ts
@@ -2,4 +2,9 @@ import { AppConfig } from "../app-config";
 
 export type StartSequenceResponse = { id: string }
 
-export type StartSequencePayload = { appConfig: AppConfig, args?: any[], outputTopic?: string }
+export type StartSequencePayload = {
+    appConfig: AppConfig,
+    args?: any[],
+    outputTopic?: string,
+    inputTopic?: string
+}


### PR DESCRIPTION
Introducing a functionality as orignally described in https://github.com/scramjetorg/transform-hub/issues/262

### TODO 
* [x] Verify it works with Python runner (mind the wait for `INPUT_CONTENT_TYPE`)
* [ ] Support sequences that do not declare any in-code topics (preferably in another PR)
* [ ] Obtain contentType from sequence (preferably in another PR)