### PR TITLE
Python Packseq Fix

### DIFF
--- a/scripts/lib/pack.js
+++ b/scripts/lib/pack.js
@@ -2,8 +2,6 @@ const tar = require("tar");
 const { createWriteStream, readdirSync } = require("fs");
 
 class Pack {
-    PACKAGES_DIR = "packages";
-
     constructor(options) {
         this.options = options || {};
 
@@ -11,8 +9,15 @@ class Pack {
             throw new Error("No output folder specified");
         }
 
+        if (!this.options.packagesDir) {
+            throw new Error("No base folder specified");
+        }
+
         this.currDir = process.cwd();
-        this.rootDistPackPath = this.currDir.replace(this.PACKAGES_DIR, this.options.outDir);
+        this.packagesDir = options.packagesDir || this.packagesDir;
+        this.rootDistPackPath = this.currDir.replace(this.packagesDir, this.options.outDir);
+
+        console.log(`Packing ${this.rootDistPackPath} in ${options.packagesDir}`)
     }
 
     async pack() {

--- a/scripts/packsequence.js
+++ b/scripts/packsequence.js
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 
 const Pack = require("./lib/pack");
-const pack = new Pack({
+const packOptions = {
     outDir: process.env.OUT_DIR || "dist",
     localPkgs: process.env.LOCAL_PACKAGES,
-});
+    packagesDir: process.env.PACKAGES_DIR || "packages"
+};
+const pack = new Pack(packOptions);
 
 pack.pack()
     .then(


### PR DESCRIPTION
Simple fix for the directory replacement in Packseq script for python apps.

Currently python packages were packed from just the package source, not the built package in `dist`.	﻿
