### PR TITLE
Handle Runner init errors in CSIController and Clients.

### DIFF
--- a/packages/api-client/src/sequence-client.ts
+++ b/packages/api-client/src/sequence-client.ts
@@ -1,4 +1,4 @@
-import { ClientError, ClientProvider, HttpClient } from "@scramjet/client-utils";
+import { ClientProvider, HttpClient } from "@scramjet/client-utils";
 import { STHRestAPI } from "@scramjet/types";
 
 import { InstanceClient } from "./instance-client";
@@ -57,14 +57,14 @@ export class SequenceClient {
             `${this.sequenceURL}/start`,
             payload,
             {},
-            { json: true, parse: "json" }
+            { json: true, parse: "json", throwOnErrorHttpCode: false }
         );
 
-        if (response.id) {
-            return InstanceClient.from(response.id, this.host);
+        if (response.result === "error") {
+            return Promise.reject({ error: response.error });
         }
 
-        throw new ClientError("INVALID_RESPONSE", "Response did not include instance id.");
+        return InstanceClient.from(response.id, this.host);
     }
 
     /**

--- a/packages/cli/src/lib/commands/sequence.ts
+++ b/packages/cli/src/lib/commands/sequence.ts
@@ -99,15 +99,19 @@ export const sequence: CommandDefinition = (program) => {
             const { config: configPath, configJson, outputTopic, inputTopic } = opts;
             const sequenceClient = SequenceClient.from(getSequenceId(id), getHostClient(program));
 
-            const instance = await sequenceClient.start({
-                appConfig: await resolveConfigJson(configJson, configPath),
-                args,
-                outputTopic,
-                inputTopic
-            });
+            try {
+                const instance = await sequenceClient.start({
+                    appConfig: await resolveConfigJson(configJson, configPath),
+                    args,
+                    outputTopic,
+                    inputTopic
+                });
 
-            sessionConfig.setLastInstanceId(instance.id);
-            return displayObject(program, instance);
+                sessionConfig.setLastInstanceId(instance.id);
+                return displayObject(program, instance);
+            } catch (error) {
+                return displayObject(program, error);
+            }
         });
 
     /**

--- a/packages/client-utils/src/client-utils.ts
+++ b/packages/client-utils/src/client-utils.ts
@@ -41,7 +41,7 @@ export abstract class ClientUtilsBase implements HttpClient {
      * @param {RequestInit} init Request options.
      * @param {RequestConfig} options Request wrapper options.
      */
-    private async safeRequest<T>(input: RequestInfo, init: RequestInit, options: RequestConfig = { parse: "stream" }) {
+    private async safeRequest<T>(input: RequestInfo, init: RequestInit, options: RequestConfig = { parse: "stream", throwOnErrorHttpCode: true }) {
         const fetchInit: RequestInit = init;
 
         fetchInit.headers = { ...ClientUtilsBase.headers, ...fetchInit.headers };
@@ -49,7 +49,7 @@ export abstract class ClientUtilsBase implements HttpClient {
         try {
             const response = await this.fetch(input, fetchInit)
                 .then((result: any) => {
-                    if (result.ok) {
+                    if (!options.throwOnErrorHttpCode || result.ok) {
                         if (this.log) {
                             this.log.ok(result);
                         }

--- a/packages/client-utils/src/client-utils.ts
+++ b/packages/client-utils/src/client-utils.ts
@@ -41,10 +41,12 @@ export abstract class ClientUtilsBase implements HttpClient {
      * @param {RequestInit} init Request options.
      * @param {RequestConfig} options Request wrapper options.
      */
-    private async safeRequest<T>(input: RequestInfo, init: RequestInit, options: RequestConfig = { parse: "stream", throwOnErrorHttpCode: true }) {
+    private async safeRequest<T>(input: RequestInfo, init: RequestInit, options: RequestConfig = { parse: "stream" }) {
         const fetchInit: RequestInit = init;
 
         fetchInit.headers = { ...ClientUtilsBase.headers, ...fetchInit.headers };
+
+        options.throwOnErrorHttpCode ??= true;
 
         try {
             const response = await this.fetch(input, fetchInit)

--- a/packages/client-utils/src/types/index.ts
+++ b/packages/client-utils/src/types/index.ts
@@ -37,6 +37,8 @@ export type RequestConfig = {
      * Defines if payload should be stringified.
      */
     json?: boolean;
+
+    throwOnErrorHttpCode?: boolean
 };
 
 /**

--- a/packages/runner/src/bin/start-runner.ts
+++ b/packages/runner/src/bin/start-runner.ts
@@ -4,6 +4,7 @@ import { Runner } from "../runner";
 import fs from "fs";
 import { AppConfig } from "@scramjet/types";
 import { HostClient } from "../host-client";
+import { RunnerExitCode } from "@scramjet/symbols";
 
 const sequencePath: string = process.env.SEQUENCE_PATH?.replace(/.js$/, "") + ".js";
 const instancesServerPort = process.env.INSTANCES_SERVER_PORT;
@@ -12,22 +13,22 @@ const instanceId = process.env.INSTANCE_ID;
 
 if (!instancesServerPort || instancesServerPort !== parseInt(instancesServerPort, 10).toString()) {
     console.error("Incorrect run argument: instancesServerPort");
-    process.exit(1);
+    process.exit(RunnerExitCode.INVALID_ENV_VARS);
 }
 
 if (!instancesServerHost) {
     console.error("Incorrect run argument: instancesServerHost");
-    process.exit(1);
+    process.exit(RunnerExitCode.INVALID_ENV_VARS);
 }
 
 if (!instanceId) {
     console.error("Incorrect run argument: instanceId");
-    process.exit(1);
+    process.exit(RunnerExitCode.INVALID_ENV_VARS);
 }
 
 if (!fs.existsSync(sequencePath)) {
     console.error("Incorrect run argument: sequence path (" + sequencePath + ") does not exists. ");
-    process.exit(1);
+    process.exit(RunnerExitCode.INVALID_SEQUENCE_PATH);
 }
 
 const hostClient = new HostClient(+instancesServerPort, instancesServerHost);

--- a/packages/symbols/src/index.ts
+++ b/packages/symbols/src/index.ts
@@ -1,6 +1,7 @@
 export { exposeSequenceSymbol } from "./symbols";
 export { CommunicationChannel } from "./communication-channel";
 export { RunnerMessageCode } from "./runner-message-code";
+export { RunnerExitCode } from "./runner-exit-code";
 export { CPMMessageCode } from "./cpm-message-code";
 export { InstanceMessageCode } from "./instance-status-code";
 export { SequenceMessageCode } from "./sequence-status-code";

--- a/packages/symbols/src/runner-exit-code.ts
+++ b/packages/symbols/src/runner-exit-code.ts
@@ -1,0 +1,4 @@
+export enum RunnerExitCode {
+    INVALID_ENV_VARS = 8,
+    INVALID_SEQUENCE_PATH = 9,
+}

--- a/packages/symbols/src/runner-exit-code.ts
+++ b/packages/symbols/src/runner-exit-code.ts
@@ -1,4 +1,4 @@
 export enum RunnerExitCode {
-    INVALID_ENV_VARS = 8,
-    INVALID_SEQUENCE_PATH = 9,
+    INVALID_ENV_VARS = 20,
+    INVALID_SEQUENCE_PATH = 21,
 }

--- a/packages/types/src/rest-api-sth/start-sequence.ts
+++ b/packages/types/src/rest-api-sth/start-sequence.ts
@@ -1,6 +1,6 @@
 import { AppConfig } from "../app-config";
 
-export type StartSequenceResponse = { id: string }
+export type StartSequenceResponse = { result: "success", id: string } | { result: "error", error: unknown }
 
 export type StartSequencePayload = {
     appConfig: AppConfig,


### PR DESCRIPTION
Now when Runner fails on start because for example the sequence path is incorrect, it will exit with the appropriate exit code, then this exit code will be mapped in csi controller to error message and sent out in REST API response to sequence start request

### Verify
Make sure you have the CLI installed from this branch and STH running.
1. Modify package.json of [some sample](https://github.com/scramjetorg/scramjet-cloud-docs/tree/main/samples/hello) to an invalid one
2. Pack, send and start the sequence
```
si pack . -o dist.tar.gz && si seq send dist.tar.gz && si seq start -
```
3. You should see an error in CLI similar to this:
![image](https://user-images.githubusercontent.com/15108331/161779348-83d0e1bb-89d4-4df5-9191-839025123d1f.png)

