### PR TITLE
Prepare 0.21 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,7 +138,15 @@ Bugfixes and minor improvements:
 - Provide more information about the service on /version endpoint (service name, commit ID)
 - API base url (e.g. the one provided to CLI) is normalized
 - Fixes for CLI
+- Make version endpoint type consistent
+- Fix passing args to Sequence through CLI
+- Introduce si seq prune for bulk Sequence removal
+- Add docs on how to write a Sequence
+- Enable ending input stream through CLI
+- Enable closing HTTP connection in API Clients
+- Select first healthy hub as default in CLI
+- Make rebuilding STH much faster
 
-## @scramjet/transform Hub - v0.20.0
+## @scramjet/transform Hub - v0.21.0
 
 This is the last release in changelog.

--- a/docs/api-client/classes/HostClient.md
+++ b/docs/api-client/classes/HostClient.md
@@ -23,6 +23,7 @@ Provides methods to interact with Host.
 ### Methods
 
 - [deleteSequence](HostClient.md#deletesequence)
+- [getConfig](HostClient.md#getconfig)
 - [getInstanceInfo](HostClient.md#getinstanceinfo)
 - [getLoadCheck](HostClient.md#getloadcheck)
 - [getLogStream](HostClient.md#getlogstream)
@@ -99,6 +100,24 @@ Promise resolving to delete Sequence result.
 #### Defined in
 
 [api-client/src/host-client.ts:76](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L76)
+
+___
+
+### getConfig
+
+▸ **getConfig**(): `Promise`<`PublicSTHConfiguration`\>
+
+Returns Host public configuration.
+
+#### Returns
+
+`Promise`<`PublicSTHConfiguration`\>
+
+Promise resolving to Host configuration (public part).
+
+#### Defined in
+
+[api-client/src/host-client.ts:114](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L114)
 
 ___
 
@@ -182,7 +201,7 @@ Promise resolving to readable stream.
 
 #### Defined in
 
-[api-client/src/host-client.ts:129](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L129)
+[api-client/src/host-client.ts:138](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L138)
 
 ___
 
@@ -220,7 +239,7 @@ ___
 
 #### Defined in
 
-[api-client/src/host-client.ts:133](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L133)
+[api-client/src/host-client.ts:142](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L142)
 
 ___
 
@@ -308,7 +327,7 @@ TODO: comment.
 
 #### Defined in
 
-[api-client/src/host-client.ts:119](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L119)
+[api-client/src/host-client.ts:128](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L128)
 
 ___
 

--- a/docs/api-client/classes/SequenceClient.md
+++ b/docs/api-client/classes/SequenceClient.md
@@ -149,7 +149,7 @@ Promise resolving to Sequence info.
 
 #### Defined in
 
-[api-client/src/sequence-client.ts:95](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/sequence-client.ts#L95)
+[api-client/src/sequence-client.ts:93](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/sequence-client.ts#L93)
 
 ___
 
@@ -174,7 +174,7 @@ Instance client.
 
 #### Defined in
 
-[api-client/src/sequence-client.ts:86](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/sequence-client.ts#L86)
+[api-client/src/sequence-client.ts:84](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/sequence-client.ts#L84)
 
 ___
 
@@ -192,7 +192,7 @@ Promise resolving to list of Instances.
 
 #### Defined in
 
-[api-client/src/sequence-client.ts:75](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/sequence-client.ts#L75)
+[api-client/src/sequence-client.ts:73](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/sequence-client.ts#L73)
 
 ___
 
@@ -208,7 +208,7 @@ Not implemented.
 
 #### Defined in
 
-[api-client/src/sequence-client.ts:102](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/sequence-client.ts#L102)
+[api-client/src/sequence-client.ts:100](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/sequence-client.ts#L100)
 
 ___
 
@@ -220,9 +220,9 @@ Starts sequence.
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `payload` | `StartSequencePayload` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `payload` | `StartSequencePayload` | App start configuration. |
 
 #### Returns
 
@@ -232,4 +232,4 @@ Promise resolving to Instance Client.
 
 #### Defined in
 
-[api-client/src/sequence-client.ts:55](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/sequence-client.ts#L55)
+[api-client/src/sequence-client.ts:53](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/sequence-client.ts#L53)

--- a/docs/host/classes/Host.md
+++ b/docs/host/classes/Host.md
@@ -320,7 +320,7 @@ Stops running servers.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:752](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L752)
+[packages/host/src/lib/host.ts:751](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L751)
 
 ___
 
@@ -354,7 +354,7 @@ List of Instances.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:659](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L659)
+[packages/host/src/lib/host.ts:658](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L658)
 
 ___
 
@@ -378,7 +378,7 @@ Sequence info object.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:674](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L674)
+[packages/host/src/lib/host.ts:673](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L673)
 
 ___
 
@@ -402,7 +402,7 @@ List of Instances.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:711](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L711)
+[packages/host/src/lib/host.ts:710](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L710)
 
 ___
 
@@ -420,7 +420,7 @@ List of Sequences.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:696](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L696)
+[packages/host/src/lib/host.ts:695](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L695)
 
 ___
 
@@ -434,7 +434,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:722](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L722)
+[packages/host/src/lib/host.ts:721](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L721)
 
 ___
 
@@ -603,7 +603,7 @@ Creates new CSIController [CSIController](CSIController.md) object and handles i
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `sequence` | `SequenceInfo` | Sequence info object. |
-| `payload` | `StartSequencePayload` | - |
+| `payload` | `StartSequencePayload` | App start configuration. |
 
 #### Returns
 
@@ -611,7 +611,7 @@ Creates new CSIController [CSIController](CSIController.md) object and handles i
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:525](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L525)
+[packages/host/src/lib/host.ts:524](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L524)
 
 ___
 
@@ -628,7 +628,7 @@ using its CSIController [CSIController](CSIController.md)
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:735](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L735)
+[packages/host/src/lib/host.ts:734](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L734)
 
 ___
 

--- a/docs/types/modules.md
+++ b/docs/types/modules.md
@@ -176,6 +176,7 @@
 
 ### Namespaces
 
+- [MHRestAPI](modules/MHRestAPI.md)
 - [MMRestAPI](modules/MMRestAPI.md)
 - [MRestAPI](modules/MRestAPI.md)
 - [MWRestAPI](modules/MWRestAPI.md)

--- a/docs/types/modules/MMRestAPI.md
+++ b/docs/types/modules/MMRestAPI.md
@@ -8,12 +8,16 @@
 
 - [ControlMessageResponse](MMRestAPI.md#controlmessageresponse)
 - [GetInfoReposnse](MMRestAPI.md#getinforeposnse)
+- [GetLoadCheckResponse](MMRestAPI.md#getloadcheckresponse)
 - [GetManagerResponse](MMRestAPI.md#getmanagerresponse)
 - [GetManagersResponse](MMRestAPI.md#getmanagersresponse)
-- [GetVersionResponse](MMRestAPI.md#getversionresponse)
 - [OpResponse](MMRestAPI.md#opresponse)
 - [SendStartManagerResponse](MMRestAPI.md#sendstartmanagerresponse)
 - [SendStopManagerResponse](MMRestAPI.md#sendstopmanagerresponse)
+
+### References
+
+- [GetVersionResponse](MMRestAPI.md#getversionresponse)
 
 ## Type aliases
 
@@ -52,6 +56,16 @@ ___
 
 ___
 
+### GetLoadCheckResponse
+
+Ƭ **GetLoadCheckResponse**: [`LoadCheckStat`](../modules.md#loadcheckstat)
+
+#### Defined in
+
+[packages/types/src/rest-api-commons/load-check.ts:3](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-commons/load-check.ts#L3)
+
+___
+
 ### GetManagerResponse
 
 Ƭ **GetManagerResponse**: `Object`
@@ -75,22 +89,6 @@ ___
 #### Defined in
 
 [packages/types/src/rest-api-multi-manager/get-managers.ts:3](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-multi-manager/get-managers.ts#L3)
-
-___
-
-### GetVersionResponse
-
-Ƭ **GetVersionResponse**: `Object`
-
-#### Type declaration
-
-| Name | Type |
-| :------ | :------ |
-| `version` | `string` |
-
-#### Defined in
-
-[packages/types/src/rest-api-multi-manager/get-version.ts:1](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-multi-manager/get-version.ts#L1)
 
 ___
 
@@ -139,3 +137,9 @@ ___
 #### Defined in
 
 [packages/types/src/rest-api-multi-manager/stop-manager.ts:1](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-multi-manager/stop-manager.ts#L1)
+
+## References
+
+### GetVersionResponse
+
+Re-exports [GetVersionResponse](MRestAPI.md#getversionresponse)

--- a/docs/types/modules/MRestAPI.md
+++ b/docs/types/modules/MRestAPI.md
@@ -152,11 +152,14 @@ ___
 
 | Name | Type |
 | :------ | :------ |
+| `apiVersion` | `string` |
+| `build` | `string` |
+| `service` | `string` |
 | `version` | `string` |
 
 #### Defined in
 
-[packages/types/src/rest-api-manager/get-version.ts:1](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-manager/get-version.ts#L1)
+[packages/types/src/rest-api-commons/version.ts:1](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-commons/version.ts#L1)
 
 ___
 

--- a/docs/types/modules/MWRestAPI.md
+++ b/docs/types/modules/MWRestAPI.md
@@ -4,11 +4,20 @@
 
 ## Table of contents
 
+### References
+
+- [GetVersionResponse](MWRestAPI.md#getversionresponse)
+
 ### Type aliases
 
 - [MultiManagerResponse](MWRestAPI.md#multimanagerresponse)
 - [MultiManagersResponse](MWRestAPI.md#multimanagersresponse)
-- [VersionResponse](MWRestAPI.md#versionresponse)
+
+## References
+
+### GetVersionResponse
+
+Re-exports [GetVersionResponse](MRestAPI.md#getversionresponse)
 
 ## Type aliases
 
@@ -37,19 +46,3 @@ ___
 #### Defined in
 
 [packages/types/src/rest-api-middleware/get-multi-managers.ts:3](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-middleware/get-multi-managers.ts#L3)
-
-___
-
-### VersionResponse
-
-Ƭ **VersionResponse**: `Object`
-
-#### Type declaration
-
-| Name | Type |
-| :------ | :------ |
-| `version` | `string` |
-
-#### Defined in
-
-[packages/types/src/rest-api-middleware/get-version.ts:1](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-middleware/get-version.ts#L1)

--- a/docs/types/modules/STHRestAPI.md
+++ b/docs/types/modules/STHRestAPI.md
@@ -8,23 +8,27 @@
 
 - [ControlMessageResponse](STHRestAPI.md#controlmessageresponse)
 - [DeleteSequenceResponse](STHRestAPI.md#deletesequenceresponse)
+- [GetConfigResponse](STHRestAPI.md#getconfigresponse)
 - [GetEventResponse](STHRestAPI.md#geteventresponse)
 - [GetHealthResponse](STHRestAPI.md#gethealthresponse)
 - [GetInstanceResponse](STHRestAPI.md#getinstanceresponse)
 - [GetInstancesResponse](STHRestAPI.md#getinstancesresponse)
-- [GetLoadCheckResponse](STHRestAPI.md#getloadcheckresponse)
 - [GetNextEventResponse](STHRestAPI.md#getnexteventresponse)
 - [GetSequenceInstancesResponse](STHRestAPI.md#getsequenceinstancesresponse)
 - [GetSequenceResponse](STHRestAPI.md#getsequenceresponse)
 - [GetSequencesResponse](STHRestAPI.md#getsequencesresponse)
 - [GetTopicsResponse](STHRestAPI.md#gettopicsresponse)
-- [GetVersionResponse](STHRestAPI.md#getversionresponse)
 - [SendEventResponse](STHRestAPI.md#sendeventresponse)
 - [SendKillInstanceResponse](STHRestAPI.md#sendkillinstanceresponse)
 - [SendSequenceResponse](STHRestAPI.md#sendsequenceresponse)
 - [SendStopInstanceResponse](STHRestAPI.md#sendstopinstanceresponse)
 - [StartSequencePayload](STHRestAPI.md#startsequencepayload)
 - [StartSequenceResponse](STHRestAPI.md#startsequenceresponse)
+
+### References
+
+- [GetLoadCheckResponse](STHRestAPI.md#getloadcheckresponse)
+- [GetVersionResponse](STHRestAPI.md#getversionresponse)
 
 ## Type aliases
 
@@ -60,13 +64,23 @@ ___
 
 ___
 
+### GetConfigResponse
+
+Ƭ **GetConfigResponse**: [`PublicSTHConfiguration`](../modules.md#publicsthconfiguration)
+
+#### Defined in
+
+[packages/types/src/rest-api-sth/get-config.ts:3](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-sth/get-config.ts#L3)
+
+___
+
 ### GetEventResponse
 
 Ƭ **GetEventResponse**: `any`
 
 #### Defined in
 
-[packages/types/src/rest-api-sth/index.ts:19](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-sth/index.ts#L19)
+[packages/types/src/rest-api-sth/index.ts:20](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-sth/index.ts#L20)
 
 ___
 
@@ -114,23 +128,13 @@ ___
 
 ___
 
-### GetLoadCheckResponse
-
-Ƭ **GetLoadCheckResponse**: [`LoadCheckStat`](../modules.md#loadcheckstat)
-
-#### Defined in
-
-[packages/types/src/rest-api-sth/get-load-check.ts:3](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-sth/get-load-check.ts#L3)
-
-___
-
 ### GetNextEventResponse
 
 Ƭ **GetNextEventResponse**: `any`
 
 #### Defined in
 
-[packages/types/src/rest-api-sth/index.ts:20](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-sth/index.ts#L20)
+[packages/types/src/rest-api-sth/index.ts:21](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-sth/index.ts#L21)
 
 ___
 
@@ -154,7 +158,7 @@ ___
 | :------ | :------ |
 | `config` | [`SequenceConfig`](../modules.md#sequenceconfig) |
 | `id` | `string` |
-| `instances` | `string`[] |
+| `instances` | readonly `string`[] |
 
 #### Defined in
 
@@ -179,25 +183,6 @@ ___
 #### Defined in
 
 [packages/types/src/rest-api-sth/get-topics.ts:1](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-sth/get-topics.ts#L1)
-
-___
-
-### GetVersionResponse
-
-Ƭ **GetVersionResponse**: `Object`
-
-#### Type declaration
-
-| Name | Type |
-| :------ | :------ |
-| `apiVersion` | `string` |
-| `build` | `string` |
-| `service` | `string` |
-| `version` | `string` |
-
-#### Defined in
-
-[packages/types/src/rest-api-sth/version.ts:1](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-sth/version.ts#L1)
 
 ___
 
@@ -273,3 +258,15 @@ ___
 #### Defined in
 
 [packages/types/src/rest-api-sth/start-sequence.ts:3](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-sth/start-sequence.ts#L3)
+
+## References
+
+### GetLoadCheckResponse
+
+Re-exports [GetLoadCheckResponse](MMRestAPI.md#getloadcheckresponse)
+
+___
+
+### GetVersionResponse
+
+Re-exports [GetVersionResponse](MRestAPI.md#getversionresponse)


### PR DESCRIPTION
## @scramjet/transform Hub - v0.21.0

- Make version endpoint type consistent
- Fix passing args to sequence through CLI
- Introduce si seq prune for bulk sequence removal
- Add docs on how to write a sequence
- Enable ending input stream through CLI
- Enable closing HTTP connection in API Clients
- Select first healthy hub as default in CLI
- Make rebuilding STH much faster

Let me know if there is something I should have listed in prominent/features section.