### PR TITLE
Fix: when CLI fails to parse the args, it sends an empty array to the Host

### DIFF
--- a/packages/cli/src/lib/commands/sequence.ts
+++ b/packages/cli/src/lib/commands/sequence.ts
@@ -48,9 +48,7 @@ function parseSequenceArgs(argsStr: string | undefined): any[] {
     try {
         return argsStr ? JSON.parse(argsStr) : [];
     } catch (err) {
-        // eslint-disable-next-line no-console
-        console.error("Error parsing arguments JSON string, defaulting to empty array.", (err as Error).message);
-        return [];
+        throw new Error(`Error while parsing the provided Instance arguments. '${(err as Error).message}'`);
     }
 }
 


### PR DESCRIPTION
If a user passes to an Instance the arguments that are in an incorrect JSON, CLI should signal it by throwing an error.
CLI should bubble the errors up to the main method where they should be handled.