### PR TITLE
Bugfix for CLI --help

### DIFF
--- a/packages/cli/src/lib/commands/config.ts
+++ b/packages/cli/src/lib/commands/config.ts
@@ -21,7 +21,7 @@ export const config: CommandDefinition = (program) => {
         .command("config")
         .addHelpCommand(false)
         .alias("c")
-        .usage("si config [command] ")
+        .usage("[command] ")
         .description("config contains default Scramjet Transform Hub (STH) and Scramjet Cloud Platform (SCP) settings");
 
     configCmd

--- a/packages/cli/src/lib/commands/hub.ts
+++ b/packages/cli/src/lib/commands/hub.ts
@@ -17,7 +17,7 @@ export const hub: CommandDefinition = (program) => {
     const hubCmd = program
         .command("hub")
         .addHelpCommand(false)
-        .usage("si hub [command] [options...]")
+        .usage("[command] [options...]")
         /* TODO: for future implementation
             .option("--driver", "", "scp")
             .option("--provider <value>", "specify provider: aws|cpm")

--- a/packages/cli/src/lib/commands/init.ts
+++ b/packages/cli/src/lib/commands/init.ts
@@ -5,7 +5,7 @@ export const init: CommandDefinition = (program) => {
         .command("init")
         .addHelpCommand(false)
         .alias("i")
-        .usage("si init [command] [options...]");
+        .usage("[command] [options...]");
 
     initCmd
         .command("template")

--- a/packages/cli/src/lib/commands/instance.ts
+++ b/packages/cli/src/lib/commands/instance.ts
@@ -14,8 +14,8 @@ export const instance: CommandDefinition = (program) => {
     const instanceCmd = program
         .command("instance [command]")
         .addHelpCommand(false)
-        .usage("si inst [command] [options...]")
         .alias("inst")
+        .usage("[command] [options...]")
         .description("operations on running sequence");
 
     instanceCmd

--- a/packages/cli/src/lib/commands/scope.ts
+++ b/packages/cli/src/lib/commands/scope.ts
@@ -14,7 +14,7 @@ export const scope: CommandDefinition = (program) => {
         .command("scope")
         .addHelpCommand(false)
         .alias("s")
-        .usage("si scope [command] [options...]")
+        .usage("[command] [options...]")
         .description("manage scopes that store pairs of spaces and hubs used when working");
 
     scopeCmd.command("list").alias("ls").description("list all created scopes").action(listScopes);

--- a/packages/cli/src/lib/commands/sequence.ts
+++ b/packages/cli/src/lib/commands/sequence.ts
@@ -52,7 +52,7 @@ export const sequence: CommandDefinition = (program) => {
         .command("sequence")
         .addHelpCommand(false)
         .alias("seq")
-        .usage("si seq [command] [options...]")
+        .usage("[command] [options...]")
         .description("operations on a program, consisting of one or more functions executed one after another");
 
     sequenceCmd

--- a/packages/cli/src/lib/commands/space.ts
+++ b/packages/cli/src/lib/commands/space.ts
@@ -13,7 +13,7 @@ export const space: CommandDefinition = (program) => {
         .command("space")
         .addHelpCommand(false)
         .alias("spc")
-        .usage("si space [command] [options...]")
+        .usage("[command] [options...]")
         .option("-c, --stdout", "output to stdout (ignores -o)")
         .option("-o, --output <file.tar.gz>", "output path - defaults to dirname")
         .description("operations on grouped and separated runtime environments that allow sharing the data within them");

--- a/packages/cli/src/lib/commands/topic.ts
+++ b/packages/cli/src/lib/commands/topic.ts
@@ -12,7 +12,7 @@ export const topic: CommandDefinition = (program) => {
     const topicCmd = program
         .command("topic")
         .addHelpCommand(false)
-        .usage("si topic [command] [options...]")
+        .usage("[command] [options...]")
         .description("publish/subscribe operations allows to manage data flow");
 
     if (isDevelopment())


### PR DESCRIPTION
Fix for bug [CLI help: command is duplicated in the header line #413](https://github.com/scramjetorg/transform-hub/issues/413)

to verify:

- `yarn build:packages`
- `npm install -g ./dist/cli`
- `si hub --help`
- `si seq --help`
- `si inst --help`
- `si topic --help`
- `si config --help`

expected output:

![image](https://user-images.githubusercontent.com/61054769/162723068-3958951d-e45c-4fe4-b970-5dc67b70997c.png)
