### PR TITLE
Fixing Python sequences version

### DIFF
--- a/python/reference-apps/python-alice/package.json
+++ b/python/reference-apps/python-alice/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/scramjetorg/transform-hub.git"
   },
   "engines": {
-    "python3": "3.5.0"
+    "python3": "3.9.0"
   },
   "assets": [
     "data.json"

--- a/python/reference-apps/python-chunk-lengths/package.json
+++ b/python/reference-apps/python-chunk-lengths/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/scramjetorg/transform-hub.git"
   },
   "engines": {
-    "python3": "3.5.0"
+    "python3": "3.9.0"
   },
   "scripts": {
     "build:refapps": "mkdir -p dist/__pypackages__/ && cp *.py dist/ && pip3 install -t dist/__pypackages__/ -r requirements.txt",

--- a/python/reference-apps/python-debug-args/package.json
+++ b/python/reference-apps/python-debug-args/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/scramjetorg/transform-hub.git"
   },
   "engines": {
-    "python3": "3.5.0"
+    "python3": "3.9.0"
   },
   "scripts": {
     "build:refapps": "mkdir -p dist/__pypackages__/ && cp *.py dist/ && pip3 install -t dist/__pypackages__/ -r requirements.txt",

--- a/python/reference-apps/python-debug-input/package.json
+++ b/python/reference-apps/python-debug-input/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "url": "https://github.com/scramjetorg/transform-hub.git"
   },
+  "engines": {
+    "python3": "3.9.0"
+  },
   "scripts": {
     "build:refapps": "mkdir -p dist/__pypackages__/ && cp *.py dist/ && pip3 install -t dist/__pypackages__/ -r requirements.txt",
     "postbuild:refapps": "yarn prepack && yarn packseq",

--- a/python/reference-apps/python-events/package.json
+++ b/python/reference-apps/python-events/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/scramjetorg/transform-hub.git"
   },
   "engines": {
-    "python3": "3.5.0"
+    "python3": "3.9.0"
   },
   "scripts": {
     "build:refapps": "mkdir -p dist/ && cp *.py dist/",

--- a/python/reference-apps/python-exception-test/package.json
+++ b/python/reference-apps/python-exception-test/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/scramjetorg/transform-hub.git"
   },
   "engines": {
-    "python3": "3.5.0"
+    "python3": "3.9.0"
   },
   "scripts": {
     "build:refapps": "mkdir -p dist/ && cp *.py dist/",

--- a/python/reference-apps/python-forever/package.json
+++ b/python/reference-apps/python-forever/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/scramjetorg/transform-hub.git"
   },
   "engines": {
-    "python3": "3.5.0"
+    "python3": "3.9.0"
   },
   "scripts": {
     "build:refapps": "mkdir -p dist/ && cp *.py dist/",

--- a/python/reference-apps/python-healthy-sequence/package.json
+++ b/python/reference-apps/python-healthy-sequence/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/scramjetorg/transform-hub.git"
   },
   "engines": {
-    "python3": "3.7.0"
+    "python3": "3.9.0"
   },
   "scripts": {
     "build:refapps": "mkdir -p dist/__pypackages__/ && cp *.py dist/ && pip3 install -t dist/__pypackages__/ -r requirements.txt",

--- a/python/reference-apps/python-hello/package.json
+++ b/python/reference-apps/python-hello/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/scramjetorg/transform-hub.git"
   },
   "engines": {
-    "python3": "3.5.0"
+    "python3": "3.9.0"
   },
   "scripts": {
     "build:refapps": "mkdir -p dist/__pypackages__/ && cp *.py dist/ && pip3 install -t dist/__pypackages__/ -r requirements.txt",

--- a/python/reference-apps/python-logs-test/package.json
+++ b/python/reference-apps/python-logs-test/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/scramjetorg/transform-hub.git"
   },
   "engines": {
-    "python3": "3.5.0"
+    "python3": "3.9.0"
   },
   "scripts": {
     "build:refapps": "mkdir -p dist/ && cp *.py dist/",

--- a/python/reference-apps/python-s3-demo/package.json
+++ b/python/reference-apps/python-s3-demo/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/scramjetorg/transform-hub.git"
   },
   "engines": {
-    "python3": "3.5.0"
+    "python3": "3.9.0"
   },
   "scripts": {
     "build:refapps": "mkdir -p dist/__pypackages__/ && cp *.py dist/ && pip3 install -t dist/__pypackages__/ -r requirements.txt",

--- a/python/reference-apps/python-s5-demo/package.json
+++ b/python/reference-apps/python-s5-demo/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/scramjetorg/transform-hub.git"
   },
   "engines": {
-    "python3": "3.5.0"
+    "python3": "3.9.0"
   },
   "scripts": {
     "build:refapps": "mkdir -p dist/__pypackages__/ && cp *.py dist/ && pip3 install -t dist/__pypackages__/ -r requirements.txt",

--- a/python/reference-apps/python-s7-demo/package.json
+++ b/python/reference-apps/python-s7-demo/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/scramjetorg/transform-hub.git"
   },
   "engines": {
-    "python3": "3.5.0"
+    "python3": "3.9.0"
   },
   "scripts": {
     "build:refapps": "mkdir -p dist/__pypackages__/ && cp *.py dist/ && pip3 install -t dist/__pypackages__/ -r requirements.txt",

--- a/python/reference-apps/python-stdinout/package.json
+++ b/python/reference-apps/python-stdinout/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/scramjetorg/transform-hub.git"
   },
   "engines": {
-    "python3": "3.5.0"
+    "python3": "3.9.0"
   },
   "scripts": {
     "build:refapps": "mkdir -p dist/__pypackages__/ && cp *.py dist/ && pip3 install -t dist/__pypackages__/ -r requirements.txt",

--- a/python/reference-apps/python-stop-handler/package.json
+++ b/python/reference-apps/python-stop-handler/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/scramjetorg/transform-hub.git"
   },
   "engines": {
-    "python3": "3.5.0"
+    "python3": "3.9.0"
   },
   "scripts": {
     "build:refapps": "mkdir -p dist/ && cp *.py dist/",

--- a/python/reference-apps/python-topic-consumer/package.json
+++ b/python/reference-apps/python-topic-consumer/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/scramjetorg/transform-hub.git"
   },
   "engines": {
-    "python3": "3.7.0"
+    "python3": "3.9.0"
   },
   "scripts": {
     "build:refapps": "mkdir -p dist/ && cp *.py dist/",

--- a/python/reference-apps/python-topic-producer/package.json
+++ b/python/reference-apps/python-topic-producer/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/scramjetorg/transform-hub.git"
   },
   "engines": {
-    "python3": "3.7.0"
+    "python3": "3.9.0"
   },
   "scripts": {
     "build:refapps": "mkdir -p dist/ && cp *.py dist/",

--- a/python/reference-apps/python-unhealthy-sequence/package.json
+++ b/python/reference-apps/python-unhealthy-sequence/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/scramjetorg/transform-hub.git"
   },
   "engines": {
-    "python3": "3.7.0"
+    "python3": "3.9.0"
   },
   "scripts": {
     "build:refapps": "mkdir -p dist/ && cp *.py dist/",


### PR DESCRIPTION
As long as user don't use any external library, it is possible to run sequences normally from version 3.5. However it can be confusing, when user build package localy on version e.g **3.8**, but our Dockerfile for python-runner specified version **3.9**. 
As we don't install requirements on the fly on STH, but we package all deps into tar.gz file, I would recommend to have unified version of python3 in all our sequences with version visible in Dockerfile.