### PR TITLE
GH release workflow: fix trigger

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -1,6 +1,6 @@
 name: Release test
 
-on: workflow_run
+on: workflow_dispatch
 
 jobs:
   test-npm-sth:


### PR DESCRIPTION
The intention of commit 8ff499d43a2bb86ff51f1cdf35903bd6ef98f292 was to
make this workflow manual, and as far as I understand GH docs
`workflow_dispatch` should be used for that.