### PR TITLE
[Bugfix] Parse seq args in CLI "si seq deploy"

### DIFF
--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -336,8 +336,19 @@ This feature checks CLI functionalities
         Then confirm data named "args-on-output" will be received
         * stop host
 
+        @ci @cli @starts-host
+    Scenario: E2E-010 TC-029 Deploy sequence with multiple JSON arguments
+        Given start host
+        Then I set json format
+        Then I use apiUrl in config
+        When I execute CLI with "seq deploy ../dist/reference-apps/args-to-output --args [\"Hello\",123,{\"abc\":456},[\"789\"]]" arguments
+        Then I get Instance id after deployment
+        And I get Instance output without waiting for the end
+        Then confirm data named "args-on-output" will be received
+        * stop host
+
     @ci @cli
-    Scenario: E2E-010 TC-029 Send input data to Instance and close input stream
+    Scenario: E2E-010 TC-030 Send input data to Instance and close input stream
         Given host is running
         Then I set json format
         Then I use apiUrl in config

--- a/bdd/step-definitions/e2e/cli.ts
+++ b/bdd/step-definitions/e2e/cli.ts
@@ -292,6 +292,15 @@ Then("I get Instance id", function() {
     assert.equal(typeof res.instanceId !== "undefined", true);
 });
 
+Then("I get Instance id after deployment", function() {
+    const res = (this as CustomWorld).cliResources;
+    const stdio = res.stdio![0].split("\n");
+    const json = JSON.parse(stdio[1]);
+
+    (this as CustomWorld).cliResources.instanceId = json._id;
+    assert.equal(typeof json._id !== "undefined", true);
+});
+
 Then("I kill Instance", async function() {
     const res = (this as CustomWorld).cliResources;
 

--- a/packages/cli/src/lib/commands/sequence.ts
+++ b/packages/cli/src/lib/commands/sequence.ts
@@ -166,13 +166,15 @@ export const sequence: CommandDefinition = (program) => {
         // TODO: check if output-topic and input-topic should be added after development
         .option("--args <json-string>", "arguments to be passed to first function in Sequence")
         .description("pack (if needed), send and start the sequence")
-        .action(async (path: string, { output, configFile, configString, args }:
-            { output: string, configFile: any, configString: string, args: any }) => {
+        .action(async (path: string, { output, configFile, configString, args: argsStr }:
+            { output: string, configFile: any, configString: string, args: string }) => {
             if (lstatSync(path).isDirectory()) {
                 await packAction(path, { stdout: false, output });
                 await sendPackage("-");
             } else
                 await sendPackage(path);
+            const args = parseSequenceArgs(argsStr);
+
             await startSequence("-", { configFile, configString, args });
         });
 


### PR DESCRIPTION
Changes done by @pietrzakacper in PR [#432](https://github.com/scramjetorg/transform-hub/pull/432) also needed to be implemented in `si seq deploy --args '[]'`

test added: `NO_HOST=1 yarn test:bdd --name="E2E-010 TC-029"`