### PR TITLE
Image choice for Kubernates adapter

### DIFF
--- a/packages/adapters/src/kubernetes-client-adapter.ts
+++ b/packages/adapters/src/kubernetes-client-adapter.ts
@@ -98,7 +98,7 @@ class KubernetesClientAdapter {
             try {
                 const response = await kubeApi.readNamespacedPodStatus(podName, this._namespace);
                 const status = response.body.status?.phase || "";
-                
+
                 if (expectedStatuses.includes(status)) {
                     return status;
                 }

--- a/packages/adapters/src/kubernetes-client-adapter.ts
+++ b/packages/adapters/src/kubernetes-client-adapter.ts
@@ -98,7 +98,7 @@ class KubernetesClientAdapter {
             try {
                 const response = await kubeApi.readNamespacedPodStatus(podName, this._namespace);
                 const status = response.body.status?.phase || "";
-
+                
                 if (expectedStatuses.includes(status)) {
                     return status;
                 }

--- a/packages/adapters/src/kubernetes-config-decoder.ts
+++ b/packages/adapters/src/kubernetes-config-decoder.ts
@@ -5,6 +5,10 @@ export const adapterConfigDecoder = JsonDecoder.object<K8SAdapterConfiguration>(
     authConfigPath: JsonDecoder.optional(JsonDecoder.string),
     namespace: JsonDecoder.string,
     sthPodHost: JsonDecoder.string,
-    runnerImage: JsonDecoder.string,
-    sequencesRoot: JsonDecoder.string
+    runnerImages: JsonDecoder.object({
+        python3: JsonDecoder.string,
+        node: JsonDecoder.string
+    }, "K8SImagesDecoder"),
+    sequencesRoot: JsonDecoder.string,
+    timeout:  JsonDecoder.optional(JsonDecoder.string)
 }, "K8SAdapterConfiguration");

--- a/packages/adapters/src/kubernetes-instance-adapter.ts
+++ b/packages/adapters/src/kubernetes-instance-adapter.ts
@@ -84,9 +84,9 @@ IComponent {
             INSTANCE_ID: instanceId,
         }).map(([name, value]) => ({ name, value }));
 
-        const runnerImage = config.engines.node
-            ? this.adapterConfig.runnerImages.node
-            : this.adapterConfig.runnerImages.python3;
+        const runnerImage = config.engines.python3
+            ? this.adapterConfig.runnerImages.python3
+            : this.adapterConfig.runnerImages.node;
 
         await this.kubeClient.createPod(
             {

--- a/packages/adapters/src/kubernetes-instance-adapter.ts
+++ b/packages/adapters/src/kubernetes-instance-adapter.ts
@@ -84,6 +84,10 @@ IComponent {
             INSTANCE_ID: instanceId,
         }).map(([name, value]) => ({ name, value }));
 
+        const runnerImage = config.engines.node
+            ? this.adapterConfig.runnerImages.node
+            : this.adapterConfig.runnerImages.python3;
+
         await this.kubeClient.createPod(
             {
                 name: runnerName,
@@ -95,7 +99,7 @@ IComponent {
                 containers: [{
                     env,
                     name: runnerName,
-                    image: config.engines.node ? this.adapterConfig.runnerImages.node: this.adapterConfig.runnerImages.python3,
+                    image: runnerImage,
                     stdin: true,
                     command: ["wait-for-sequence-and-start.sh"],
                     imagePullPolicy: "Always"
@@ -158,9 +162,7 @@ IComponent {
         return new Promise(resolve => setTimeout(resolve, parseInt(ms, 10)));
     }
 
-    /**
-     * Forcefully stops Runner process.
-     */
+    // Forcefully stops Runner process.
     async remove(ms: string = "0") {
         if (!this._runnerName) {
             this.logger.error("Trying to stop non existent runner", this._runnerName);

--- a/packages/python-runner/Dockerfile
+++ b/packages/python-runner/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update \
 COPY packages/python-runner/*.py ./
 COPY packages/python-runner/requirements.txt ./requirements.txt
 COPY packages/python-runner/docker-entrypoint.sh /usr/local/bin/
+COPY packages/runner/unpack.sh /usr/local/bin/
+COPY packages/runner/wait-for-sequence-and-start.sh /usr/local/bin/
 
 RUN pip install -r requirements.txt
 

--- a/packages/python-runner/unpack.sh
+++ b/packages/python-runner/unpack.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+tar zxf - -C /package && touch /package/.ready

--- a/packages/python-runner/wait-for-sequence-and-start.sh
+++ b/packages/python-runner/wait-for-sequence-and-start.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+while true; do
+    sleep 1;
+
+    if test -f /package/.ready; then
+       docker-entrypoint.sh start-runner;
+       exit $?; 
+    fi
+done;

--- a/packages/sth-config/src/config-service.ts
+++ b/packages/sth-config/src/config-service.ts
@@ -47,14 +47,21 @@ const _defaultConfig: STHConfiguration = {
         namespace: "default",
         authConfigPath: undefined,
         sthPodHost: undefined,
-        runnerImage: undefined,
-        sequencesRoot: path.join(homedir(), ".scramjet_k8s_sequences")
+        runnerImages: {
+            python3: "",
+            node: "",
+        },
+        sequencesRoot: path.join(homedir(), ".scramjet_k8s_sequences"),
+        timeout: "0"
     }
 };
 
 merge(_defaultConfig, {
     docker: {
         prerunner: { image: imageConfig.prerunner },
+        runnerImages: imageConfig.runner,
+    },
+    kubernetes: {
         runnerImages: imageConfig.runner,
     }
 });

--- a/packages/sth/src/bin/hub.ts
+++ b/packages/sth/src/bin/hub.ts
@@ -29,7 +29,7 @@ const options: STHCommandOptions = program
     .option("--k8s-runner-py-image <image>", "Runner image spawned in Python Pod.")
     .option("--k8s-sequences-root <path>", "Kuberenetes Process Adapter will store sequences here.")
     .option("--no-docker", "Run all the instances on the host machine instead of in docker containers. UNSAFE FOR RUNNING ARBITRARY CODE.", false)
-    .option("--k8s-timeout <timeout>", "Set timeout for deleting Pod.")
+    .option("--k8s-runner-cleanup-timeout <timeout>", "Set timeout for deleting runner Pod after failure in ms")
     .parse(process.argv)
     .opts();
 
@@ -69,7 +69,7 @@ configService.update({
             python3: options.k8sRunnerPyImage
         },
         sequencesRoot: options.k8sSequencesRoot,
-        timeout: options.k8sTimeout
+        timeout: options.k8sRunnerCleanupTimeout
     }
 });
 

--- a/packages/sth/src/bin/hub.ts
+++ b/packages/sth/src/bin/hub.ts
@@ -25,9 +25,11 @@ const options: STHCommandOptions = program
     .option("--k8s-namespace <namespace>", "Kubernetes namespace used in Sequence and Instance adapters.")
     .option("--k8s-auth-config-path <path>", "Kubernetes authorization config path. If not supplied the mounted service account will be used.")
     .option("--k8s-sth-pod-host <host>", "Runner needs to connect to STH. This is the host (IP or hostname) that it will try to connect to.")
-    .option("--k8s-runner-image <image>", "Runner image spawned in Pod.")
+    .option("--k8s-runner-image <image>", "Runner image spawned in Nodejs Pod.")
+    .option("--k8s-runner-py-image <image>", "Runner image spawned in Python Pod.")
     .option("--k8s-sequences-root <path>", "Kuberenetes Process Adapter will store sequences here.")
     .option("--no-docker", "Run all the instances on the host machine instead of in docker containers. UNSAFE FOR RUNNING ARBITRARY CODE.", false)
+    .option("--k8s-timeout <timeout>", "Set timeout for deleting Pod.")
     .parse(process.argv)
     .opts();
 
@@ -62,8 +64,12 @@ configService.update({
         namespace: options.k8sNamespace,
         authConfigPath: options.k8sAuthConfigPath,
         sthPodHost: options.k8sSthPodHost,
-        runnerImage: options.k8sRunnerImage,
-        sequencesRoot: options.k8sSequencesRoot
+        runnerImages: {
+            node: options.k8sRunnerImage,
+            python3: options.k8sRunnerPyImage
+        },
+        sequencesRoot: options.k8sSequencesRoot,
+        timeout: options.k8sTimeout
     }
 });
 

--- a/packages/types/src/sth-command-options.ts
+++ b/packages/types/src/sth-command-options.ts
@@ -20,7 +20,9 @@ export type STHCommandOptions = {
     k8sNamespace: string;
     k8sAuthConfigPath: string;
     k8sSthPodHost: string;
-    k8sRunnerImage: string;
+    k8sRunnerImage: string,
+    k8sRunnerPyImage: string
     k8sSequencesRoot: string;
     docker: boolean;
+    k8sTimeout: string
 }

--- a/packages/types/src/sth-command-options.ts
+++ b/packages/types/src/sth-command-options.ts
@@ -24,5 +24,5 @@ export type STHCommandOptions = {
     k8sRunnerPyImage: string
     k8sSequencesRoot: string;
     docker: boolean;
-    k8sTimeout: string
+    k8sRunnerCleanupTimeout: string
 }

--- a/packages/types/src/sth-configuration.ts
+++ b/packages/types/src/sth-configuration.ts
@@ -73,8 +73,9 @@ export type K8SAdapterConfiguration = {
     namespace: string,
     authConfigPath?: string,
     sthPodHost: string,
-    runnerImage: string,
-    sequencesRoot: string
+    runnerImages: { python3: string, node: string },
+    sequencesRoot: string,
+    timeout?: string
 }
 
 export type STHConfiguration = {


### PR DESCRIPTION
As part of PR:
1. Support for image choice in Kubernates adapter
2. As default, we use **scramjetorg/runner** and **scramjetorg/runner-py** for creating pods
3. Python-Runner adjustments for Kubernates
4. New CLI k8s parameters:
```
--k8s-runner-image=repo.example.com/runner:0.19.2
--k8s-runner-py-image=repo.example.com/runner-py:0.19.2
```
5. @daro1337 asked for parameter "timeout", which won't kill pod immediately after finishing sequence/instance. Useful for developing. I'm not only sure if the name for that is not slightly confusing, usage: 
`--k8s-timeout=5000`

**Update**
timeout parameter name changed according to @daro1337 suggestion
`--k8s-runner-cleanup-timeout=5000`