### PR TITLE
Release/0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ Prominent
 - b214a8d4 - Add HTTPS support to Verser.
 - 7f2484f16 - CLI commands for interacting with Scramjet Cloud Platform
 - 417685b07 - Switch topic requests to https.
+- ac15ee4e4 - Do not close topic when producing output stream is ended.
+- 22f1a1656 - Add python3 to STH docker image
+- 7417b7a98 - Enable assigning output topic on sequence start.
+- 018e6975d - CLI commands update
 
 New features:
 
@@ -67,6 +71,9 @@ New features:
 - **Python Instance events** - Handle Instance events in Python Runner
 - **Kubernetes Runtime Adapters** - new Sequence and Instance Adapters allow running programs on Kubernetes
 - **Dockerized Python Runner** - Python programs can now be run in Docker containers
+- **Reusable topics** - Topic streams don't end when input ends, you can always send more input
+- **Python in Docker image** - When running STH from docker image, you will have python installed to run python sequences inside
+
 
 Bugfixes and minor improvements:
 
@@ -126,7 +133,11 @@ Bugfixes and minor improvements:
 - Fix the build scripts of @scramjet/cli so that completion is added
 - Add cli utility for coloring JSON logs obtained from remote STH
 - Add /config API endpoint for checking STH/Host config
+- Fix for adding Python sequence library to path
+- Choosing runner image in kubernetes adapter (so that either python or node runner can be used)
+- Provide more infromation about the service on /version endpoint (service name, commit ID)
+- API base url (e.g. the one provided to CLI) is normalized
 
-## @scramjet/transform Hub - v0.19.2
+## @scramjet/transform Hub - v0.20.0
 
 This is the last release in changelog.

--- a/docs/adapters/classes/KubernetesInstanceAdapter.md
+++ b/docs/adapters/classes/KubernetesInstanceAdapter.md
@@ -28,6 +28,7 @@ Adapter for running Instance by Runner executed in separate process.
 - [remove](KubernetesInstanceAdapter.md#remove)
 - [run](KubernetesInstanceAdapter.md#run)
 - [stats](KubernetesInstanceAdapter.md#stats)
+- [timeout](KubernetesInstanceAdapter.md#timeout)
 
 ### Constructors
 
@@ -107,7 +108,7 @@ ILifeCycleAdapterMain.cleanup
 
 #### Defined in
 
-[kubernetes-instance-adapter.ts:148](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L148)
+[kubernetes-instance-adapter.ts:152](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L152)
 
 ___
 
@@ -149,15 +150,19 @@ ILifeCycleAdapterRun.monitorRate
 
 #### Defined in
 
-[kubernetes-instance-adapter.ts:153](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L153)
+[kubernetes-instance-adapter.ts:157](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L157)
 
 ___
 
 ### remove
 
-▸ **remove**(): `Promise`<`void`\>
+▸ **remove**(`ms?`): `Promise`<`void`\>
 
-Forcefully stops Runner process.
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `ms` | `string` | `"0"` |
 
 #### Returns
 
@@ -169,7 +174,7 @@ ILifeCycleAdapterMain.remove
 
 #### Defined in
 
-[kubernetes-instance-adapter.ts:160](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L160)
+[kubernetes-instance-adapter.ts:166](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L166)
 
 ___
 
@@ -220,6 +225,26 @@ ILifeCycleAdapterRun.stats
 #### Defined in
 
 [kubernetes-instance-adapter.ts:63](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L63)
+
+___
+
+### timeout
+
+▸ **timeout**(`ms`): `Promise`<`unknown`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `ms` | `string` |
+
+#### Returns
+
+`Promise`<`unknown`\>
+
+#### Defined in
+
+[kubernetes-instance-adapter.ts:161](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L161)
 
 ## Constructors
 

--- a/docs/api-client/classes/HostClient.md
+++ b/docs/api-client/classes/HostClient.md
@@ -28,6 +28,7 @@ Provides methods to interact with Host.
 - [getLogStream](HostClient.md#getlogstream)
 - [getNamedData](HostClient.md#getnameddata)
 - [getSequence](HostClient.md#getsequence)
+- [getTopics](HostClient.md#gettopics)
 - [getVersion](HostClient.md#getversion)
 - [listInstances](HostClient.md#listinstances)
 - [listSequences](HostClient.md#listsequences)
@@ -206,6 +207,20 @@ Promise resolving to Sequence details.
 #### Defined in
 
 [api-client/src/host-client.ts:66](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L66)
+
+___
+
+### getTopics
+
+▸ **getTopics**(): `Promise`<`GetTopicsResponse`\>
+
+#### Returns
+
+`Promise`<`GetTopicsResponse`\>
+
+#### Defined in
+
+[api-client/src/host-client.ts:133](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L133)
 
 ___
 

--- a/docs/api-client/classes/SequenceClient.md
+++ b/docs/api-client/classes/SequenceClient.md
@@ -149,7 +149,7 @@ Promise resolving to Sequence info.
 
 #### Defined in
 
-[api-client/src/sequence-client.ts:94](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/sequence-client.ts#L94)
+[api-client/src/sequence-client.ts:95](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/sequence-client.ts#L95)
 
 ___
 
@@ -174,7 +174,7 @@ Instance client.
 
 #### Defined in
 
-[api-client/src/sequence-client.ts:85](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/sequence-client.ts#L85)
+[api-client/src/sequence-client.ts:86](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/sequence-client.ts#L86)
 
 ___
 
@@ -192,7 +192,7 @@ Promise resolving to list of Instances.
 
 #### Defined in
 
-[api-client/src/sequence-client.ts:74](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/sequence-client.ts#L74)
+[api-client/src/sequence-client.ts:75](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/sequence-client.ts#L75)
 
 ___
 
@@ -208,22 +208,21 @@ Not implemented.
 
 #### Defined in
 
-[api-client/src/sequence-client.ts:101](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/sequence-client.ts#L101)
+[api-client/src/sequence-client.ts:102](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/sequence-client.ts#L102)
 
 ___
 
 ### start
 
-▸ **start**(`appConfig`, `args`): `Promise`<[`InstanceClient`](InstanceClient.md)\>
+▸ **start**(`payload`): `Promise`<[`InstanceClient`](InstanceClient.md)\>
 
 Starts sequence.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `appConfig` | `any` | Configuration to be passed to Instance context. |
-| `args` | `any` | Arguments to be passed to first function in Sequence. |
+| Name | Type |
+| :------ | :------ |
+| `payload` | `StartSequencePayload` |
 
 #### Returns
 
@@ -233,4 +232,4 @@ Promise resolving to Instance Client.
 
 #### Defined in
 
-[api-client/src/sequence-client.ts:54](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/sequence-client.ts#L54)
+[api-client/src/sequence-client.ts:55](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/sequence-client.ts#L55)

--- a/docs/host/classes/CPMConnector.md
+++ b/docs/host/classes/CPMConnector.md
@@ -64,8 +64,8 @@ Provides communication with Manager.
 - [sendInstancesInfo](CPMConnector.md#sendinstancesinfo)
 - [sendSequenceInfo](CPMConnector.md#sendsequenceinfo)
 - [sendSequencesInfo](CPMConnector.md#sendsequencesinfo)
-- [sendTopic](CPMConnector.md#sendtopic)
 - [sendTopicInfo](CPMConnector.md#sendtopicinfo)
+- [sendTopicsInfo](CPMConnector.md#sendtopicsinfo)
 - [setLoadCheck](CPMConnector.md#setloadcheck)
 - [setLoadCheckMessageSender](CPMConnector.md#setloadcheckmessagesender)
 - [setMaxListeners](CPMConnector.md#setmaxlisteners)
@@ -84,7 +84,7 @@ Maximum attempts for first connection try.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:47](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L47)
+[packages/host/src/lib/cpm-connector.ts:45](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L45)
 
 ___
 
@@ -96,7 +96,7 @@ Maximum retries on connection lost.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:54](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L54)
+[packages/host/src/lib/cpm-connector.ts:52](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L52)
 
 ___
 
@@ -108,7 +108,7 @@ Delay between connection attempts.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:61](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L61)
+[packages/host/src/lib/cpm-connector.ts:59](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L59)
 
 ___
 
@@ -120,7 +120,7 @@ Loaded certficiate authority file for connecting to CPM via HTTPS
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:165](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L165)
+[packages/host/src/lib/cpm-connector.ts:163](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L163)
 
 ___
 
@@ -132,7 +132,7 @@ Stream used to read and write data to Manager.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:96](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L96)
+[packages/host/src/lib/cpm-connector.ts:94](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L94)
 
 ___
 
@@ -144,7 +144,7 @@ Stream used to write data to Manager.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:89](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L89)
+[packages/host/src/lib/cpm-connector.ts:87](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L87)
 
 ___
 
@@ -156,7 +156,7 @@ Connector options.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:75](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L75)
+[packages/host/src/lib/cpm-connector.ts:73](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L73)
 
 ___
 
@@ -168,7 +168,7 @@ Connection status indicator.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:82](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L82)
+[packages/host/src/lib/cpm-connector.ts:80](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L80)
 
 ___
 
@@ -180,7 +180,7 @@ Connection object.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:122](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L122)
+[packages/host/src/lib/cpm-connector.ts:120](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L120)
 
 ___
 
@@ -192,7 +192,7 @@ Connection attempts counter
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:139](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L139)
+[packages/host/src/lib/cpm-connector.ts:137](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L137)
 
 ___
 
@@ -204,7 +204,7 @@ Id of Manager (e.g. "cpm-1").
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:146](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L146)
+[packages/host/src/lib/cpm-connector.ts:144](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L144)
 
 ___
 
@@ -216,7 +216,7 @@ Custom id indicator.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:110](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L110)
+[packages/host/src/lib/cpm-connector.ts:108](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L108)
 
 ___
 
@@ -228,7 +228,7 @@ Host info object containing host id.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:117](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L117)
+[packages/host/src/lib/cpm-connector.ts:115](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L115)
 
 ___
 
@@ -240,7 +240,7 @@ Indicator for reconnection state.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:127](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L127)
+[packages/host/src/lib/cpm-connector.ts:125](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L125)
 
 ___
 
@@ -252,7 +252,7 @@ Load check instance to be used to get load check data.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:68](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L68)
+[packages/host/src/lib/cpm-connector.ts:66](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L66)
 
 ___
 
@@ -264,7 +264,7 @@ Reference for method called in interval and sending load check data to the Manag
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:160](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L160)
+[packages/host/src/lib/cpm-connector.ts:158](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L158)
 
 ___
 
@@ -276,7 +276,7 @@ Logger.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:103](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L103)
+[packages/host/src/lib/cpm-connector.ts:101](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L101)
 
 ___
 
@@ -288,7 +288,7 @@ VerserClient instance used for connecting with Verser.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:153](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L153)
+[packages/host/src/lib/cpm-connector.ts:151](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L151)
 
 ___
 
@@ -300,7 +300,7 @@ True if connection to Manager has been established at least once.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:132](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L132)
+[packages/host/src/lib/cpm-connector.ts:130](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L130)
 
 ## Methods
 
@@ -352,7 +352,7 @@ Promise that resolves when connection is established.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:340](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L340)
+[packages/host/src/lib/cpm-connector.ts:336](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L336)
 
 ___
 
@@ -419,7 +419,7 @@ Host id.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:234](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L234)
+[packages/host/src/lib/cpm-connector.ts:230](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L230)
 
 ___
 
@@ -437,7 +437,7 @@ Promise<LoadCheckStatMessage> Promise resolving to LoadCheckStatMessage object.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:472](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L472)
+[packages/host/src/lib/cpm-connector.ts:468](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L468)
 
 ___
 
@@ -473,7 +473,7 @@ Promise resolving to NetworkInfo object.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:439](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L439)
+[packages/host/src/lib/cpm-connector.ts:435](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L435)
 
 ___
 
@@ -497,7 +497,7 @@ Promise resolving to `ReadableStream<any>` with topic data.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:600](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L600)
+[packages/host/src/lib/cpm-connector.ts:589](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L589)
 
 ___
 
@@ -514,7 +514,7 @@ Tries to reconnect.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:387](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L387)
+[packages/host/src/lib/cpm-connector.ts:383](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L383)
 
 ___
 
@@ -530,7 +530,7 @@ Initializes connector.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:241](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L241)
+[packages/host/src/lib/cpm-connector.ts:237](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L237)
 
 ___
 
@@ -793,7 +793,7 @@ Configuration object.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:258](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L258)
+[packages/host/src/lib/cpm-connector.ts:254](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L254)
 
 ___
 
@@ -809,7 +809,7 @@ Reconnects to Manager if maximum number of connection attempts is not reached.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:406](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L406)
+[packages/host/src/lib/cpm-connector.ts:402](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L402)
 
 ___
 
@@ -827,7 +827,7 @@ Channel 1 is reserved for log stream sent to Manager.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:283](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L283)
+[packages/host/src/lib/cpm-connector.ts:279](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L279)
 
 ___
 
@@ -911,7 +911,7 @@ Sends instance information to Manager via communication channel.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:537](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L537)
+[packages/host/src/lib/cpm-connector.ts:533](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L533)
 
 ___
 
@@ -933,7 +933,7 @@ Sends list of sequence to Manager via communication channel.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:505](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L505)
+[packages/host/src/lib/cpm-connector.ts:501](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L501)
 
 ___
 
@@ -956,7 +956,7 @@ Sends sequence status to Manager via communication channel.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:521](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L521)
+[packages/host/src/lib/cpm-connector.ts:517](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L517)
 
 ___
 
@@ -978,34 +978,7 @@ Sends list of sequence to Manager via communication channel.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:490](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L490)
-
-___
-
-### sendTopic
-
-▸ **sendTopic**(`topic`, `topicCfg`): `void`
-
-Makes a POST request to Manager with topic data.
-
-**`todo:`** Consider to make this request via VerserClient.
-
-#### Parameters
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `topic` | `string` | Topic name. |
-| `topicCfg` | `Object` | Topic configuration. |
-| `topicCfg.contentType` | `string` | - |
-| `topicCfg.stream` | `ReadableStream`<`any`\> \| `WritableStream`<`any`\> | - |
-
-#### Returns
-
-`void`
-
-#### Defined in
-
-[packages/host/src/lib/cpm-connector.ts:566](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L566)
+[packages/host/src/lib/cpm-connector.ts:486](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L486)
 
 ___
 
@@ -1031,7 +1004,27 @@ Topic information is send via communication channel.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:553](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L553)
+[packages/host/src/lib/cpm-connector.ts:549](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L549)
+
+___
+
+### sendTopicsInfo
+
+▸ **sendTopicsInfo**(`topics`): `Promise`<`void`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `topics` | { `contentType?`: `string` ; `provides?`: `string` ; `requires?`: `string`  }[] |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Defined in
+
+[packages/host/src/lib/cpm-connector.ts:555](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L555)
 
 ___
 
@@ -1053,7 +1046,7 @@ Sets up load check object to be used to get load check data.
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:225](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L225)
+[packages/host/src/lib/cpm-connector.ts:221](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L221)
 
 ___
 
@@ -1069,7 +1062,7 @@ Sets up a method sending load check data and to be called with interval
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:456](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L456)
+[packages/host/src/lib/cpm-connector.ts:452](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L452)
 
 ___
 
@@ -1116,4 +1109,4 @@ TypedEmitter&lt;Events\&gt;.constructor
 
 #### Defined in
 
-[packages/host/src/lib/cpm-connector.ts:174](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L174)
+[packages/host/src/lib/cpm-connector.ts:172](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/cpm-connector.ts#L172)

--- a/docs/host/classes/CSIController.md
+++ b/docs/host/classes/CSIController.md
@@ -23,8 +23,10 @@ Handles all Instance lifecycle, exposes instance's HTTP API.
 - [id](CSIController.md#id)
 - [info](CSIController.md#info)
 - [initResolver](CSIController.md#initresolver)
+- [inputTopic](CSIController.md#inputtopic)
 - [instancePromise](CSIController.md#instancepromise)
 - [logger](CSIController.md#logger)
+- [outputTopic](CSIController.md#outputtopic)
 - [provides](CSIController.md#provides)
 - [requires](CSIController.md#requires)
 - [router](CSIController.md#router)
@@ -38,7 +40,6 @@ Handles all Instance lifecycle, exposes instance's HTTP API.
 
 - [addListener](CSIController.md#addlistener)
 - [cleanup](CSIController.md#cleanup)
-- [confirmInputHook](CSIController.md#confirminputhook)
 - [createInstanceAPIRouter](CSIController.md#createinstanceapirouter)
 - [emit](CSIController.md#emit)
 - [eventNames](CSIController.md#eventnames)
@@ -86,7 +87,7 @@ Handles all Instance lifecycle, exposes instance's HTTP API.
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:96](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L96)
+[packages/host/src/lib/csi-controller.ts:106](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L106)
 
 ___
 
@@ -126,7 +127,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:116](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L116)
+[packages/host/src/lib/csi-controller.ts:126](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L126)
 
 ___
 
@@ -185,6 +186,18 @@ ___
 
 ___
 
+### inputTopic
+
+• `Optional` **inputTopic**: `string`
+
+Topic to which the input stream should be routed
+
+#### Defined in
+
+[packages/host/src/lib/csi-controller.ts:87](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L87)
+
+___
+
 ### instancePromise
 
 • `Optional` **instancePromise**: `Promise`<`number`\>
@@ -203,7 +216,19 @@ Logger.
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:84](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L84)
+[packages/host/src/lib/csi-controller.ts:94](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L94)
+
+___
+
+### outputTopic
+
+• `Optional` **outputTopic**: `string`
+
+Topic to which the output stream should be routed
+
+#### Defined in
+
+[packages/host/src/lib/csi-controller.ts:82](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L82)
 
 ___
 
@@ -335,21 +360,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:224](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L224)
-
-___
-
-### confirmInputHook
-
-▸ **confirmInputHook**(): `Promise`<`void`\>
-
-#### Returns
-
-`Promise`<`void`\>
-
-#### Defined in
-
-[packages/host/src/lib/csi-controller.ts:526](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L526)
+[packages/host/src/lib/csi-controller.ts:250](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L250)
 
 ___
 
@@ -363,7 +374,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:351](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L351)
+[packages/host/src/lib/csi-controller.ts:377](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L377)
 
 ___
 
@@ -426,7 +437,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:500](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L500)
+[packages/host/src/lib/csi-controller.ts:526](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L526)
 
 ___
 
@@ -440,7 +451,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:518](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L518)
+[packages/host/src/lib/csi-controller.ts:544](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L544)
 
 ___
 
@@ -454,7 +465,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:522](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L522)
+[packages/host/src/lib/csi-controller.ts:548](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L548)
 
 ___
 
@@ -486,7 +497,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:514](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L514)
+[packages/host/src/lib/csi-controller.ts:540](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L540)
 
 ___
 
@@ -506,7 +517,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:313](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L313)
+[packages/host/src/lib/csi-controller.ts:339](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L339)
 
 ___
 
@@ -526,7 +537,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:340](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L340)
+[packages/host/src/lib/csi-controller.ts:366](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L366)
 
 ___
 
@@ -546,7 +557,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:579](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L579)
+[packages/host/src/lib/csi-controller.ts:596](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L596)
 
 ___
 
@@ -566,7 +577,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:533](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L533)
+[packages/host/src/lib/csi-controller.ts:553](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L553)
 
 ___
 
@@ -586,7 +597,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:551](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L551)
+[packages/host/src/lib/csi-controller.ts:569](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L569)
 
 ___
 
@@ -606,7 +617,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:239](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L239)
+[packages/host/src/lib/csi-controller.ts:265](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L265)
 
 ___
 
@@ -620,7 +631,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:231](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L231)
+[packages/host/src/lib/csi-controller.ts:257](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L257)
 
 ___
 
@@ -694,7 +705,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:159](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L159)
+[packages/host/src/lib/csi-controller.ts:170](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L170)
 
 ___
 
@@ -978,7 +989,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:146](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L146)
+[packages/host/src/lib/csi-controller.ts:157](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L157)
 
 ___
 
@@ -992,13 +1003,13 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:176](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L176)
+[packages/host/src/lib/csi-controller.ts:187](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L187)
 
 ## Constructors
 
 ### constructor
 
-• **new CSIController**(`id`, `sequence`, `appConfig`, `sequenceArgs`, `communicationHandler`, `sthConfig`)
+• **new CSIController**(`id`, `sequence`, `payload`, `communicationHandler`, `sthConfig`)
 
 #### Parameters
 
@@ -1006,8 +1017,7 @@ ___
 | :------ | :------ |
 | `id` | `string` |
 | `sequence` | `SequenceInfo` |
-| `appConfig` | `AppConfig` |
-| `sequenceArgs` | `undefined` \| `any`[] |
+| `payload` | `StartSequencePayload` |
 | `communicationHandler` | `CommunicationHandler` |
 | `sthConfig` | `STHConfiguration` |
 
@@ -1017,7 +1027,7 @@ TypedEmitter&lt;Events\&gt;.constructor
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:118](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L118)
+[packages/host/src/lib/csi-controller.ts:128](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L128)
 
 ## Accessors
 
@@ -1031,7 +1041,7 @@ TypedEmitter&lt;Events\&gt;.constructor
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:98](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L98)
+[packages/host/src/lib/csi-controller.ts:108](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L108)
 
 • `set` **endOfSequence**(`prm`): `void`
 
@@ -1047,7 +1057,7 @@ TypedEmitter&lt;Events\&gt;.constructor
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:106](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L106)
+[packages/host/src/lib/csi-controller.ts:116](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L116)
 
 ___
 
@@ -1061,4 +1071,4 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:88](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L88)
+[packages/host/src/lib/csi-controller.ts:98](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L98)

--- a/docs/host/classes/Host.md
+++ b/docs/host/classes/Host.md
@@ -27,6 +27,14 @@ Can communicate with Manager.
 - [sequencesStore](Host.md#sequencesstore)
 - [serviceDiscovery](Host.md#servicediscovery)
 - [socketServer](Host.md#socketserver)
+- [topicsBase](Host.md#topicsbase)
+
+### Accessors
+
+- [apiVersion](Host.md#apiversion)
+- [build](Host.md#build)
+- [service](Host.md#service)
+- [version](Host.md#version)
 
 ### Methods
 
@@ -37,6 +45,7 @@ Can communicate with Manager.
 - [getSequence](Host.md#getsequence)
 - [getSequenceInstances](Host.md#getsequenceinstances)
 - [getSequences](Host.md#getsequences)
+- [getTopics](Host.md#gettopics)
 - [handleDeleteSequence](Host.md#handledeletesequence)
 - [handleNewSequence](Host.md#handlenewsequence)
 - [handleStartSequence](Host.md#handlestartsequence)
@@ -45,6 +54,7 @@ Can communicate with Manager.
 - [main](Host.md#main)
 - [startCSIController](Host.md#startcsicontroller)
 - [stop](Host.md#stop)
+- [topicsMiddleware](Host.md#topicsmiddleware)
 
 ### Constructors
 
@@ -60,7 +70,7 @@ The Host's API Server.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:48](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L48)
+[packages/host/src/lib/host.ts:52](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L52)
 
 ___
 
@@ -72,7 +82,7 @@ Api path prefix based on initial configuration.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:53](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L53)
+[packages/host/src/lib/host.ts:57](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L57)
 
 ___
 
@@ -82,7 +92,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:92](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L92)
+[packages/host/src/lib/host.ts:98](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L98)
 
 ___
 
@@ -94,7 +104,7 @@ Configuration.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:43](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L43)
+[packages/host/src/lib/host.ts:47](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L47)
 
 ___
 
@@ -106,7 +116,7 @@ Instance of CPMConnector used to communicate with Manager.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:65](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L65)
+[packages/host/src/lib/host.ts:71](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L71)
 
 ___
 
@@ -118,7 +128,7 @@ Instance path prefix.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:58](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L58)
+[packages/host/src/lib/host.ts:62](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L62)
 
 ___
 
@@ -134,7 +144,7 @@ Object to store CSIControllers.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:70](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L70)
+[packages/host/src/lib/host.ts:76](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L76)
 
 ___
 
@@ -146,7 +156,7 @@ Instance of class providing load check.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:85](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L85)
+[packages/host/src/lib/host.ts:91](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L91)
 
 ___
 
@@ -162,7 +172,7 @@ IComponent.logger
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:80](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L80)
+[packages/host/src/lib/host.ts:86](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L86)
 
 ___
 
@@ -172,7 +182,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:93](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L93)
+[packages/host/src/lib/host.ts:99](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L99)
 
 ___
 
@@ -184,7 +194,7 @@ Sequences store.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:75](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L75)
+[packages/host/src/lib/host.ts:81](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L81)
 
 ___
 
@@ -196,7 +206,7 @@ Service to handle topics.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:90](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L90)
+[packages/host/src/lib/host.ts:96](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L96)
 
 ___
 
@@ -206,7 +216,73 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:60](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L60)
+[packages/host/src/lib/host.ts:66](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L66)
+
+___
+
+### topicsBase
+
+• **topicsBase**: `string`
+
+#### Defined in
+
+[packages/host/src/lib/host.ts:64](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L64)
+
+## Accessors
+
+### apiVersion
+
+• `get` **apiVersion**(): `string`
+
+#### Returns
+
+`string`
+
+#### Defined in
+
+[packages/host/src/lib/host.ts:116](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L116)
+
+___
+
+### build
+
+• `get` **build**(): `string`
+
+#### Returns
+
+`string`
+
+#### Defined in
+
+[packages/host/src/lib/host.ts:126](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L126)
+
+___
+
+### service
+
+• `get` **service**(): `string`
+
+#### Returns
+
+`string`
+
+#### Defined in
+
+[packages/host/src/lib/host.ts:112](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L112)
+
+___
+
+### version
+
+• `get` **version**(): `string`
+
+#### Returns
+
+`string`
+
+#### Defined in
+
+[packages/host/src/lib/host.ts:122](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L122)
 
 ## Methods
 
@@ -228,7 +304,7 @@ Setting up handlers for general Host API endpoints:
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:241](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L241)
+[packages/host/src/lib/host.ts:269](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L269)
 
 ___
 
@@ -244,7 +320,7 @@ Stops running servers.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:699](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L699)
+[packages/host/src/lib/host.ts:752](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L752)
 
 ___
 
@@ -260,7 +336,7 @@ Initializes connector and connects to Manager.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:221](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L221)
+[packages/host/src/lib/host.ts:248](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L248)
 
 ___
 
@@ -278,7 +354,7 @@ List of instances.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:615](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L615)
+[packages/host/src/lib/host.ts:659](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L659)
 
 ___
 
@@ -302,7 +378,7 @@ Sequence info object.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:630](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L630)
+[packages/host/src/lib/host.ts:674](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L674)
 
 ___
 
@@ -326,7 +402,7 @@ List of instances.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:667](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L667)
+[packages/host/src/lib/host.ts:711](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L711)
 
 ___
 
@@ -344,7 +420,21 @@ List of sequences.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:652](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L652)
+[packages/host/src/lib/host.ts:696](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L696)
+
+___
+
+### getTopics
+
+▸ **getTopics**(): { `contentType`: `string` = topic.contentType; `name`: `string` = topic.topic }[]
+
+#### Returns
+
+{ `contentType`: `string` = topic.contentType; `name`: `string` = topic.topic }[]
+
+#### Defined in
+
+[packages/host/src/lib/host.ts:722](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L722)
 
 ___
 
@@ -371,7 +461,7 @@ Promise resolving to operation result object.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:344](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L344)
+[packages/host/src/lib/host.ts:351](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L351)
 
 ___
 
@@ -397,7 +487,7 @@ Promise resolving to operation result.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:421](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L421)
+[packages/host/src/lib/host.ts:428](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L428)
 
 ___
 
@@ -425,7 +515,7 @@ Promise resolving to operation result object.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:467](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L467)
+[packages/host/src/lib/host.ts:474](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L474)
 
 ___
 
@@ -442,7 +532,7 @@ Used to recover sequences information after restart.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:394](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L394)
+[packages/host/src/lib/host.ts:401](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L401)
 
 ___
 
@@ -472,7 +562,7 @@ Instance middleware.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:308](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L308)
+[packages/host/src/lib/host.ts:311](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L311)
 
 ___
 
@@ -498,13 +588,13 @@ Promise resolving to instance of Host.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:175](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L175)
+[packages/host/src/lib/host.ts:202](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L202)
 
 ___
 
 ### startCSIController
 
-▸ **startCSIController**(`sequence`, `appConfig`, `sequenceArgs?`): `Promise`<[`CSIController`](CSIController.md)\>
+▸ **startCSIController**(`sequence`, `payload`): `Promise`<[`CSIController`](CSIController.md)\>
 
 Creates new CSIController [CSIController](CSIController.md) object and handles its events.
 
@@ -513,8 +603,7 @@ Creates new CSIController [CSIController](CSIController.md) object and handles i
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `sequence` | `SequenceInfo` | Sequence info object. |
-| `appConfig` | `AppConfig` | App configuration object. |
-| `sequenceArgs?` | `any`[] | - |
+| `payload` | `StartSequencePayload` | - |
 
 #### Returns
 
@@ -522,7 +611,7 @@ Creates new CSIController [CSIController](CSIController.md) object and handles i
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:511](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L511)
+[packages/host/src/lib/host.ts:525](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L525)
 
 ___
 
@@ -539,7 +628,29 @@ using its CSIController [CSIController](CSIController.md)
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:682](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L682)
+[packages/host/src/lib/host.ts:735](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L735)
+
+___
+
+### topicsMiddleware
+
+▸ **topicsMiddleware**(`req`, `res`, `next`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `req` | `ParsedMessage` |
+| `res` | `ServerResponse` |
+| `next` | `NextCallback` |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/host/src/lib/host.ts:336](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L336)
 
 ## Constructors
 
@@ -560,4 +671,4 @@ Sets used modules with provided configuration.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:114](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L114)
+[packages/host/src/lib/host.ts:138](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L138)

--- a/docs/host/classes/ServiceDiscovery.md
+++ b/docs/host/classes/ServiceDiscovery.md
@@ -11,12 +11,16 @@ and requesting Manager when instance requires data but data is not available loc
 ### Methods
 
 - [addData](ServiceDiscovery.md#adddata)
+- [createTopicsRouter](ServiceDiscovery.md#createtopicsrouter)
 - [getByTopic](ServiceDiscovery.md#getbytopic)
 - [getData](ServiceDiscovery.md#getdata)
 - [getTopics](ServiceDiscovery.md#gettopics)
 - [removeData](ServiceDiscovery.md#removedata)
 - [removeLocalProvider](ServiceDiscovery.md#removelocalprovider)
+- [routeStreamToTopic](ServiceDiscovery.md#routestreamtotopic)
+- [routeTopicToStream](ServiceDiscovery.md#routetopictostream)
 - [setConnector](ServiceDiscovery.md#setconnector)
+- [update](ServiceDiscovery.md#update)
 
 ### Constructors
 
@@ -27,6 +31,7 @@ and requesting Manager when instance requires data but data is not available loc
 - [cpmConnector](ServiceDiscovery.md#cpmconnector)
 - [dataMap](ServiceDiscovery.md#datamap)
 - [logger](ServiceDiscovery.md#logger)
+- [router](ServiceDiscovery.md#router)
 
 ## Methods
 
@@ -51,7 +56,21 @@ added topic data.
 
 #### Defined in
 
-[packages/host/src/lib/sd-adapter.ts:64](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L64)
+[packages/host/src/lib/sd-adapter.ts:139](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L139)
+
+___
+
+### createTopicsRouter
+
+▸ **createTopicsRouter**(): `void`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/host/src/lib/sd-adapter.ts:79](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L79)
 
 ___
 
@@ -75,13 +94,13 @@ Topic details.
 
 #### Defined in
 
-[packages/host/src/lib/sd-adapter.ts:110](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L110)
+[packages/host/src/lib/sd-adapter.ts:175](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L175)
 
 ___
 
 ### getData
 
-▸ **getData**(`dataType`): `undefined` \| `ReadableStream`<`any`\> \| `WritableStream`<`any`\>
+▸ **getData**(`dataType`): `Duplex`
 
 Returns topic details for given topic.
 If topic does not exist it will be created.
@@ -95,31 +114,31 @@ If topic exists but is not local, data will be requested from Manager.
 
 #### Returns
 
-`undefined` \| `ReadableStream`<`any`\> \| `WritableStream`<`any`\>
+`Duplex`
 
 Topic stream.
 
 #### Defined in
 
-[packages/host/src/lib/sd-adapter.ts:139](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L139)
+[packages/host/src/lib/sd-adapter.ts:204](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L204)
 
 ___
 
 ### getTopics
 
-▸ **getTopics**(): `any`
+▸ **getTopics**(): { `contentType`: `string` ; `cpmRequest?`: `boolean` ; `localProvider?`: `string` ; `stream`: `Duplex` ; `topic`: `string` = key }[]
 
 **`todo:`** implement.
 
 #### Returns
 
-`any`
+{ `contentType`: `string` ; `cpmRequest?`: `boolean` ; `localProvider?`: `string` ; `stream`: `Duplex` ; `topic`: `string` = key }[]
 
 All topics.
 
 #### Defined in
 
-[packages/host/src/lib/sd-adapter.ts:98](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L98)
+[packages/host/src/lib/sd-adapter.ts:163](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L163)
 
 ___
 
@@ -141,7 +160,7 @@ Removes store topic with given id.
 
 #### Defined in
 
-[packages/host/src/lib/sd-adapter.ts:180](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L180)
+[packages/host/src/lib/sd-adapter.ts:235](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L235)
 
 ___
 
@@ -163,7 +182,50 @@ Unsets local provider for given topic.
 
 #### Defined in
 
-[packages/host/src/lib/sd-adapter.ts:123](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L123)
+[packages/host/src/lib/sd-adapter.ts:188](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L188)
+
+___
+
+### routeStreamToTopic
+
+▸ **routeStreamToTopic**(`source`, `topicData`, `localProvider?`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `source` | `Readable` |
+| `topicData` | [`dataType`](../modules.md#datatype) |
+| `localProvider?` | `string` |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/host/src/lib/sd-adapter.ts:249](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L249)
+
+___
+
+### routeTopicToStream
+
+▸ **routeTopicToStream**(`topicData`, `target`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `topicData` | [`dataType`](../modules.md#datatype) |
+| `target` | `Writable` |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/host/src/lib/sd-adapter.ts:243](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L243)
 
 ___
 
@@ -185,13 +247,41 @@ Sets the CPM connector.
 
 #### Defined in
 
-[packages/host/src/lib/sd-adapter.ts:53](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L53)
+[packages/host/src/lib/sd-adapter.ts:128](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L128)
+
+___
+
+### update
+
+▸ **update**(`data`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | `Object` |
+| `data.contentType` | `string` |
+| `data.provides?` | `string` |
+| `data.requires?` | `string` |
+| `data.topicName` | `string` |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/host/src/lib/sd-adapter.ts:256](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L256)
 
 ## Constructors
 
 ### constructor
 
 • **new ServiceDiscovery**()
+
+#### Defined in
+
+[packages/host/src/lib/sd-adapter.ts:75](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L75)
 
 ## Properties
 
@@ -201,7 +291,7 @@ Sets the CPM connector.
 
 #### Defined in
 
-[packages/host/src/lib/sd-adapter.ts:46](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L46)
+[packages/host/src/lib/sd-adapter.ts:71](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L71)
 
 ___
 
@@ -211,7 +301,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/sd-adapter.ts:39](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L39)
+[packages/host/src/lib/sd-adapter.ts:64](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L64)
 
 ___
 
@@ -221,4 +311,14 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/sd-adapter.ts:44](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L44)
+[packages/host/src/lib/sd-adapter.ts:69](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L69)
+
+___
+
+### router
+
+• **router**: `APIRoute`
+
+#### Defined in
+
+[packages/host/src/lib/sd-adapter.ts:73](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L73)

--- a/docs/host/classes/SocketServer.md
+++ b/docs/host/classes/SocketServer.md
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/socket-server.ts:98](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/socket-server.ts#L98)
+[packages/host/src/lib/socket-server.ts:100](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/socket-server.ts#L100)
 
 ___
 
@@ -499,7 +499,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/socket-server.ts:37](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/socket-server.ts#L37)
+[packages/host/src/lib/socket-server.ts:38](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/socket-server.ts#L38)
 
 ## Constructors
 
@@ -519,7 +519,7 @@ TypedEmitter&lt;Events\&gt;.constructor
 
 #### Defined in
 
-[packages/host/src/lib/socket-server.ts:31](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/socket-server.ts#L31)
+[packages/host/src/lib/socket-server.ts:32](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/socket-server.ts#L32)
 
 ## Properties
 
@@ -533,7 +533,7 @@ IComponent.logger
 
 #### Defined in
 
-[packages/host/src/lib/socket-server.ts:27](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/socket-server.ts#L27)
+[packages/host/src/lib/socket-server.ts:28](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/socket-server.ts#L28)
 
 ___
 
@@ -543,4 +543,4 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/socket-server.ts:25](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/socket-server.ts#L25)
+[packages/host/src/lib/socket-server.ts:26](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/socket-server.ts#L26)

--- a/docs/host/modules.md
+++ b/docs/host/modules.md
@@ -36,7 +36,7 @@
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:30](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L30)
+[packages/host/src/lib/host.ts:34](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L34)
 
 ___
 
@@ -55,7 +55,7 @@ TODO: Refactor types below.
 
 #### Defined in
 
-[packages/host/src/lib/sd-adapter.ts:10](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L10)
+[packages/host/src/lib/sd-adapter.ts:12](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L12)
 
 ___
 
@@ -70,11 +70,11 @@ Topic stream type definition.
 | Name | Type |
 | :------ | :------ |
 | `contentType` | `string` |
-| `stream` | `Stream` |
+| `stream` | `Duplex` |
 
 #### Defined in
 
-[packages/host/src/lib/sd-adapter.ts:18](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L18)
+[packages/host/src/lib/sd-adapter.ts:20](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L20)
 
 ___
 
@@ -91,11 +91,11 @@ Topic details type definition.
 | `contentType` | `string` |
 | `cpmRequest?` | `boolean` |
 | `localProvider?` | `string` |
-| `stream` | `ReadableStream`<`any`\> \| `WritableStream`<`any`\> |
+| `stream` | `Duplex` |
 
 #### Defined in
 
-[packages/host/src/lib/sd-adapter.ts:26](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L26)
+[packages/host/src/lib/sd-adapter.ts:28](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L28)
 
 ## Variables
 

--- a/docs/runner/classes/Runner.md
+++ b/docs/runner/classes/Runner.md
@@ -66,7 +66,7 @@ reacts to control messages such as stopping etc.
 
 #### Defined in
 
-[runner.ts:245](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L245)
+[runner.ts:236](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L236)
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 #### Defined in
 
-[runner.ts:165](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L165)
+[runner.ts:156](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L156)
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[runner.ts:121](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L121)
+[runner.ts:120](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L120)
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 #### Defined in
 
-[runner.ts:155](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L155)
+[runner.ts:146](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L146)
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-[runner.ts:431](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L431)
+[runner.ts:410](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L410)
 
 ___
 
@@ -142,7 +142,7 @@ ___
 
 #### Defined in
 
-[runner.ts:229](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L229)
+[runner.ts:220](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L220)
 
 ___
 
@@ -162,7 +162,7 @@ ___
 
 #### Defined in
 
-[runner.ts:203](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L203)
+[runner.ts:194](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L194)
 
 ___
 
@@ -176,7 +176,7 @@ ___
 
 #### Defined in
 
-[runner.ts:583](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L583)
+[runner.ts:562](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L562)
 
 ___
 
@@ -199,7 +199,7 @@ set up streams process.stdin, process.stdout, process.stderr, fifo downstream, f
 
 #### Defined in
 
-[runner.ts:397](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L397)
+[runner.ts:376](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L376)
 
 ___
 
@@ -213,7 +213,7 @@ ___
 
 #### Defined in
 
-[runner.ts:278](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L278)
+[runner.ts:269](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L269)
 
 ___
 
@@ -234,7 +234,7 @@ ___
 
 #### Defined in
 
-[runner.ts:443](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L443)
+[runner.ts:422](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L422)
 
 ___
 
@@ -248,7 +248,7 @@ ___
 
 #### Defined in
 
-[runner.ts:419](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L419)
+[runner.ts:398](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L398)
 
 ___
 
@@ -268,7 +268,7 @@ ___
 
 #### Defined in
 
-[runner.ts:190](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L190)
+[runner.ts:181](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L181)
 
 ___
 
@@ -282,7 +282,7 @@ ___
 
 #### Defined in
 
-[runner.ts:425](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L425)
+[runner.ts:404](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L404)
 
 ## Constructors
 
@@ -306,7 +306,7 @@ ___
 
 #### Defined in
 
-[runner.ts:85](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L85)
+[runner.ts:83](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L83)
 
 ## Accessors
 
@@ -320,7 +320,7 @@ ___
 
 #### Defined in
 
-[runner.ts:111](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L111)
+[runner.ts:110](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L110)
 
 ## Properties
 
@@ -337,7 +337,7 @@ ___
 
 #### Defined in
 
-[runner.ts:78](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L78)
+[runner.ts:76](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L76)
 
 ___
 
@@ -351,4 +351,4 @@ IComponent.logger
 
 #### Defined in
 
-[runner.ts:80](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L80)
+[runner.ts:78](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L78)

--- a/docs/sth-config/classes/ConfigService.md
+++ b/docs/sth-config/classes/ConfigService.md
@@ -29,7 +29,7 @@
 
 #### Defined in
 
-[sth-config/src/config-service.ts:67](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L67)
+[sth-config/src/config-service.ts:74](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L74)
 
 ## Methods
 
@@ -43,7 +43,7 @@
 
 #### Defined in
 
-[sth-config/src/config-service.ts:75](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L75)
+[sth-config/src/config-service.ts:82](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L82)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[sth-config/src/config-service.ts:87](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L87)
+[sth-config/src/config-service.ts:94](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L94)
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 #### Defined in
 
-[sth-config/src/config-service.ts:79](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L79)
+[sth-config/src/config-service.ts:86](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L86)
 
 ___
 
@@ -105,4 +105,4 @@ ___
 
 #### Defined in
 
-[sth-config/src/config-service.ts:83](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L83)
+[sth-config/src/config-service.ts:90](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L90)

--- a/docs/sth-config/modules.md
+++ b/docs/sth-config/modules.md
@@ -25,7 +25,7 @@
 
 #### Defined in
 
-[sth-config/src/config-service.ts:62](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L62)
+[sth-config/src/config-service.ts:69](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L69)
 
 ## Functions
 

--- a/docs/symbols/enums/RunnerExitCode.md
+++ b/docs/symbols/enums/RunnerExitCode.md
@@ -1,0 +1,30 @@
+[@scramjet/symbols](../README.md) / [Exports](../modules.md) / RunnerExitCode
+
+# Enumeration: RunnerExitCode
+
+## Table of contents
+
+### Enumeration members
+
+- [INVALID\_ENV\_VARS](RunnerExitCode.md#invalid_env_vars)
+- [INVALID\_SEQUENCE\_PATH](RunnerExitCode.md#invalid_sequence_path)
+
+## Enumeration members
+
+### INVALID\_ENV\_VARS
+
+• **INVALID\_ENV\_VARS** = `20`
+
+#### Defined in
+
+[runner-exit-code.ts:2](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/runner-exit-code.ts#L2)
+
+___
+
+### INVALID\_SEQUENCE\_PATH
+
+• **INVALID\_SEQUENCE\_PATH** = `21`
+
+#### Defined in
+
+[runner-exit-code.ts:3](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/runner-exit-code.ts#L3)

--- a/docs/symbols/modules.md
+++ b/docs/symbols/modules.md
@@ -9,6 +9,7 @@
 - [CPMMessageCode](enums/CPMMessageCode.md)
 - [CommunicationChannel](enums/CommunicationChannel.md)
 - [InstanceMessageCode](enums/InstanceMessageCode.md)
+- [RunnerExitCode](enums/RunnerExitCode.md)
 - [RunnerMessageCode](enums/RunnerMessageCode.md)
 - [SequenceMessageCode](enums/SequenceMessageCode.md)
 

--- a/docs/types/interfaces/APIBase.md
+++ b/docs/types/interfaces/APIBase.md
@@ -43,7 +43,7 @@ A method that allows to consume incoming stream from the specified path on the A
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:120](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L120)
+[packages/types/src/api-expose.ts:126](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L126)
 
 ___
 
@@ -66,7 +66,7 @@ Allows to handle dual direction (duplex) streams.
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:132](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L132)
+[packages/types/src/api-expose.ts:138](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L138)
 
 ___
 
@@ -96,7 +96,7 @@ Simple GET request hook for static data in monitoring stream.
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:89](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L89)
+[packages/types/src/api-expose.ts:95](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L95)
 
 ▸ **get**(`path`, `msg`): `void`
 
@@ -115,7 +115,7 @@ Alternative GET request hook with dynamic resolution
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:98](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L98)
+[packages/types/src/api-expose.ts:104](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L104)
 
 ___
 
@@ -153,7 +153,7 @@ router.op("post", `${this.apiBase}/start`, (req) => this.handleStartRequest(req)
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:79](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L79)
+[packages/types/src/api-expose.ts:85](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L85)
 
 ___
 
@@ -177,7 +177,7 @@ A method that allows to pass a stream to the specified path on the API server
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:107](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L107)
+[packages/types/src/api-expose.ts:113](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L113)
 
 ___
 
@@ -200,4 +200,4 @@ Allows to register middlewares for specific paths, for all HTTP methods.
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:143](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L143)
+[packages/types/src/api-expose.ts:149](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L149)

--- a/docs/types/interfaces/APIError.md
+++ b/docs/types/interfaces/APIError.md
@@ -27,7 +27,7 @@
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:61](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L61)
+[packages/types/src/api-expose.ts:67](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L67)
 
 ___
 
@@ -39,7 +39,7 @@ Http status code to be outputted
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:53](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L53)
+[packages/types/src/api-expose.ts:59](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L59)
 
 ___
 
@@ -51,7 +51,7 @@ The message that will be sent in reason line
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:57](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L57)
+[packages/types/src/api-expose.ts:63](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L63)
 
 ___
 

--- a/docs/types/interfaces/APIExpose.md
+++ b/docs/types/interfaces/APIExpose.md
@@ -44,7 +44,7 @@
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:152](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L152)
+[packages/types/src/api-expose.ts:158](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L158)
 
 ___
 
@@ -72,7 +72,7 @@ A method that allows to consume incoming stream from the specified path on the A
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:120](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L120)
+[packages/types/src/api-expose.ts:126](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L126)
 
 ___
 
@@ -99,7 +99,7 @@ Allows to handle dual direction (duplex) streams.
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:132](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L132)
+[packages/types/src/api-expose.ts:138](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L138)
 
 ___
 
@@ -133,7 +133,7 @@ Simple GET request hook for static data in monitoring stream.
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:89](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L89)
+[packages/types/src/api-expose.ts:95](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L95)
 
 ▸ **get**(`path`, `msg`): `void`
 
@@ -156,7 +156,7 @@ Alternative GET request hook with dynamic resolution
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:98](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L98)
+[packages/types/src/api-expose.ts:104](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L104)
 
 ___
 
@@ -198,7 +198,7 @@ router.op("post", `${this.apiBase}/start`, (req) => this.handleStartRequest(req)
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:79](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L79)
+[packages/types/src/api-expose.ts:85](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L85)
 
 ___
 
@@ -226,7 +226,7 @@ A method that allows to pass a stream to the specified path on the API server
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:107](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L107)
+[packages/types/src/api-expose.ts:113](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L113)
 
 ___
 
@@ -253,7 +253,7 @@ Allows to register middlewares for specific paths, for all HTTP methods.
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:143](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L143)
+[packages/types/src/api-expose.ts:149](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L149)
 
 ## Properties
 
@@ -263,7 +263,7 @@ Allows to register middlewares for specific paths, for all HTTP methods.
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:151](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L151)
+[packages/types/src/api-expose.ts:157](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L157)
 
 ___
 
@@ -275,4 +275,4 @@ The raw HTTP server
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:150](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L150)
+[packages/types/src/api-expose.ts:156](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L156)

--- a/docs/types/interfaces/APIRoute.md
+++ b/docs/types/interfaces/APIRoute.md
@@ -49,7 +49,7 @@ A method that allows to consume incoming stream from the specified path on the A
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:120](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L120)
+[packages/types/src/api-expose.ts:126](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L126)
 
 ___
 
@@ -76,7 +76,7 @@ Allows to handle dual direction (duplex) streams.
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:132](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L132)
+[packages/types/src/api-expose.ts:138](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L138)
 
 ___
 
@@ -110,7 +110,7 @@ Simple GET request hook for static data in monitoring stream.
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:89](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L89)
+[packages/types/src/api-expose.ts:95](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L95)
 
 ▸ **get**(`path`, `msg`): `void`
 
@@ -133,7 +133,7 @@ Alternative GET request hook with dynamic resolution
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:98](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L98)
+[packages/types/src/api-expose.ts:104](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L104)
 
 ___
 
@@ -175,7 +175,7 @@ router.op("post", `${this.apiBase}/start`, (req) => this.handleStartRequest(req)
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:79](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L79)
+[packages/types/src/api-expose.ts:85](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L85)
 
 ___
 
@@ -203,7 +203,7 @@ A method that allows to pass a stream to the specified path on the API server
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:107](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L107)
+[packages/types/src/api-expose.ts:113](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L113)
 
 ___
 
@@ -230,7 +230,7 @@ Allows to register middlewares for specific paths, for all HTTP methods.
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:143](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L143)
+[packages/types/src/api-expose.ts:149](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L149)
 
 ## Properties
 
@@ -240,4 +240,4 @@ Allows to register middlewares for specific paths, for all HTTP methods.
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:156](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L156)
+[packages/types/src/api-expose.ts:162](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L162)

--- a/docs/types/modules.md
+++ b/docs/types/modules.md
@@ -1110,9 +1110,12 @@ ___
 | :------ | :------ |
 | `authConfigPath?` | `string` |
 | `namespace` | `string` |
-| `runnerImage` | `string` |
+| `runnerImages` | { `node`: `string` ; `python3`: `string`  } |
+| `runnerImages.node` | `string` |
+| `runnerImages.python3` | `string` |
 | `sequencesRoot` | `string` |
 | `sthPodHost` | `string` |
+| `timeout?` | `string` |
 
 #### Defined in
 
@@ -1835,7 +1838,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/sth-configuration.ts:181](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L181)
+[packages/types/src/sth-configuration.ts:182](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L182)
 
 ___
 
@@ -2001,7 +2004,9 @@ ___
 | `instancesServerPort` | `string` |
 | `k8sAuthConfigPath` | `string` |
 | `k8sNamespace` | `string` |
+| `k8sRunnerCleanupTimeout` | `string` |
 | `k8sRunnerImage` | `string` |
+| `k8sRunnerPyImage` | `string` |
 | `k8sSequencesRoot` | `string` |
 | `k8sSthPodHost` | `string` |
 | `logLevel` | [`LogLevel`](modules.md#loglevel) |
@@ -2052,7 +2057,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/sth-configuration.ts:80](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L80)
+[packages/types/src/sth-configuration.ts:81](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L81)
 
 ___
 
@@ -2367,6 +2372,7 @@ Configuration options for streaming endpoionts
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `checkContentType?` | `boolean` | Perform stream content-type type checks |
+| `checkEndHeader?` | `boolean` | Should consider x-end-stream header or just use the 'end'  **`default`** true |
 | `encoding?` | `BufferEncoding` | Encoding used in the stream |
 | `end?` | `boolean` | Should request end also end the stream or can the endpoint accept subsequent connections |
 | `json?` | `boolean` | Is the stream a JSON stream? |

--- a/docs/types/modules/MRestAPI.md
+++ b/docs/types/modules/MRestAPI.md
@@ -136,11 +136,11 @@ ___
 
 ### GetTopicsResponse
 
-Ƭ **GetTopicsResponse**: `Record`<`string`, { `contentType`: `string` ; `stream`: [`ReadableStream`](../interfaces/ReadableStream.md)<`any`\> \| [`WritableStream`](../interfaces/WritableStream.md)<`any`\>  }\>
+Ƭ **GetTopicsResponse**: { `contentType`: `string` ; `name`: `string`  }[]
 
 #### Defined in
 
-[packages/types/src/rest-api-manager/get-topics.ts:3](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-manager/get-topics.ts#L3)
+[packages/types/src/rest-api-manager/get-topics.ts:1](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-manager/get-topics.ts#L1)
 
 ___
 

--- a/docs/types/modules/STHRestAPI.md
+++ b/docs/types/modules/STHRestAPI.md
@@ -17,11 +17,13 @@
 - [GetSequenceInstancesResponse](STHRestAPI.md#getsequenceinstancesresponse)
 - [GetSequenceResponse](STHRestAPI.md#getsequenceresponse)
 - [GetSequencesResponse](STHRestAPI.md#getsequencesresponse)
+- [GetTopicsResponse](STHRestAPI.md#gettopicsresponse)
 - [GetVersionResponse](STHRestAPI.md#getversionresponse)
 - [SendEventResponse](STHRestAPI.md#sendeventresponse)
 - [SendKillInstanceResponse](STHRestAPI.md#sendkillinstanceresponse)
 - [SendSequenceResponse](STHRestAPI.md#sendsequenceresponse)
 - [SendStopInstanceResponse](STHRestAPI.md#sendstopinstanceresponse)
+- [StartSequencePayload](STHRestAPI.md#startsequencepayload)
 - [StartSequenceResponse](STHRestAPI.md#startsequenceresponse)
 
 ## Type aliases
@@ -64,7 +66,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/rest-api-sth/index.ts:18](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-sth/index.ts#L18)
+[packages/types/src/rest-api-sth/index.ts:19](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-sth/index.ts#L19)
 
 ___
 
@@ -128,7 +130,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/rest-api-sth/index.ts:19](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-sth/index.ts#L19)
+[packages/types/src/rest-api-sth/index.ts:20](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-sth/index.ts#L20)
 
 ___
 
@@ -170,6 +172,16 @@ ___
 
 ___
 
+### GetTopicsResponse
+
+Ƭ **GetTopicsResponse**: { `contentType`: `string` ; `name`: `string`  }[]
+
+#### Defined in
+
+[packages/types/src/rest-api-sth/get-topics.ts:1](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-sth/get-topics.ts#L1)
+
+___
+
 ### GetVersionResponse
 
 Ƭ **GetVersionResponse**: `Object`
@@ -178,6 +190,9 @@ ___
 
 | Name | Type |
 | :------ | :------ |
+| `apiVersion` | `string` |
+| `build` | `string` |
+| `service` | `string` |
 | `version` | `string` |
 
 #### Defined in
@@ -232,16 +247,29 @@ ___
 
 ___
 
-### StartSequenceResponse
+### StartSequencePayload
 
-Ƭ **StartSequenceResponse**: `Object`
+Ƭ **StartSequencePayload**: `Object`
 
 #### Type declaration
 
 | Name | Type |
 | :------ | :------ |
-| `id` | `string` |
+| `appConfig` | [`AppConfig`](../modules.md#appconfig) |
+| `args?` | `any`[] |
+| `inputTopic?` | `string` |
+| `outputTopic?` | `string` |
 
 #### Defined in
 
-[packages/types/src/rest-api-sth/start-sequence.ts:1](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-sth/start-sequence.ts#L1)
+[packages/types/src/rest-api-sth/start-sequence.ts:5](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-sth/start-sequence.ts#L5)
+
+___
+
+### StartSequenceResponse
+
+Ƭ **StartSequenceResponse**: { `id`: `string` ; `result`: ``"success"``  } \| { `error`: `unknown` ; `result`: ``"error"``  }
+
+#### Defined in
+
+[packages/types/src/rest-api-sth/start-sequence.ts:3](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-sth/start-sequence.ts#L3)

--- a/docs/utility/modules.md
+++ b/docs/utility/modules.md
@@ -14,7 +14,9 @@
 - [defer](modules.md#defer)
 - [isDefined](modules.md#isdefined)
 - [merge](modules.md#merge)
+- [normalizeUrl](modules.md#normalizeurl)
 - [promiseTimeout](modules.md#promisetimeout)
+- [readJsonFile](modules.md#readjsonfile)
 - [readStreamedJSON](modules.md#readstreamedjson)
 
 ## Functions
@@ -109,6 +111,31 @@ Returns nothing.
 
 ___
 
+### normalizeUrl
+
+▸ **normalizeUrl**(`url`, `options?`): `string`
+
+Normalizes provided URL.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `url` | `string` | URL to be normalized. |
+| `options?` | `Options` | - |
+
+#### Returns
+
+`string`
+
+Normalized URL.
+
+#### Defined in
+
+[packages/utility/src/normalize-url.ts:10](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/utility/src/normalize-url.ts#L10)
+
+___
+
 ### promiseTimeout
 
 ▸ **promiseTimeout**<`T`\>(`promise`, `timeout`): `Promise`<`T`\>
@@ -137,6 +164,27 @@ Promise that reject after timeout or.
 #### Defined in
 
 [packages/utility/src/promise-timeout.ts:10](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/utility/src/promise-timeout.ts#L10)
+
+___
+
+### readJsonFile
+
+▸ **readJsonFile**(`fileName`, ...`path`): `Object`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `fileName` | `string` |
+| `...path` | `string`[] |
+
+#### Returns
+
+`Object`
+
+#### Defined in
+
+[packages/utility/src/read-json-file.ts:4](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/utility/src/read-json-file.ts#L4)
 
 ___
 


### PR DESCRIPTION
# Scramjet Transform Hub Changelog v0.20.0

Prominent

- ac15ee4e4 - Do not close topic when producing output stream is ended.
- 22f1a1656 - Add python3 to STH docker image
- 7417b7a98 - Enable assigning output topic on sequence start.
- 018e6975d - CLI commands update

New features:

- **Reusable topics** - Topic streams don't end when input ends, you can always send more input
- **Python in Docker image** - When running STH from docker image, you will have python installed to run python sequences inside

Bugfixes and minor improvements:

- Fix for adding Python sequence library to path
- Choosing runner image in kubernetes adapter (so that either python or node runner can be used)
- Provide more infromation about the service on /version endpoint (service name, commit ID)
- API base url (e.g. the one provided to CLI) is normalized
