### PR TITLE
Trigger CPM-STH compatibility test in PR checks

### DIFF
--- a/.github/workflows/sth-build-test.yml
+++ b/.github/workflows/sth-build-test.yml
@@ -424,3 +424,19 @@ jobs:
 
         - name: Run BDD tests
           run: SCRAMJET_TEST_LOG=1 yarn test:bdd-ci-no-docker
+
+  trigger-compatibility-test:
+    name: STH-CPM compatibility test (from platform-tests)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.1
+        with:
+          owner: scramjetorg
+          repo: platform-tests
+          github_token: ${{ secrets.SCRAMJET_BOT_TOKEN }}
+          github_user: ${{ secrets.WORKFLOW_TRIGGER_USERNAME }}
+          workflow_file_name: compatibility-check.yml
+          client_payload: |
+            {
+              "sth-version": "${{ github.event.pull_request.head.sha }}"
+            }


### PR DESCRIPTION
Use compatibility test workflow from
https://github.com/scramjetorg/platform-tests repository, triggering it
and awaiting for the result.

https://app.clickup.com/t/24308805/SCP-3466