### PR TITLE
The message type + codes for the audit stream

### DIFF
--- a/packages/symbols/src/index.ts
+++ b/packages/symbols/src/index.ts
@@ -5,3 +5,5 @@ export { RunnerExitCode } from "./runner-exit-code";
 export { CPMMessageCode } from "./cpm-message-code";
 export { InstanceMessageCode } from "./instance-status-code";
 export { SequenceMessageCode } from "./sequence-status-code";
+export { OpRecordCode } from "./op-record-code";
+

--- a/packages/symbols/src/op-record-code.ts
+++ b/packages/symbols/src/op-record-code.ts
@@ -1,0 +1,3 @@
+export enum OpRecordCode {
+
+}

--- a/packages/symbols/src/op-record-code.ts
+++ b/packages/symbols/src/op-record-code.ts
@@ -24,7 +24,7 @@ export enum OpRecordCode {
 
     /**
      * The message codes related to the operation on a Sequence.
-     * They are trigger in response for the user operations performed by the API.
+     * They are triggered in response to the user operations performed by the API.
      */
 
     GET_SEQUENCE = 11200,

--- a/packages/symbols/src/op-record-code.ts
+++ b/packages/symbols/src/op-record-code.ts
@@ -1,3 +1,60 @@
 export enum OpRecordCode {
 
+    /**
+     * The message codes related to the operation on an Instance.
+     * They are trigger in response for the user operations performed by the API.
+     */
+
+    GET_INSTANCE = 8000,
+    GET_INSTANCE_STDOUT = 8001,
+    GET_INSTANCE_STDERR = 8002,
+    GET_INSTANCE_STDIN = 8003,
+    GET_INSTANCE_LOG = 8004,
+    GET_INSTANCE_MONITORING = 8005,
+    GET_INSTANCE_OUTPUT = 8006,
+    GET_INSTANCE_HEALTH = 8007,
+    GET_INSTANCE_EVENTS = 8008,
+    GET_INSTANCE_EVENT = 8009,
+    GET_INSTANCE_EVENT_ONCE = 8010,
+    POST_INSTANCE_INPUT = 8100,
+    POST_INSTANCE_MONITORING_RATE = 8101,
+    POST_INSTANCE_EVENT = 8102,
+    POST_STOP_INSTANCE = 8103,
+    POST_KILL_INSTANCE = 8104,
+
+    /**
+     * The message codes related to the operation on a Sequence.
+     * They are trigger in response for the user operations performed by the API.
+     */
+
+    GET_SEQUENCE = 9000,
+    DELETE_SEQUENCE = 9200,
+    POST_SEQUENCE = 9100,
+    POST_START_INSTANCE = 9101,
+
+    /**
+     * The message codes related to the operation on Topics.
+     * They are trigger in response for the user operations performed by the API.
+     */
+
+    GET_TOPIC = 7000,
+    POST_TOPIC = 7001,
+
+    /**
+     * The message codes for the events which originate from within the system itself and
+     * are not the responses for the user operations performed by the API.
+     */
+
+    /**
+     * The HEARTBEAT message is a signal issued periodically (configurable)
+     * by the CSI Controller, the Host and the Manager.
+     * It indicates whether the services are still operational.
+     */
+    HEARTBEAT = 6000,
+
+    /**
+     * The INSTANCE_STOPPED message is sent when an Instance terminated not 
+     * in response to the API request but gracefully by itself or by throwing an error. 
+     */
+    INSTANCE_STOPPED = 6001
 }

--- a/packages/symbols/src/op-record-code.ts
+++ b/packages/symbols/src/op-record-code.ts
@@ -5,40 +5,40 @@ export enum OpRecordCode {
      * They are triggered in response to the user operations performed by the API.
      */
 
-    GET_INSTANCE = 12200,
-    GET_INSTANCE_STDOUT = 12201,
-    GET_INSTANCE_STDERR = 12202,
-    GET_INSTANCE_STDIN = 12203,
-    GET_INSTANCE_LOG = 12204,
-    GET_INSTANCE_MONITORING = 12205,
-    GET_INSTANCE_OUTPUT = 12206,
-    GET_INSTANCE_HEALTH = 12208,
-    GET_INSTANCE_EVENTS = 12209,
-    GET_INSTANCE_EVENT = 12210,
-    GET_INSTANCE_EVENT_ONCE = 12211,
-    POST_INSTANCE_INPUT = 12107,
-    POST_INSTANCE_MONITORING_RATE = 12112,
-    POST_INSTANCE_EVENT = 12110,
-    POST_STOP_INSTANCE = 12114,
-    POST_KILL_INSTANCE = 12115,
+    GET_INSTANCE = 11200,
+    GET_INSTANCE_STDOUT = 11201,
+    GET_INSTANCE_STDERR = 11202,
+    GET_INSTANCE_STDIN = 11203,
+    GET_INSTANCE_LOG = 11204,
+    GET_INSTANCE_MONITORING = 11205,
+    GET_INSTANCE_OUTPUT = 11206,
+    GET_INSTANCE_HEALTH = 11208,
+    GET_INSTANCE_EVENTS = 11209,
+    GET_INSTANCE_EVENT = 11210,
+    GET_INSTANCE_EVENT_ONCE = 11211,
+    POST_INSTANCE_INPUT = 11107,
+    POST_INSTANCE_MONITORING_RATE = 11112,
+    POST_INSTANCE_EVENT = 11110,
+    POST_STOP_INSTANCE = 11114,
+    POST_KILL_INSTANCE = 11115,
 
     /**
      * The message codes related to the operation on a Sequence.
      * They are triggered in response to the user operations performed by the API.
      */
 
-    GET_SEQUENCE = 11200,
-    DELETE_SEQUENCE = 11400,
-    POST_SEQUENCE = 11100,
-    POST_START_INSTANCE = 11117,
+    GET_SEQUENCE = 10200,
+    DELETE_SEQUENCE = 10400,
+    POST_SEQUENCE = 10100,
+    POST_START_INSTANCE = 10117,
 
     /**
      * The message codes related to the operation on Topics.
      * They are triggered in response to the user operations performed by the API.
      */
 
-    GET_TOPIC = 13200,
-    POST_TOPIC = 13100,
+    GET_TOPIC = 12200,
+    POST_TOPIC = 12100,
 
     /**
      * The message codes for the events which originate from within the system itself and

--- a/packages/symbols/src/op-record-code.ts
+++ b/packages/symbols/src/op-record-code.ts
@@ -5,40 +5,40 @@ export enum OpRecordCode {
      * They are trigger in response for the user operations performed by the API.
      */
 
-    GET_INSTANCE = 8000,
-    GET_INSTANCE_STDOUT = 8001,
-    GET_INSTANCE_STDERR = 8002,
-    GET_INSTANCE_STDIN = 8003,
-    GET_INSTANCE_LOG = 8004,
-    GET_INSTANCE_MONITORING = 8005,
-    GET_INSTANCE_OUTPUT = 8006,
-    GET_INSTANCE_HEALTH = 8007,
-    GET_INSTANCE_EVENTS = 8008,
-    GET_INSTANCE_EVENT = 8009,
-    GET_INSTANCE_EVENT_ONCE = 8010,
-    POST_INSTANCE_INPUT = 8100,
-    POST_INSTANCE_MONITORING_RATE = 8101,
-    POST_INSTANCE_EVENT = 8102,
-    POST_STOP_INSTANCE = 8103,
-    POST_KILL_INSTANCE = 8104,
+    GET_INSTANCE = 12200,
+    GET_INSTANCE_STDOUT = 12201,
+    GET_INSTANCE_STDERR = 12202,
+    GET_INSTANCE_STDIN = 12203,
+    GET_INSTANCE_LOG = 12204,
+    GET_INSTANCE_MONITORING = 12205,
+    GET_INSTANCE_OUTPUT = 12206,
+    GET_INSTANCE_HEALTH = 12208,
+    GET_INSTANCE_EVENTS = 12209,
+    GET_INSTANCE_EVENT = 12210,
+    GET_INSTANCE_EVENT_ONCE = 12211,
+    POST_INSTANCE_INPUT = 12107,
+    POST_INSTANCE_MONITORING_RATE = 12112,
+    POST_INSTANCE_EVENT = 12110,
+    POST_STOP_INSTANCE = 12114,
+    POST_KILL_INSTANCE = 12115,
 
     /**
      * The message codes related to the operation on a Sequence.
      * They are trigger in response for the user operations performed by the API.
      */
 
-    GET_SEQUENCE = 9000,
-    DELETE_SEQUENCE = 9200,
-    POST_SEQUENCE = 9100,
-    POST_START_INSTANCE = 9101,
+    GET_SEQUENCE = 11200,
+    DELETE_SEQUENCE = 11400,
+    POST_SEQUENCE = 11100,
+    POST_START_INSTANCE = 11117,
 
     /**
      * The message codes related to the operation on Topics.
      * They are trigger in response for the user operations performed by the API.
      */
 
-    GET_TOPIC = 7000,
-    POST_TOPIC = 7001,
+    GET_TOPIC = 13200,
+    POST_TOPIC = 13100,
 
     /**
      * The message codes for the events which originate from within the system itself and
@@ -50,11 +50,11 @@ export enum OpRecordCode {
      * by the CSI Controller, the Host and the Manager.
      * It indicates whether the services are still operational.
      */
-    HEARTBEAT = 6000,
+    HEARTBEAT = -1, // NOT YET IMPLEMENTED
 
     /**
      * The INSTANCE_STOPPED message is sent when an Instance terminated not 
      * in response to the API request but gracefully by itself or by throwing an error. 
      */
-    INSTANCE_STOPPED = 6001
+    INSTANCE_STOPPED = -1 // NOT YET IMPLEMENTED
 }

--- a/packages/symbols/src/op-record-code.ts
+++ b/packages/symbols/src/op-record-code.ts
@@ -34,7 +34,7 @@ export enum OpRecordCode {
 
     /**
      * The message codes related to the operation on Topics.
-     * They are trigger in response for the user operations performed by the API.
+     * They are triggered in response to the user operations performed by the API.
      */
 
     GET_TOPIC = 13200,

--- a/packages/symbols/src/op-record-code.ts
+++ b/packages/symbols/src/op-record-code.ts
@@ -2,7 +2,7 @@ export enum OpRecordCode {
 
     /**
      * The message codes related to the operation on an Instance.
-     * They are trigger in response for the user operations performed by the API.
+     * They are triggered in response to the user operations performed by the API.
      */
 
     GET_INSTANCE = 12200,

--- a/packages/symbols/src/op-state.ts
+++ b/packages/symbols/src/op-state.ts
@@ -1,0 +1,6 @@
+export enum OpState {
+
+    ACTIVE,
+    END,
+    ERROR
+}

--- a/packages/symbols/src/op-state.ts
+++ b/packages/symbols/src/op-state.ts
@@ -1,5 +1,4 @@
 export enum OpState {
-
     ACTIVE,
     END,
     ERROR

--- a/packages/symbols/src/op-state.ts
+++ b/packages/symbols/src/op-state.ts
@@ -1,4 +1,5 @@
 export enum OpState {
+    START,
     ACTIVE,
     END,
     ERROR

--- a/packages/types/src/messages/op-record.ts
+++ b/packages/types/src/messages/op-record.ts
@@ -8,6 +8,11 @@ export type OpRecord = {
     opCode: OpRecordCode;
 
     /**
+    * The operation state from the OpState enumeration.
+    */
+    opState: string;
+
+    /**
     * The generated unique request ID for operations coming from the API.
     */
 
@@ -19,29 +24,9 @@ export type OpRecord = {
     requestorId: string;
 
     /**
-    * The address of the original requestor for operations coming from the API .
-    */
-    requestorIP?: string;
-
-    /**
     * The timestamp of when the operation was registered.
     */
     receivedAt: number;
-
-    /**
-    * The timestamp of when the operation was finished (if applicable).
-    */
-    endedAt?: number;
-
-    /**
-    * An instance of the object which the operation concerns, e.g. Host.
-    */
-    objectId: string;
-
-    /**
-    * A type of the object which the operation concerns, e.g. Host ID.
-    */
-    objectType: string;
 
     /**
     * The data written to the request stream. 
@@ -52,11 +37,6 @@ export type OpRecord = {
     * The data received in the request stream
     */
     rx?: number;
-
-    /**
-    * The full API URL of the operations coming from the API.
-    */
-    requestedURL?: string;
 
 }
 

--- a/packages/types/src/messages/op-record.ts
+++ b/packages/types/src/messages/op-record.ts
@@ -1,7 +1,6 @@
 import { OpRecordCode } from "@scramjet/symbols";
 
 export type OpRecord = {
-
     /**
     * The type of recorded operation is identified by the code value from the OpRecord enumeration.
     */

--- a/packages/types/src/messages/op-record.ts
+++ b/packages/types/src/messages/op-record.ts
@@ -37,7 +37,7 @@ export type OpRecord = {
     rx?: number;
 
     /**
-    * An instance of the object which the operation concerns, e.g. Host.
+    * An instance of the object which the operation concerns, e.g. Instance ID.
     */
     objectId: string;
 }

--- a/packages/types/src/messages/op-record.ts
+++ b/packages/types/src/messages/op-record.ts
@@ -15,7 +15,6 @@ export type OpRecord = {
     /**
     * The generated unique request ID for operations coming from the API.
     */
-
     requestId: string;
 
     /**

--- a/packages/types/src/messages/op-record.ts
+++ b/packages/types/src/messages/op-record.ts
@@ -38,5 +38,10 @@ export type OpRecord = {
     */
     rx?: number;
 
+    /**
+    * An instance of the object which the operation concerns, e.g. Host.
+    */
+    objectId: string;
+
 }
 

--- a/packages/types/src/messages/op-record.ts
+++ b/packages/types/src/messages/op-record.ts
@@ -1,0 +1,17 @@
+import { OpRecordCode } from "@scramjet/symbols";
+
+export type OpRecord = {
+    opCode: OpRecordCode;
+    requestId: string;
+    requestorId: string;
+    requestorIP?: string;
+    receivedAt: number;
+    endedAt?: number;
+    objectId: string;
+    objectType: string;
+    bytesWritten?: number;
+    bytesRead?: number;
+    requestedURL?: string;
+
+}
+

--- a/packages/types/src/messages/op-record.ts
+++ b/packages/types/src/messages/op-record.ts
@@ -42,6 +42,5 @@ export type OpRecord = {
     * An instance of the object which the operation concerns, e.g. Host.
     */
     objectId: string;
-
 }
 

--- a/packages/types/src/messages/op-record.ts
+++ b/packages/types/src/messages/op-record.ts
@@ -1,16 +1,61 @@
 import { OpRecordCode } from "@scramjet/symbols";
 
 export type OpRecord = {
+
+    /**
+    * The type of recorded operation is identified by the code value from the OpRecord enumeration.
+    */
     opCode: OpRecordCode;
+
+    /**
+    * The generated unique request ID for operations coming from the API.
+    */
+
     requestId: string;
+
+    /**
+    * The requestor can be either a user who performed the operation or the system.
+    */
     requestorId: string;
+
+    /**
+    * The address of the original requestor for operations coming from the API .
+    */
     requestorIP?: string;
+
+    /**
+    * The timestamp of when the operation was registered.
+    */
     receivedAt: number;
+
+    /**
+    * The timestamp of when the operation was finished (if applicable).
+    */
     endedAt?: number;
+
+    /**
+    * An instance of the object which the operation concerns, e.g. Host.
+    */
     objectId: string;
+
+    /**
+    * A type of the object which the operation concerns, e.g. Host ID.
+    */
     objectType: string;
+
+    /**
+    * The data written to the request stream. 
+    */
     tx?: number;
+
+    /**
+    * The data received in the request stream
+    */
     rx?: number;
+
+    /**
+    * The full API URL of the operations coming from the API.
+    */
     requestedURL?: string;
 
 }

--- a/packages/types/src/messages/op-record.ts
+++ b/packages/types/src/messages/op-record.ts
@@ -9,8 +9,8 @@ export type OpRecord = {
     endedAt?: number;
     objectId: string;
     objectType: string;
-    bytesWritten?: number;
-    bytesRead?: number;
+    tx?: number;
+    rx?: number;
     requestedURL?: string;
 
 }


### PR DESCRIPTION
The audit stream carries information on all operations performed in the platform.

The message codes included are for the basic operations; 
- operations on Instance,
- operations on Sequence,
- operations on Topics,
- internal system operations.

Suggestions on the improvements of the message code created are very welcome. Perhaps for the codes we should use string and create a hash from the request method name (can be digits) + the part of URL (after removing the base and the IDs from the URL). 
The current codes are based on @patuwwy suggestion to have the first digit indicating a category of operations (Instance, Sequence, etc.) and the second digit for the method. However, the last digits would still need to be known. 

There is only one message type proposed with all required attributes listed without nesting. It's not the neatest modelling, but otherwise we would need to maintain a long list of various combinations of message codes and attributes.

[EDIT]: After debugging the Auditor service with @patuwwy I adopted his status codes convention which can be found in https://github.com/scramjetorg/transform-hub/pull/461/files#diff-10ce2297b522d8ec475f58fc3b0c9022d899a48ff62cb9430c28f503ccf36389