### PR TITLE
Serialize objectMode output stream

### DIFF
--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -530,6 +530,7 @@ export class Runner<X extends AppConfig> implements IComponent {
 
                 const shouldSerialize = stream.contentType &&
                 ["application/x-ndjson", "text/x-ndjson"].includes(stream.contentType) ||
+                stream.readableObjectMode ||
                 stream instanceof DataStream && !(
                     stream instanceof StringStream || stream instanceof BufferStream
                 );


### PR DESCRIPTION
https://github.com/scramjetorg/transform-hub/issues/427

> Currently the following sequence will error:
> ```ts
> export default function() {
>    const out = new PassThrough({objectMode: true})
>
>    let i = 0
>
>    const fn = () => {
>        const canWrite = out.write(i++)
>        if(!canWrite) {
>            clearInterval(intervalRef)
>        }
>    }
>
>    let intervalRef = setInterval(fn, 1000)
>
>    out.on('drain', () => {
>      intervalRef = setInterval(fn, 1000)
>    })
>
>    return out
>}
>```
>
>and this is the error:
>```ts
>2022-04-12T11:54:39.057Z ERROR DockerInstanceAdapter Docker container error:  [
>  'node:events:504\n' +
>    "      throw er; // Unhandled 'error' event\n" +
>    '      ^\n' +
>    '\n' +
>    'TypeError [ERR_INVALID_ARG_TYPE]: The "chunk" argument must be of type string or an instance of >Buffer or Uint8Array. Received type number (0)\n' +
>    '    at new NodeError (node:internal/errors:371:5)\n' +
>    '    at readableAddChunk (node:internal/streams/readable:260:13)\n' +
>    '    at PassThrough.Readable.push (node:internal/streams/readable:228:10)\n' +
>    '    at node:internal/streams/transform:192:12\n' +
>    '    at PassThrough._transform (node:internal/streams/passthrough:46:3)\n' +
>    '    at PassThrough.Transform._write (node:internal/streams/transform:184:23)\n' +
>    '    at writeOrBuffer (node:internal/streams/writable:389:12)\n' +
>    '    at _write (node:internal/streams/writable:330:10)\n' +
>    '    at PassThrough.Writable.write (node:internal/streams/writable:334:10)\n' +
>    '    at Timeout.fn [as _onTimeout] (/package/index.js:8:30)\n' +
>    "Emitted 'error' event on PassThrough instance at:\n" +
>    '    at emitErrorNT (node:internal/streams/destroy:157:8)\n' +
>    '    at emitErrorCloseNT (node:internal/streams/destroy:122:3)\n' +
>    '    at processTicksAndRejections (node:internal/process/task_queues:83:21) {\n' +
>    "  code: 'ERR_INVALID_ARG_TYPE'\n" +
>    '}\n'
>]
>```
>
>this would mean that somewhere along the way it's not encoded.
>
>Let's note that it works correctly if output is routed to a topic :)
>
>What's also interesting is that a similar sequence, implemented with generators will work correctly:
>
>```ts
>export default async function*() {
>    let i = 0
>    while(true) {
>        await sleep(1000)
>        yield i++
>    }
>}
>
>```
>
>it might be due to the usage of framework in runner in the case of the generator example