### PR TITLE
A timings refapp

### DIFF
--- a/packages/reference-apps/timings-test/.eslintrc.js
+++ b/packages/reference-apps/timings-test/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+    ignorePatterns: [".eslintrc.js"],
+    parserOptions:{
+        project: "./tsconfig.json",
+        tsconfigRootDir: __dirname
+    }
+};

--- a/packages/reference-apps/timings-test/index.ts
+++ b/packages/reference-apps/timings-test/index.ts
@@ -1,0 +1,24 @@
+/* eslint-disable no-loop-func */
+
+import { TransformApp } from "@scramjet/types";
+
+const exp: TransformApp<{a: number}, {b: number}, [], {x: number}> =
+    function(stream) {
+        const logger = this.logger;
+        const tsStart = Date.now();
+
+        this.logger.info("Simple transform function started");
+
+        return async function* () {
+            let i = 0;
+
+            for await (const { a } of stream) {
+                yield { millis: Date.now() - tsStart, b: a };
+                if (!(++i % 100)) {
+                    logger.debug(`Parsed ${i / 100}00 items`);
+                }
+            }
+        };
+    };
+
+export = exp;

--- a/packages/reference-apps/timings-test/package.json
+++ b/packages/reference-apps/timings-test/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@scramjet/reference-timings",
+  "version": "0.19.2",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "prepack": "node ../../../scripts/publish.js",
+    "build:refapps": "tsc -p tsconfig.json",
+    "postbuild:refapps": "yarn prepack && yarn packseq",
+    "packseq": "node ../../../scripts/packsequence.js",
+    "clean": "rm -rf ./dist .bic_cache"
+  },
+  "author": "Scramjet <open-source@scramjet.org>",
+  "license": "ISC",
+  "devDependencies": {
+    "@scramjet/types": "^0.19.2",
+    "@types/node": "15.12.5"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scramjetorg/transform-hub.git"
+  }
+}

--- a/packages/reference-apps/timings-test/tsconfig.json
+++ b/packages/reference-apps/timings-test/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "extends": "../../../tsconfig.base.json",
+  "include": [
+    "./index.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ],
+  "typedocOptions": {
+    "gitRevision": "HEAD"
+  }
+}


### PR DESCRIPTION
This is a simple app that adds timestamps (since sequence start) to input data﻿.

Test:

```
# build the app
yarn build:refapps --scope=@scramjet/reference-timings

# upload sequence
sequence send packages/reference-apps/timings-test.tar.gz

# run the following script:

si sequence start - \
    && sleep 1 \
    && ( ( si instance log - && echo '----LOG END----') & si instance output - | sed "x;s/.*/date +%T/e;G;s/\n/ /g" | tee ~/test.txt & ) \
    && ( echo -e '{"a":1}\n{"a":2}\n'; sleep 3; echo '{"a":3}' ) | si instance input -t 'application/x-ndjson' -;
```

This will send the data to the endpoint, read it from and add timestamp to every data point send and received.