### PR TITLE
Prepare new release - 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ Prominent
 - 22f1a1656 - Add python3 to STH docker image
 - 7417b7a98 - Enable assigning output topic on sequence start.
 - 018e6975d - CLI commands update
+- 913b8877 - IaC startup mode (#239)
+- 93391784 - Introduce Auditor class to provide audit stream
 
 New features:
 
@@ -73,6 +75,8 @@ New features:
 - **Dockerized Python Runner** - Python programs can now be run in Docker containers
 - **Reusable topics** - Topic streams don't end when input ends, you can always send more input
 - **Python in Docker image** - When running STH from docker image, you will have python installed to run python sequences inside
+- **Infrastructure as Code mode** - allow configuring sequences that should be started automatically when STH is started.
+- **Audit stream** - Adds middleware to Host API Server to intercept all requests and push their details to Audit stream.
 
 
 Bugfixes and minor improvements:
@@ -146,7 +150,9 @@ Bugfixes and minor improvements:
 - Enable closing HTTP connection in API Clients
 - Select first healthy hub as default in CLI
 - Make rebuilding STH much faster
+- Ability to pass a RequestInit object to stream requests in Api clients (Fix ClientUtils for browser)
 
-## @scramjet/transform Hub - v0.21.0
+
+## @scramjet/transform Hub - v0.22.0
 
 This is the last release in changelog.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ Prominent
 - f31916d7 - Fixes for stream ending with `x-stream-end` header.
 - ceb4362d - Make `fetchOnlyIfExists` truly optional in docker image pulling procedure.
 - 250d9f31 - Fix docker adapter to wait until image pull is finished.
-- 547eeb8e - Allow to publish sequence ports, both TCP and UDP
+- 547eeb8e - Allow to publish Sequence ports, both TCP and UDP
 - 48d59c69 - Temporary restoring wait before detaching endpoint
 - 424bd67d - Colorize logger function name, update logs
 - da503b9b - Enable starting runner with ts-node in --no-docker mode, which is very useful for development contributors
 - 542080ed - Introducing in consistent response type from STH API endpoints, also implementation of type-layer error mechanism for StartSequence and DeleteSequence
-- a60bf30e - Added configurable instance adapter exit delay to sth config
+- a60bf30e - Added configurable Instance Adapter exit delay to sth config
 - 9eb223dc - Improved error handling in api server
 - c37bed19 - Reduce size of Common Logs Pipe buffer
 - 80c46760 - Improve Dockerfile for runner
@@ -29,7 +29,7 @@ Prominent
 - 3f0b4494 - Listen and reconnect on VerserClient error in Host to Manager connection
 - d0f7bdc4 - Python runner work in progress
 - f0963d02 - Logger upgrade, now it operates on objects not strings
-- e89113b2 - CLI: fix for saving instance id in config
+- e89113b2 - CLI: fix for saving Instance id in config
 - 5217044e - Introduce a new, faster building for development using esbuild
 - fe364b1a - Add support for complex packages in python apps
 - 2d193278 - Introduce HTTPS support in the API Server
@@ -49,22 +49,22 @@ Prominent
 - 417685b07 - Switch topic requests to https.
 - ac15ee4e4 - Do not close topic when producing output stream is ended.
 - 22f1a1656 - Add python3 to STH docker image
-- 7417b7a98 - Enable assigning output topic on sequence start.
+- 7417b7a98 - Enable assigning output topic on Sequence start.
 - 018e6975d - CLI commands update
 - 913b8877 - IaC startup mode (#239)
 - 93391784 - Introduce Auditor class to provide audit stream
 
 New features:
 
-- **Topics** - You can now send data to STH without having to have a sequence
+- **Topics** - You can now send data to STH without having to have a Sequence
 - **Cloud Platform Connection** - Scramjet will allow to connect multiple STH to allow multipoint data sharing between them
-- **New Adapters** - New adapters added to instance and sequence which doesn't depend on Docker
-- **Log endpoint** - New endpoint '/logs' that streams all instances logs
+- **New Adapters** - New adapters added to Instance and Sequence which doesn't depend on Docker
+- **Log endpoint** - New endpoint '/logs' that streams all Instances logs
 - **Verser module** - New module for reverse server functionality
 - **Comments** - Improved code documentation
 - **TCP Runner** - Connection between Runner and Host is replaced from socket to TCP
-- **CLI extension** - Last uploaded/added sequence can now be referenced when starting etc. This will massively improve the CLI experience, as there's no longer need to parse the previous command line if we want to do quick deployment of a sequence
-- **Python runner WIP** - Running STH without docker can now spawn sequences written in python
+- **CLI extension** - Last uploaded/added Sequence can now be referenced when starting etc. This will massively improve the CLI experience, as there's no longer need to parse the previous command line if we want to do quick deployment of a Sequence
+- **Python runner WIP** - Running STH without docker can now spawn Sequences written in python
 - **HTTPS Upgrade** - The API server can now be secured using HTTPS
 - **Instance stop improvement** - Support for graceful stop of Instance in Python Runner
 - **Typed responses for api-client** - Integrate sapphire fetch wrapper in api-cli
@@ -74,8 +74,8 @@ New features:
 - **Kubernetes Runtime Adapters** - new Sequence and Instance Adapters allow running programs on Kubernetes
 - **Dockerized Python Runner** - Python programs can now be run in Docker containers
 - **Reusable topics** - Topic streams don't end when input ends, you can always send more input
-- **Python in Docker image** - When running STH from docker image, you will have python installed to run python sequences inside
-- **Infrastructure as Code mode** - allow configuring sequences that should be started automatically when STH is started.
+- **Python in Docker image** - When running STH from docker image, you will have python installed to run python Sequences inside
+- **Infrastructure as Code mode** - allow configuring Sequences that should be started automatically when STH is started.
 - **Audit stream** - Adds middleware to Host API Server to intercept all requests and push their details to Audit stream.
 
 
@@ -137,7 +137,7 @@ Bugfixes and minor improvements:
 - Fix the build scripts of @scramjet/cli so that completion is added
 - Add cli utility for coloring JSON logs obtained from remote STH
 - Add /config API endpoint for checking STH/Host config
-- Fix for adding Python sequence library to path
+- Fix for adding Python Sequence library to path
 - Choosing runner image in kubernetes adapter (so that either python or node runner can be used)
 - Provide more information about the service on /version endpoint (service name, commit ID)
 - API base url (e.g. the one provided to CLI) is normalized

--- a/docs/api-client/classes/HostClient.md
+++ b/docs/api-client/classes/HostClient.md
@@ -99,7 +99,7 @@ Promise resolving to delete Sequence result.
 
 #### Defined in
 
-[api-client/src/host-client.ts:76](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L76)
+[api-client/src/host-client.ts:78](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L78)
 
 ___
 
@@ -117,7 +117,7 @@ Promise resolving to Host configuration (public part).
 
 #### Defined in
 
-[api-client/src/host-client.ts:114](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L114)
+[api-client/src/host-client.ts:116](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L116)
 
 ___
 
@@ -141,7 +141,7 @@ Promise resolving to Instance details.
 
 #### Defined in
 
-[api-client/src/host-client.ts:87](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L87)
+[api-client/src/host-client.ts:89](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L89)
 
 ___
 
@@ -159,15 +159,21 @@ Promise resolving to Host load check data.
 
 #### Defined in
 
-[api-client/src/host-client.ts:96](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L96)
+[api-client/src/host-client.ts:98](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L98)
 
 ___
 
 ### getLogStream
 
-▸ **getLogStream**(): `Promise`<`Readable`\>
+▸ **getLogStream**(`requestInit?`): `Promise`<`Readable`\>
 
 Returns Host log stream.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `requestInit?` | `RequestInit` | RequestInit object to be passed to fetch. |
 
 #### Returns
 
@@ -177,13 +183,13 @@ Promise resolving to response with log stream.
 
 #### Defined in
 
-[api-client/src/host-client.ts:42](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L42)
+[api-client/src/host-client.ts:43](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L43)
 
 ___
 
 ### getNamedData
 
-▸ **getNamedData**(`topic`): `Promise`<`Readable`\>
+▸ **getNamedData**(`topic`, `requestInit?`): `Promise`<`Readable`\>
 
 Returns stream from given topic.
 
@@ -192,6 +198,7 @@ Returns stream from given topic.
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `topic` | `string` | Topic name. |
+| `requestInit?` | `RequestInit` | RequestInit object to be passed to fetch. |
 
 #### Returns
 
@@ -201,7 +208,7 @@ Promise resolving to readable stream.
 
 #### Defined in
 
-[api-client/src/host-client.ts:138](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L138)
+[api-client/src/host-client.ts:148](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L148)
 
 ___
 
@@ -225,7 +232,7 @@ Promise resolving to Sequence details.
 
 #### Defined in
 
-[api-client/src/host-client.ts:66](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L66)
+[api-client/src/host-client.ts:68](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L68)
 
 ___
 
@@ -239,7 +246,7 @@ ___
 
 #### Defined in
 
-[api-client/src/host-client.ts:142](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L142)
+[api-client/src/host-client.ts:152](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L152)
 
 ___
 
@@ -257,7 +264,7 @@ Promise resolving to Host version.
 
 #### Defined in
 
-[api-client/src/host-client.ts:105](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L105)
+[api-client/src/host-client.ts:107](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L107)
 
 ___
 
@@ -299,7 +306,7 @@ ___
 
 ### sendNamedData
 
-▸ **sendNamedData**<`T`\>(`topic`, `stream`, `contentType?`, `end?`): `Promise`<`T`\>
+▸ **sendNamedData**<`T`\>(`topic`, `stream`, `requestInit?`, `contentType?`, `end?`): `Promise`<`T`\>
 
 Sends data to the topic.
 Topics are a part of Service Discovery feature enabling data exchange through Topics API.
@@ -316,6 +323,7 @@ Topics are a part of Service Discovery feature enabling data exchange through To
 | :------ | :------ | :------ |
 | `topic` | `string` | Topic name. |
 | `stream` | `string` \| `Readable` | Stream to be piped to topic. |
+| `requestInit?` | `RequestInit` | RequestInit object to be passed to fetch. |
 | `contentType?` | `string` | - |
 | `end?` | `boolean` | Indicates if "end" event from stream should be passed to topic. |
 
@@ -327,13 +335,13 @@ TODO: comment.
 
 #### Defined in
 
-[api-client/src/host-client.ts:128](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L128)
+[api-client/src/host-client.ts:131](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L131)
 
 ___
 
 ### sendSequence
 
-▸ **sendSequence**(`sequencePackage`): `Promise`<[`SequenceClient`](SequenceClient.md)\>
+▸ **sendSequence**(`sequencePackage`, `requestInit?`): `Promise`<[`SequenceClient`](SequenceClient.md)\>
 
 Uploads Sequence to Host.
 
@@ -342,6 +350,7 @@ Uploads Sequence to Host.
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `sequencePackage` | `string` \| `Readable` | Stream with packed Sequence. |
+| `requestInit?` | `RequestInit` | RequestInit object to be passed to fetch. |
 
 #### Returns
 
@@ -351,4 +360,4 @@ Sequence client.
 
 #### Defined in
 
-[api-client/src/host-client.ts:52](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L52)
+[api-client/src/host-client.ts:54](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/host-client.ts#L54)

--- a/docs/api-client/classes/InstanceClient.md
+++ b/docs/api-client/classes/InstanceClient.md
@@ -319,7 +319,7 @@ ___
 
 ### sendInput
 
-▸ **sendInput**(`stream`, `options?`): `Promise`<`any`\>
+▸ **sendInput**(`stream`, `requestInit?`, `options?`): `Promise`<`any`\>
 
 Pipes given stream to Instance "input".
 
@@ -328,7 +328,8 @@ Pipes given stream to Instance "input".
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `stream` | `string` \| `Readable` | Stream to be piped. Or string written to "stdin" stream. |
-| `options?` | `Partial`<{ `end`: `boolean` ; `parseResponse?`: ``"json"`` \| ``"text"`` \| ``"stream"`` ; `type`: `string`  }\> | Request options |
+| `requestInit?` | `RequestInit` | - |
+| `options?` | `Partial`<{ `end`: `boolean` ; `parseResponse?`: ``"json"`` \| ``"text"`` \| ``"stream"`` ; `type`: `string`  }\> | - |
 
 #### Returns
 
@@ -338,7 +339,7 @@ Promise resolving to send stream result.
 
 #### Defined in
 
-[api-client/src/instance-client.ts:181](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L181)
+[api-client/src/instance-client.ts:183](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L183)
 
 ___
 
@@ -362,13 +363,13 @@ Promise resolving to send stream result.
 
 #### Defined in
 
-[api-client/src/instance-client.ts:191](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L191)
+[api-client/src/instance-client.ts:193](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L193)
 
 ___
 
 ### sendStream
 
-▸ **sendStream**(`streamId`, `stream`, `options?`): `Promise`<`any`\>
+▸ **sendStream**(`streamId`, `stream`, `requestInit?`, `options?`): `Promise`<`any`\>
 
 Sends stream to one of the Instance inputs.
 
@@ -378,6 +379,7 @@ Sends stream to one of the Instance inputs.
 | :------ | :------ | :------ |
 | `streamId` | [`InstanceInputStream`](../modules.md#instanceinputstream) | Target input stream. |
 | `stream` | `string` \| `Readable` | Stream to send. |
+| `requestInit?` | `RequestInit` | - |
 | `options?` | `Partial`<{ `end`: `boolean` ; `parseResponse?`: ``"json"`` \| ``"text"`` \| ``"stream"`` ; `type`: `string`  }\> | - |
 
 #### Returns
@@ -388,7 +390,7 @@ Promise resolving to send stream result.
 
 #### Defined in
 
-[api-client/src/instance-client.ts:170](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L170)
+[api-client/src/instance-client.ts:171](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L171)
 
 ___
 

--- a/docs/api-client/classes/SequenceClient.md
+++ b/docs/api-client/classes/SequenceClient.md
@@ -216,7 +216,7 @@ ___
 
 ▸ **start**(`payload`): `Promise`<[`InstanceClient`](InstanceClient.md)\>
 
-Starts sequence.
+Starts Sequence.
 
 #### Parameters
 

--- a/docs/host/classes/CSIController.md
+++ b/docs/host/classes/CSIController.md
@@ -20,6 +20,9 @@ Handles all Instance lifecycle, exposes instance's HTTP API.
 - [appConfig](CSIController.md#appconfig)
 - [communicationHandler](CSIController.md#communicationhandler)
 - [controlDataStream](CSIController.md#controldatastream)
+- [heartBeatPromise](CSIController.md#heartbeatpromise)
+- [heartBeatResolver](CSIController.md#heartbeatresolver)
+- [heartBeatTicker](CSIController.md#heartbeatticker)
 - [id](CSIController.md#id)
 - [info](CSIController.md#info)
 - [initResolver](CSIController.md#initresolver)
@@ -53,6 +56,9 @@ Handles all Instance lifecycle, exposes instance's HTTP API.
 - [handleKeepAliveCommand](CSIController.md#handlekeepalivecommand)
 - [handleSequenceCompleted](CSIController.md#handlesequencecompleted)
 - [handleSequenceStopped](CSIController.md#handlesequencestopped)
+- [heartBeatStart](CSIController.md#heartbeatstart)
+- [heartBeatStop](CSIController.md#heartbeatstop)
+- [heartBeatTick](CSIController.md#heartbeattick)
 - [hookupStreams](CSIController.md#hookupstreams)
 - [instanceStopped](CSIController.md#instancestopped)
 - [listenerCount](CSIController.md#listenercount)
@@ -87,7 +93,7 @@ Handles all Instance lifecycle, exposes instance's HTTP API.
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:106](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L106)
+[packages/host/src/lib/csi-controller.ts:112](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L112)
 
 ___
 
@@ -97,7 +103,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:77](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L77)
+[packages/host/src/lib/csi-controller.ts:83](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L83)
 
 ___
 
@@ -107,7 +113,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:76](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L76)
+[packages/host/src/lib/csi-controller.ts:82](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L82)
 
 ___
 
@@ -127,7 +133,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:126](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L126)
+[packages/host/src/lib/csi-controller.ts:132](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L132)
 
 ___
 
@@ -138,6 +144,43 @@ ___
 #### Defined in
 
 [packages/host/src/lib/csi-controller.ts:63](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L63)
+
+___
+
+### heartBeatPromise
+
+• `Optional` **heartBeatPromise**: `Promise`<`string`\>
+
+#### Defined in
+
+[packages/host/src/lib/csi-controller.ts:78](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L78)
+
+___
+
+### heartBeatResolver
+
+• `Optional` **heartBeatResolver**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `rej` | `Function` |
+| `res` | `Function` |
+
+#### Defined in
+
+[packages/host/src/lib/csi-controller.ts:75](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L75)
+
+___
+
+### heartBeatTicker
+
+• `Optional` **heartBeatTicker**: `Timeout`
+
+#### Defined in
+
+[packages/host/src/lib/csi-controller.ts:80](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L80)
 
 ___
 
@@ -182,7 +225,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:72](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L72)
+[packages/host/src/lib/csi-controller.ts:73](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L73)
 
 ___
 
@@ -194,7 +237,7 @@ Topic to which the input stream should be routed
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:87](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L87)
+[packages/host/src/lib/csi-controller.ts:93](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L93)
 
 ___
 
@@ -216,7 +259,7 @@ Logger.
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:94](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L94)
+[packages/host/src/lib/csi-controller.ts:100](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L100)
 
 ___
 
@@ -228,7 +271,7 @@ Topic to which the output stream should be routed
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:82](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L82)
+[packages/host/src/lib/csi-controller.ts:88](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L88)
 
 ___
 
@@ -288,7 +331,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:74](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L74)
+[packages/host/src/lib/csi-controller.ts:77](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L77)
 
 ___
 
@@ -305,7 +348,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:73](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L73)
+[packages/host/src/lib/csi-controller.ts:74](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L74)
 
 ___
 
@@ -360,7 +403,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:250](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L250)
+[packages/host/src/lib/csi-controller.ts:277](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L277)
 
 ___
 
@@ -374,7 +417,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:377](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L377)
+[packages/host/src/lib/csi-controller.ts:404](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L404)
 
 ___
 
@@ -437,7 +480,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:526](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L526)
+[packages/host/src/lib/csi-controller.ts:553](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L553)
 
 ___
 
@@ -451,7 +494,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:544](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L544)
+[packages/host/src/lib/csi-controller.ts:571](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L571)
 
 ___
 
@@ -465,7 +508,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:548](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L548)
+[packages/host/src/lib/csi-controller.ts:575](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L575)
 
 ___
 
@@ -497,7 +540,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:540](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L540)
+[packages/host/src/lib/csi-controller.ts:567](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L567)
 
 ___
 
@@ -517,7 +560,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:339](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L339)
+[packages/host/src/lib/csi-controller.ts:366](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L366)
 
 ___
 
@@ -537,7 +580,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:366](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L366)
+[packages/host/src/lib/csi-controller.ts:393](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L393)
 
 ___
 
@@ -557,7 +600,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:596](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L596)
+[packages/host/src/lib/csi-controller.ts:623](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L623)
 
 ___
 
@@ -577,7 +620,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:553](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L553)
+[packages/host/src/lib/csi-controller.ts:580](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L580)
 
 ___
 
@@ -597,7 +640,49 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:569](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L569)
+[packages/host/src/lib/csi-controller.ts:596](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L596)
+
+___
+
+### heartBeatStart
+
+▸ **heartBeatStart**(): `void`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/host/src/lib/csi-controller.ts:245](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L245)
+
+___
+
+### heartBeatStop
+
+▸ **heartBeatStop**(): `void`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/host/src/lib/csi-controller.ts:258](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L258)
+
+___
+
+### heartBeatTick
+
+▸ **heartBeatTick**(): `void`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/host/src/lib/csi-controller.ts:251](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L251)
 
 ___
 
@@ -617,7 +702,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:265](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L265)
+[packages/host/src/lib/csi-controller.ts:292](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L292)
 
 ___
 
@@ -631,7 +716,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:257](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L257)
+[packages/host/src/lib/csi-controller.ts:284](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L284)
 
 ___
 
@@ -705,7 +790,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:170](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L170)
+[packages/host/src/lib/csi-controller.ts:176](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L176)
 
 ___
 
@@ -989,7 +1074,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:157](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L157)
+[packages/host/src/lib/csi-controller.ts:163](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L163)
 
 ___
 
@@ -1003,7 +1088,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:187](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L187)
+[packages/host/src/lib/csi-controller.ts:195](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L195)
 
 ## Constructors
 
@@ -1027,7 +1112,7 @@ TypedEmitter&lt;Events\&gt;.constructor
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:128](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L128)
+[packages/host/src/lib/csi-controller.ts:134](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L134)
 
 ## Accessors
 
@@ -1041,7 +1126,7 @@ TypedEmitter&lt;Events\&gt;.constructor
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:108](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L108)
+[packages/host/src/lib/csi-controller.ts:114](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L114)
 
 • `set` **endOfSequence**(`prm`): `void`
 
@@ -1057,7 +1142,7 @@ TypedEmitter&lt;Events\&gt;.constructor
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:116](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L116)
+[packages/host/src/lib/csi-controller.ts:122](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L122)
 
 ___
 
@@ -1071,4 +1156,4 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:98](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L98)
+[packages/host/src/lib/csi-controller.ts:104](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L104)

--- a/docs/host/classes/Host.md
+++ b/docs/host/classes/Host.md
@@ -16,6 +16,7 @@ Can communicate with Manager.
 
 - [api](Host.md#api)
 - [apiBase](Host.md#apibase)
+- [auditor](Host.md#auditor)
 - [commonLogsPipe](Host.md#commonlogspipe)
 - [config](Host.md#config)
 - [cpmConnector](Host.md#cpmconnector)
@@ -46,12 +47,15 @@ Can communicate with Manager.
 - [getSequenceInstances](Host.md#getsequenceinstances)
 - [getSequences](Host.md#getsequences)
 - [getTopics](Host.md#gettopics)
+- [handleAuditRequest](Host.md#handleauditrequest)
 - [handleDeleteSequence](Host.md#handledeletesequence)
 - [handleNewSequence](Host.md#handlenewsequence)
 - [handleStartSequence](Host.md#handlestartsequence)
+- [heartBeat](Host.md#heartbeat)
 - [identifyExistingSequences](Host.md#identifyexistingsequences)
 - [instanceMiddleware](Host.md#instancemiddleware)
 - [main](Host.md#main)
+- [performStartup](Host.md#performstartup)
 - [startCSIController](Host.md#startcsicontroller)
 - [stop](Host.md#stop)
 - [topicsMiddleware](Host.md#topicsmiddleware)
@@ -70,7 +74,7 @@ The Host's API Server.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:52](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L52)
+[packages/host/src/lib/host.ts:59](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L59)
 
 ___
 
@@ -82,7 +86,19 @@ Api path prefix based on initial configuration.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:57](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L57)
+[packages/host/src/lib/host.ts:64](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L64)
+
+___
+
+### auditor
+
+• **auditor**: `Auditor`
+
+Host auditor.
+
+#### Defined in
+
+[packages/host/src/lib/host.ts:49](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L49)
 
 ___
 
@@ -92,7 +108,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:98](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L98)
+[packages/host/src/lib/host.ts:105](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L105)
 
 ___
 
@@ -104,7 +120,7 @@ Configuration.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:47](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L47)
+[packages/host/src/lib/host.ts:54](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L54)
 
 ___
 
@@ -116,7 +132,7 @@ Instance of CPMConnector used to communicate with Manager.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:71](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L71)
+[packages/host/src/lib/host.ts:78](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L78)
 
 ___
 
@@ -128,7 +144,7 @@ Instance path prefix.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:62](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L62)
+[packages/host/src/lib/host.ts:69](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L69)
 
 ___
 
@@ -144,7 +160,7 @@ Object to store CSIControllers.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:76](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L76)
+[packages/host/src/lib/host.ts:83](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L83)
 
 ___
 
@@ -156,7 +172,7 @@ Instance of class providing load check.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:91](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L91)
+[packages/host/src/lib/host.ts:98](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L98)
 
 ___
 
@@ -172,7 +188,7 @@ IComponent.logger
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:86](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L86)
+[packages/host/src/lib/host.ts:93](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L93)
 
 ___
 
@@ -182,7 +198,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:99](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L99)
+[packages/host/src/lib/host.ts:107](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L107)
 
 ___
 
@@ -194,7 +210,7 @@ Sequences store.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:81](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L81)
+[packages/host/src/lib/host.ts:88](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L88)
 
 ___
 
@@ -206,7 +222,7 @@ Service to handle topics.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:96](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L96)
+[packages/host/src/lib/host.ts:103](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L103)
 
 ___
 
@@ -216,7 +232,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:66](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L66)
+[packages/host/src/lib/host.ts:73](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L73)
 
 ___
 
@@ -226,7 +242,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:64](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L64)
+[packages/host/src/lib/host.ts:71](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L71)
 
 ## Accessors
 
@@ -240,7 +256,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:116](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L116)
+[packages/host/src/lib/host.ts:124](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L124)
 
 ___
 
@@ -254,7 +270,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:126](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L126)
+[packages/host/src/lib/host.ts:134](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L134)
 
 ___
 
@@ -268,7 +284,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:112](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L112)
+[packages/host/src/lib/host.ts:120](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L120)
 
 ___
 
@@ -282,7 +298,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:122](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L122)
+[packages/host/src/lib/host.ts:130](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L130)
 
 ## Methods
 
@@ -304,7 +320,7 @@ Setting up handlers for general Host API endpoints:
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:269](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L269)
+[packages/host/src/lib/host.ts:326](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L326)
 
 ___
 
@@ -320,23 +336,23 @@ Stops running servers.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:751](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L751)
+[packages/host/src/lib/host.ts:844](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L844)
 
 ___
 
 ### connectToCPM
 
-▸ **connectToCPM**(): `void`
+▸ **connectToCPM**(): `Promise`<`void`\>
 
 Initializes connector and connects to Manager.
 
 #### Returns
 
-`void`
+`Promise`<`void`\>
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:248](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L248)
+[packages/host/src/lib/host.ts:301](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L301)
 
 ___
 
@@ -354,7 +370,7 @@ List of Instances.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:658](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L658)
+[packages/host/src/lib/host.ts:751](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L751)
 
 ___
 
@@ -378,7 +394,7 @@ Sequence info object.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:673](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L673)
+[packages/host/src/lib/host.ts:766](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L766)
 
 ___
 
@@ -402,7 +418,7 @@ List of Instances.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:710](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L710)
+[packages/host/src/lib/host.ts:803](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L803)
 
 ___
 
@@ -420,7 +436,7 @@ List of Sequences.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:695](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L695)
+[packages/host/src/lib/host.ts:788](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L788)
 
 ___
 
@@ -434,7 +450,28 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:721](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L721)
+[packages/host/src/lib/host.ts:814](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L814)
+
+___
+
+### handleAuditRequest
+
+▸ **handleAuditRequest**(`req`, `res`): `Promise`<`Readable`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `req` | `ParsedMessage` |
+| `res` | `ServerResponse` |
+
+#### Returns
+
+`Promise`<`Readable`\>
+
+#### Defined in
+
+[packages/host/src/lib/host.ts:476](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L476)
 
 ___
 
@@ -461,7 +498,7 @@ Promise resolving to operation result object.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:351](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L351)
+[packages/host/src/lib/host.ts:413](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L413)
 
 ___
 
@@ -487,7 +524,7 @@ Promise resolving to operation result.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:428](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L428)
+[packages/host/src/lib/host.ts:521](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L521)
 
 ___
 
@@ -515,7 +552,21 @@ Promise resolving to operation result object.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:474](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L474)
+[packages/host/src/lib/host.ts:567](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L567)
+
+___
+
+### heartBeat
+
+▸ **heartBeat**(): `void`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/host/src/lib/host.ts:459](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L459)
 
 ___
 
@@ -532,7 +583,7 @@ Used to recover Sequences information after restart.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:401](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L401)
+[packages/host/src/lib/host.ts:494](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L494)
 
 ___
 
@@ -562,33 +613,41 @@ Instance middleware.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:311](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L311)
+[packages/host/src/lib/host.ts:373](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L373)
 
 ___
 
 ### main
 
-▸ **main**(`identifyExisting?`): `Promise`<[`Host`](Host.md)\>
+▸ **main**(): `Promise`<`void`\>
 
 Main method to start Host.
 Performs Hosts's initialization process: starts servers, identifies existing Instances,
 sets up API and connects to Manager.
 
-#### Parameters
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `identifyExisting` | `Partial`<{ `identifyExisting`: `boolean`  }\> | Indicates if existing Instances should be identified. |
-
 #### Returns
 
-`Promise`<[`Host`](Host.md)\>
+`Promise`<`void`\>
 
 Promise resolving to Instance of Host.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:202](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L202)
+[packages/host/src/lib/host.ts:213](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L213)
+
+___
+
+### performStartup
+
+▸ **performStartup**(): `Promise`<`void`\>
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Defined in
+
+[packages/host/src/lib/host.ts:255](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L255)
 
 ___
 
@@ -611,7 +670,7 @@ Creates new CSIController [CSIController](CSIController.md) object and handles i
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:524](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L524)
+[packages/host/src/lib/host.ts:617](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L617)
 
 ___
 
@@ -628,7 +687,7 @@ using its CSIController [CSIController](CSIController.md)
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:734](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L734)
+[packages/host/src/lib/host.ts:827](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L827)
 
 ___
 
@@ -650,7 +709,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:336](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L336)
+[packages/host/src/lib/host.ts:398](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L398)
 
 ## Constructors
 
@@ -671,4 +730,4 @@ Sets used modules with provided configuration.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:138](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L138)
+[packages/host/src/lib/host.ts:146](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L146)

--- a/docs/host/modules.md
+++ b/docs/host/modules.md
@@ -13,32 +13,37 @@
 - [ServiceDiscovery](classes/ServiceDiscovery.md)
 - [SocketServer](classes/SocketServer.md)
 
-### Type aliases
-
-- [HostOptions](modules.md#hostoptions)
-- [dataType](modules.md#datatype)
-- [streamType](modules.md#streamtype)
-- [topicDataType](modules.md#topicdatatype)
-
 ### Variables
 
 - [InstanceStore](modules.md#instancestore)
+
+### Type aliases
+
+- [dataType](modules.md#datatype)
+- [streamType](modules.md#streamtype)
+- [topicDataType](modules.md#topicdatatype)
 
 ### Functions
 
 - [startHost](modules.md#starthost)
 
-## Type aliases
+## Variables
 
-### HostOptions
+### InstanceStore
 
-Ƭ **HostOptions**: `Partial`<{ `identifyExisting`: `boolean`  }\>
+• `Const` **InstanceStore**: `Object` = `{}`
+
+Object storing Instance controllers.
+
+#### Index signature
+
+▪ [key: `string`]: [`CSIController`](classes/CSIController.md)
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:34](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L34)
+[packages/host/src/lib/instance-store.ts:6](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/instance-store.ts#L6)
 
-___
+## Type aliases
 
 ### dataType
 
@@ -97,27 +102,11 @@ Topic details type definition.
 
 [packages/host/src/lib/sd-adapter.ts:28](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/sd-adapter.ts#L28)
 
-## Variables
-
-### InstanceStore
-
-• `Const` **InstanceStore**: `Object` = `{}`
-
-Object storing Instance controllers.
-
-#### Index signature
-
-▪ [key: `string`]: [`CSIController`](classes/CSIController.md)
-
-#### Defined in
-
-[packages/host/src/lib/instance-store.ts:6](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/instance-store.ts#L6)
-
 ## Functions
 
 ### startHost
 
-▸ **startHost**(`apiServerConfig`, `sthConfig`, `hostOptions`): `Promise`<[`Host`](classes/Host.md)\>
+▸ **startHost**(`apiServerConfig`, `sthConfig`): `Promise`<[`Host`](classes/Host.md)\>
 
 Starts Host module.
 
@@ -127,7 +116,6 @@ Starts Host module.
 | :------ | :------ | :------ |
 | `apiServerConfig` | `ServerConfig` | api server configuration |
 | `sthConfig` | `STHConfiguration` | sth configuration |
-| `hostOptions` | `Partial`<{ `identifyExisting`: `boolean`  }\> | host options |
 
 #### Returns
 
@@ -135,4 +123,4 @@ Starts Host module.
 
 #### Defined in
 
-[packages/host/src/lib/start-host.ts:13](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/start-host.ts#L13)
+[packages/host/src/lib/start-host.ts:21](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/start-host.ts#L21)

--- a/docs/runner/classes/Runner.md
+++ b/docs/runner/classes/Runner.md
@@ -66,7 +66,7 @@ reacts to control messages such as stopping etc.
 
 #### Defined in
 
-[runner.ts:236](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L236)
+[runner.ts:233](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L233)
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 #### Defined in
 
-[runner.ts:156](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L156)
+[runner.ts:153](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L153)
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[runner.ts:120](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L120)
+[runner.ts:117](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L117)
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 #### Defined in
 
-[runner.ts:146](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L146)
+[runner.ts:143](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L143)
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-[runner.ts:410](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L410)
+[runner.ts:407](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L407)
 
 ___
 
@@ -142,7 +142,7 @@ ___
 
 #### Defined in
 
-[runner.ts:220](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L220)
+[runner.ts:217](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L217)
 
 ___
 
@@ -162,7 +162,7 @@ ___
 
 #### Defined in
 
-[runner.ts:194](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L194)
+[runner.ts:191](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L191)
 
 ___
 
@@ -176,7 +176,7 @@ ___
 
 #### Defined in
 
-[runner.ts:562](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L562)
+[runner.ts:559](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L559)
 
 ___
 
@@ -199,7 +199,7 @@ set up streams process.stdin, process.stdout, process.stderr, fifo downstream, f
 
 #### Defined in
 
-[runner.ts:376](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L376)
+[runner.ts:373](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L373)
 
 ___
 
@@ -213,7 +213,7 @@ ___
 
 #### Defined in
 
-[runner.ts:269](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L269)
+[runner.ts:266](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L266)
 
 ___
 
@@ -234,7 +234,7 @@ ___
 
 #### Defined in
 
-[runner.ts:422](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L422)
+[runner.ts:419](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L419)
 
 ___
 
@@ -248,7 +248,7 @@ ___
 
 #### Defined in
 
-[runner.ts:398](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L398)
+[runner.ts:395](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L395)
 
 ___
 
@@ -268,7 +268,7 @@ ___
 
 #### Defined in
 
-[runner.ts:181](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L181)
+[runner.ts:178](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L178)
 
 ___
 
@@ -282,7 +282,7 @@ ___
 
 #### Defined in
 
-[runner.ts:404](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L404)
+[runner.ts:401](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L401)
 
 ## Constructors
 
@@ -306,7 +306,7 @@ ___
 
 #### Defined in
 
-[runner.ts:83](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L83)
+[runner.ts:80](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L80)
 
 ## Accessors
 
@@ -320,7 +320,7 @@ ___
 
 #### Defined in
 
-[runner.ts:110](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L110)
+[runner.ts:107](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L107)
 
 ## Properties
 
@@ -337,7 +337,7 @@ ___
 
 #### Defined in
 
-[runner.ts:76](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L76)
+[runner.ts:73](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L73)
 
 ___
 
@@ -351,4 +351,4 @@ IComponent.logger
 
 #### Defined in
 
-[runner.ts:78](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L78)
+[runner.ts:75](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/runner/src/runner.ts#L75)

--- a/docs/sth-config/classes/ConfigService.md
+++ b/docs/sth-config/classes/ConfigService.md
@@ -29,7 +29,7 @@
 
 #### Defined in
 
-[sth-config/src/config-service.ts:74](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L74)
+[sth-config/src/config-service.ts:77](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L77)
 
 ## Methods
 
@@ -43,7 +43,7 @@
 
 #### Defined in
 
-[sth-config/src/config-service.ts:82](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L82)
+[sth-config/src/config-service.ts:85](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L85)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[sth-config/src/config-service.ts:94](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L94)
+[sth-config/src/config-service.ts:97](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L97)
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 #### Defined in
 
-[sth-config/src/config-service.ts:86](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L86)
+[sth-config/src/config-service.ts:89](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L89)
 
 ___
 
@@ -105,4 +105,4 @@ ___
 
 #### Defined in
 
-[sth-config/src/config-service.ts:90](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L90)
+[sth-config/src/config-service.ts:93](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L93)

--- a/docs/sth-config/modules.md
+++ b/docs/sth-config/modules.md
@@ -25,7 +25,7 @@
 
 #### Defined in
 
-[sth-config/src/config-service.ts:69](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L69)
+[sth-config/src/config-service.ts:72](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L72)
 
 ## Functions
 

--- a/docs/symbols/enums/OpRecordCode.md
+++ b/docs/symbols/enums/OpRecordCode.md
@@ -1,0 +1,310 @@
+[@scramjet/symbols](../README.md) / [Exports](../modules.md) / OpRecordCode
+
+# Enumeration: OpRecordCode
+
+## Table of contents
+
+### Enumeration members
+
+- [DELETE\_SEQUENCE](OpRecordCode.md#delete_sequence)
+- [GET\_INSTANCE](OpRecordCode.md#get_instance)
+- [GET\_INSTANCE\_EVENT](OpRecordCode.md#get_instance_event)
+- [GET\_INSTANCE\_EVENTS](OpRecordCode.md#get_instance_events)
+- [GET\_INSTANCE\_EVENT\_ONCE](OpRecordCode.md#get_instance_event_once)
+- [GET\_INSTANCE\_HEALTH](OpRecordCode.md#get_instance_health)
+- [GET\_INSTANCE\_LOG](OpRecordCode.md#get_instance_log)
+- [GET\_INSTANCE\_MONITORING](OpRecordCode.md#get_instance_monitoring)
+- [GET\_INSTANCE\_OUTPUT](OpRecordCode.md#get_instance_output)
+- [GET\_INSTANCE\_STDERR](OpRecordCode.md#get_instance_stderr)
+- [GET\_INSTANCE\_STDIN](OpRecordCode.md#get_instance_stdin)
+- [GET\_INSTANCE\_STDOUT](OpRecordCode.md#get_instance_stdout)
+- [GET\_SEQUENCE](OpRecordCode.md#get_sequence)
+- [GET\_TOPIC](OpRecordCode.md#get_topic)
+- [HOST\_HEARTBEAT](OpRecordCode.md#host_heartbeat)
+- [INSTANCE\_HEARTBEAT](OpRecordCode.md#instance_heartbeat)
+- [INSTANCE\_STOPPED](OpRecordCode.md#instance_stopped)
+- [MANAGER\_HEARTBEAT](OpRecordCode.md#manager_heartbeat)
+- [POST\_INSTANCE\_EVENT](OpRecordCode.md#post_instance_event)
+- [POST\_INSTANCE\_INPUT](OpRecordCode.md#post_instance_input)
+- [POST\_INSTANCE\_MONITORING\_RATE](OpRecordCode.md#post_instance_monitoring_rate)
+- [POST\_KILL\_INSTANCE](OpRecordCode.md#post_kill_instance)
+- [POST\_SEQUENCE](OpRecordCode.md#post_sequence)
+- [POST\_START\_INSTANCE](OpRecordCode.md#post_start_instance)
+- [POST\_STOP\_INSTANCE](OpRecordCode.md#post_stop_instance)
+- [POST\_TOPIC](OpRecordCode.md#post_topic)
+
+## Enumeration members
+
+### DELETE\_SEQUENCE
+
+• **DELETE\_SEQUENCE** = `10400`
+
+#### Defined in
+
+[op-record-code.ts:31](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/op-record-code.ts#L31)
+
+___
+
+### GET\_INSTANCE
+
+• **GET\_INSTANCE** = `11200`
+
+The message codes related to the operation on an Instance.
+They are triggered in response to the user operations performed by the API.
+
+#### Defined in
+
+[op-record-code.ts:8](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/op-record-code.ts#L8)
+
+___
+
+### GET\_INSTANCE\_EVENT
+
+• **GET\_INSTANCE\_EVENT** = `11210`
+
+#### Defined in
+
+[op-record-code.ts:17](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/op-record-code.ts#L17)
+
+___
+
+### GET\_INSTANCE\_EVENTS
+
+• **GET\_INSTANCE\_EVENTS** = `11209`
+
+#### Defined in
+
+[op-record-code.ts:16](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/op-record-code.ts#L16)
+
+___
+
+### GET\_INSTANCE\_EVENT\_ONCE
+
+• **GET\_INSTANCE\_EVENT\_ONCE** = `11211`
+
+#### Defined in
+
+[op-record-code.ts:18](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/op-record-code.ts#L18)
+
+___
+
+### GET\_INSTANCE\_HEALTH
+
+• **GET\_INSTANCE\_HEALTH** = `11208`
+
+#### Defined in
+
+[op-record-code.ts:15](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/op-record-code.ts#L15)
+
+___
+
+### GET\_INSTANCE\_LOG
+
+• **GET\_INSTANCE\_LOG** = `11204`
+
+#### Defined in
+
+[op-record-code.ts:12](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/op-record-code.ts#L12)
+
+___
+
+### GET\_INSTANCE\_MONITORING
+
+• **GET\_INSTANCE\_MONITORING** = `11205`
+
+#### Defined in
+
+[op-record-code.ts:13](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/op-record-code.ts#L13)
+
+___
+
+### GET\_INSTANCE\_OUTPUT
+
+• **GET\_INSTANCE\_OUTPUT** = `11206`
+
+#### Defined in
+
+[op-record-code.ts:14](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/op-record-code.ts#L14)
+
+___
+
+### GET\_INSTANCE\_STDERR
+
+• **GET\_INSTANCE\_STDERR** = `11202`
+
+#### Defined in
+
+[op-record-code.ts:10](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/op-record-code.ts#L10)
+
+___
+
+### GET\_INSTANCE\_STDIN
+
+• **GET\_INSTANCE\_STDIN** = `11203`
+
+#### Defined in
+
+[op-record-code.ts:11](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/op-record-code.ts#L11)
+
+___
+
+### GET\_INSTANCE\_STDOUT
+
+• **GET\_INSTANCE\_STDOUT** = `11201`
+
+#### Defined in
+
+[op-record-code.ts:9](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/op-record-code.ts#L9)
+
+___
+
+### GET\_SEQUENCE
+
+• **GET\_SEQUENCE** = `10200`
+
+The message codes related to the operation on a Sequence.
+They are triggered in response to the user operations performed by the API.
+
+#### Defined in
+
+[op-record-code.ts:30](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/op-record-code.ts#L30)
+
+___
+
+### GET\_TOPIC
+
+• **GET\_TOPIC** = `12200`
+
+The message codes related to the operation on Topics.
+They are triggered in response to the user operations performed by the API.
+
+#### Defined in
+
+[op-record-code.ts:40](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/op-record-code.ts#L40)
+
+___
+
+### HOST\_HEARTBEAT
+
+• **HOST\_HEARTBEAT** = `13010`
+
+The HEARTBEAT message is a signal issued periodically (configurable)
+by the CSI Controller, the Host and the Manager.
+It indicates whether the services are still operational.
+
+#### Defined in
+
+[op-record-code.ts:53](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/op-record-code.ts#L53)
+
+___
+
+### INSTANCE\_HEARTBEAT
+
+• **INSTANCE\_HEARTBEAT** = `13012`
+
+#### Defined in
+
+[op-record-code.ts:54](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/op-record-code.ts#L54)
+
+___
+
+### INSTANCE\_STOPPED
+
+• **INSTANCE\_STOPPED** = `-1`
+
+The INSTANCE_STOPPED message is sent when an Instance terminated not
+in response to the API request but gracefully by itself or by throwing an error.
+
+#### Defined in
+
+[op-record-code.ts:61](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/op-record-code.ts#L61)
+
+___
+
+### MANAGER\_HEARTBEAT
+
+• **MANAGER\_HEARTBEAT** = `13020`
+
+#### Defined in
+
+[op-record-code.ts:55](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/op-record-code.ts#L55)
+
+___
+
+### POST\_INSTANCE\_EVENT
+
+• **POST\_INSTANCE\_EVENT** = `11110`
+
+#### Defined in
+
+[op-record-code.ts:21](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/op-record-code.ts#L21)
+
+___
+
+### POST\_INSTANCE\_INPUT
+
+• **POST\_INSTANCE\_INPUT** = `11107`
+
+#### Defined in
+
+[op-record-code.ts:19](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/op-record-code.ts#L19)
+
+___
+
+### POST\_INSTANCE\_MONITORING\_RATE
+
+• **POST\_INSTANCE\_MONITORING\_RATE** = `11112`
+
+#### Defined in
+
+[op-record-code.ts:20](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/op-record-code.ts#L20)
+
+___
+
+### POST\_KILL\_INSTANCE
+
+• **POST\_KILL\_INSTANCE** = `11115`
+
+#### Defined in
+
+[op-record-code.ts:23](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/op-record-code.ts#L23)
+
+___
+
+### POST\_SEQUENCE
+
+• **POST\_SEQUENCE** = `10100`
+
+#### Defined in
+
+[op-record-code.ts:32](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/op-record-code.ts#L32)
+
+___
+
+### POST\_START\_INSTANCE
+
+• **POST\_START\_INSTANCE** = `10117`
+
+#### Defined in
+
+[op-record-code.ts:33](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/op-record-code.ts#L33)
+
+___
+
+### POST\_STOP\_INSTANCE
+
+• **POST\_STOP\_INSTANCE** = `11114`
+
+#### Defined in
+
+[op-record-code.ts:22](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/op-record-code.ts#L22)
+
+___
+
+### POST\_TOPIC
+
+• **POST\_TOPIC** = `12100`
+
+#### Defined in
+
+[op-record-code.ts:41](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/op-record-code.ts#L41)

--- a/docs/symbols/modules.md
+++ b/docs/symbols/modules.md
@@ -9,6 +9,7 @@
 - [CPMMessageCode](enums/CPMMessageCode.md)
 - [CommunicationChannel](enums/CommunicationChannel.md)
 - [InstanceMessageCode](enums/InstanceMessageCode.md)
+- [OpRecordCode](enums/OpRecordCode.md)
 - [RunnerExitCode](enums/RunnerExitCode.md)
 - [RunnerMessageCode](enums/RunnerMessageCode.md)
 - [SequenceMessageCode](enums/SequenceMessageCode.md)

--- a/docs/types/interfaces/AppContext.md
+++ b/docs/types/interfaces/AppContext.md
@@ -20,6 +20,7 @@ interruption.
 - [AppError](AppContext.md#apperror)
 - [config](AppContext.md#config)
 - [definition](AppContext.md#definition)
+- [exitTimeout](AppContext.md#exittimeout)
 - [initialState](AppContext.md#initialstate)
 - [logger](AppContext.md#logger)
 
@@ -67,6 +68,18 @@ Provides automated definition as understood by the system
 #### Defined in
 
 [packages/types/src/app-context.ts:168](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/app-context.ts#L168)
+
+___
+
+### exitTimeout
+
+• **exitTimeout**: `number`
+
+Allows setting timeout in millis to exit the sequence after exit called (default 10000)
+
+#### Defined in
+
+[packages/types/src/app-context.ts:181](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/app-context.ts#L181)
 
 ___
 

--- a/docs/types/interfaces/ISequenceAdapter.md
+++ b/docs/types/interfaces/ISequenceAdapter.md
@@ -37,7 +37,7 @@ Identifies new Sequence
 
 #### Defined in
 
-[packages/types/src/sequence-adapter.ts:27](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sequence-adapter.ts#L27)
+[packages/types/src/sequence-adapter.ts:28](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sequence-adapter.ts#L28)
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/sequence-adapter.ts:17](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sequence-adapter.ts#L17)
+[packages/types/src/sequence-adapter.ts:18](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sequence-adapter.ts#L18)
 
 ___
 
@@ -67,7 +67,7 @@ Identifies existing Sequences
 
 #### Defined in
 
-[packages/types/src/sequence-adapter.ts:22](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sequence-adapter.ts#L22)
+[packages/types/src/sequence-adapter.ts:23](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sequence-adapter.ts#L23)
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/sequence-adapter.ts:29](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sequence-adapter.ts#L29)
+[packages/types/src/sequence-adapter.ts:30](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sequence-adapter.ts#L30)
 
 ## Properties
 
@@ -97,7 +97,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/sequence-adapter.ts:31](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sequence-adapter.ts#L31)
+[packages/types/src/sequence-adapter.ts:32](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sequence-adapter.ts#L32)
 
 ___
 
@@ -109,4 +109,4 @@ Adapter name.
 
 #### Defined in
 
-[packages/types/src/sequence-adapter.ts:15](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sequence-adapter.ts#L15)
+[packages/types/src/sequence-adapter.ts:16](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sequence-adapter.ts#L16)

--- a/docs/types/modules.md
+++ b/docs/types/modules.md
@@ -116,6 +116,7 @@
 - [NetworkInfo](modules.md#networkinfo)
 - [NetworkInfoMessage](modules.md#networkinfomessage)
 - [NextCallback](modules.md#nextcallback)
+- [OpRecord](modules.md#oprecord)
 - [OpResolver](modules.md#opresolver)
 - [OpResponse](modules.md#opresponse)
 - [PangMessageData](modules.md#pangmessagedata)
@@ -151,6 +152,7 @@
 - [SequencePackageJSONScramjetConfig](modules.md#sequencepackagejsonscramjetconfig)
 - [SequencePackageJSONScramjetSection](modules.md#sequencepackagejsonscramjetsection)
 - [SequenceStoppedMessageData](modules.md#sequencestoppedmessagedata)
+- [StartSequenceDTO](modules.md#startsequencedto)
 - [StatusMessage](modules.md#statusmessage)
 - [StatusMessageData](modules.md#statusmessagedata)
 - [StopHandler](modules.md#stophandler)
@@ -941,7 +943,7 @@ ___
 
 ### HostErrorCode
 
-Ƭ **HostErrorCode**: ``"UNINITIALIZED_STREAM"`` \| ``"UNATTACHED_STREAMS"`` \| ``"UNKNOWN_CHANNEL"`` \| ``"LOG_NOT_AVAILABLE"`` \| ``"SEQUENCE_IDENTIFICATION_FAILED"`` \| ``"UNKNOWN_SEQUENCE"`` \| ``"UNKNOWN_INSTANCE"`` \| ``"EVENT_NAME_MISSING"`` \| ``"CONTROLLER_ERROR"`` \| ``"SOCKET_TAKEN"`` \| ``"API_CONFIGURATION_ERROR"``
+Ƭ **HostErrorCode**: ``"UNINITIALIZED_STREAM"`` \| ``"UNATTACHED_STREAMS"`` \| ``"UNKNOWN_CHANNEL"`` \| ``"LOG_NOT_AVAILABLE"`` \| ``"SEQUENCE_IDENTIFICATION_FAILED"`` \| ``"UNKNOWN_SEQUENCE"`` \| ``"UNKNOWN_INSTANCE"`` \| ``"EVENT_NAME_MISSING"`` \| ``"CONTROLLER_ERROR"`` \| ``"SOCKET_TAKEN"`` \| ``"API_CONFIGURATION_ERROR"`` \| ``"SEQUENCE_STARTUP_CONFIG_READ_ERROR"``
 
 #### Defined in
 
@@ -1356,14 +1358,11 @@ Manager configuration type definition.
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `allowUnknownHosts` | `boolean` | Allow to connect Host providing id but hasn't been registered in Manager. |
 | `apiBase` | `string` | MultiManager api base. |
-| `hostname` | `string` | MultiManager server hostname |
 | `id` | `string` | Manager id. |
 | `logColors` | `boolean` | Enables/disables colorized logs. |
 | `sthController` | { `unhealthyTimeoutMs`: `number`  } | Host controller configuration. |
 | `sthController.unhealthyTimeoutMs` | `number` | Number of milliseconds to wait for next LOAD message from `host` before marking it as unhealthy |
-| `sthServerPort` | `number` | Port for server listening for incoming Host connections. |
 
 #### Defined in
 
@@ -1684,6 +1683,29 @@ ___
 
 ___
 
+### OpRecord
+
+Ƭ **OpRecord**: `Object`
+
+#### Type declaration
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `objectId` | `string` | An instance of the object which the operation concerns, e.g. Instance ID. |
+| `opCode` | `OpRecordCode` | The type of recorded operation is identified by the code value from the OpRecord enumeration. |
+| `opState` | `string` | The operation state from the OpState enumeration. |
+| `receivedAt` | `number` | The timestamp of when the operation was registered. |
+| `requestId?` | `string` | The generated unique request ID for operations coming from the API. |
+| `requestorId` | `string` | The requestor can be either a user who performed the operation or the system. |
+| `rx?` | `number` | The data received in the request stream |
+| `tx?` | `number` | The data written to the request stream. |
+
+#### Defined in
+
+[packages/types/src/messages/op-record.ts:3](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/messages/op-record.ts#L3)
+
+___
+
 ### OpResolver
 
 Ƭ **OpResolver**: (`req`: [`ParsedMessage`](modules.md#parsedmessage), `res?`: `ServerResponse`) => `MaybePromise`<`any`\>
@@ -1839,7 +1861,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/sth-configuration.ts:182](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L182)
+[packages/types/src/sth-configuration.ts:201](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L201)
 
 ___
 
@@ -1998,6 +2020,7 @@ ___
 | `cpmSslCaPath?` | `string` |
 | `cpmUrl?` | `string` |
 | `docker` | `boolean` |
+| `exitWithLastInstance` | `boolean` |
 | `exposeHostIp` | `string` |
 | `hostname` | `string` |
 | `id?` | `string` |
@@ -2016,8 +2039,10 @@ ___
 | `prerunnerMaxMem` | `number` |
 | `runnerImage` | `string` |
 | `runnerMaxMem` | `number` |
+| `runnerPyImage` | `string` |
 | `runtimeAdapter` | `string` |
 | `sequencesRoot` | `string` |
+| `startupConfig` | `string` |
 
 #### Defined in
 
@@ -2042,6 +2067,8 @@ ___
 | `docker.runnerImages` | { `node`: `string` ; `python3`: `string`  } | - |
 | `docker.runnerImages.node` | `string` | - |
 | `docker.runnerImages.python3` | `string` | - |
+| `exitWithLastInstance` | `boolean` | Should the hub exit when the last instance ends |
+| `heartBeatInterval` | `number` | Heartbeat interval in miliseconds |
 | `host` | [`HostConfig`](modules.md#hostconfig) | Host configuration. |
 | `identifyExisting` | `boolean` | Should we identify existing sequences. |
 | `instanceAdapterExitDelay` | `number` | Time to wait after Runner container exit. In this additional time Instance API is still available. |
@@ -2049,12 +2076,13 @@ ___
 | `instanceRequirements.cpuLoad` | `number` | Required free CPU. In percentage. |
 | `instanceRequirements.freeMem` | `number` | Free memory required to start Instance. In megabytes. |
 | `instanceRequirements.freeSpace` | `number` | Free disk space required to start Instance. In megabytes. |
-| `kubernetes` | `Partial`<[`K8SAdapterConfiguration`](modules.md#k8sadapterconfiguration)\> | - |
+| `kubernetes` | `Partial`<[`K8SAdapterConfiguration`](modules.md#k8sadapterconfiguration)\> | Kubernetes adapter configuration |
 | `logColors` | `boolean` | Enable colors in logging. |
 | `logLevel` | [`LogLevel`](modules.md#loglevel) | Logging level. |
 | `runtimeAdapter` | `string` | Which sequence and instance adapters should STH use. One of 'docker', 'process', 'kubernetes' |
 | `safeOperationLimit` | `number` | The amount of memory that must remain free. |
 | `sequencesRoot` | `string` | Only used when `noDocker` is true Where should ProcessSequenceAdapter save new Sequences |
+| `startupConfig` | `string` | Provides the location of a config file with the list of sequences to be started along with the host |
 
 #### Defined in
 
@@ -2172,7 +2200,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/sequence-adapter.ts:5](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sequence-adapter.ts#L5)
+[packages/types/src/sequence-adapter.ts:6](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sequence-adapter.ts#L6)
 
 ___
 
@@ -2268,6 +2296,24 @@ ___
 #### Defined in
 
 [packages/types/src/messages/sequence-stopped.ts:1](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/messages/sequence-stopped.ts#L1)
+
+___
+
+### StartSequenceDTO
+
+Ƭ **StartSequenceDTO**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `appConfig?` | [`AppConfig`](modules.md#appconfig) |
+| `args?` | `string`[] |
+| `id` | `string` |
+
+#### Defined in
+
+[packages/types/src/dto/start-sequence.ts:3](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/dto/start-sequence.ts#L3)
 
 ___
 

--- a/docs/types/modules/MRestAPI.md
+++ b/docs/types/modules/MRestAPI.md
@@ -48,19 +48,11 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `config` | { `allowUnknownHosts`: `boolean` ; `apiBase`: `string` ; `hostname`: `string` ; `id`: `string` ; `logColors`: `boolean` ; `sthController`: { `unhealthyTimeoutMs`: `number`  } ; `sthServerPort`: `number`  } |
-| `config.allowUnknownHosts` | `boolean` |
-| `config.apiBase` | `string` |
-| `config.hostname` | `string` |
-| `config.id` | `string` |
-| `config.logColors` | `boolean` |
-| `config.sthController` | { `unhealthyTimeoutMs`: `number`  } |
-| `config.sthController.unhealthyTimeoutMs` | `number` |
-| `config.sthServerPort` | `number` |
+| `config` | [`ManagerConfiguration`](../modules.md#managerconfiguration) |
 
 #### Defined in
 
-[packages/types/src/rest-api-manager/get-config.ts:1](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-manager/get-config.ts#L1)
+[packages/types/src/rest-api-manager/get-config.ts:3](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-manager/get-config.ts#L3)
 
 ___
 

--- a/docs/utility/modules.md
+++ b/docs/utility/modules.md
@@ -13,9 +13,11 @@
 
 - [defer](modules.md#defer)
 - [isDefined](modules.md#isdefined)
+- [isStartSequenceDTO](modules.md#isstartsequencedto)
 - [merge](modules.md#merge)
 - [normalizeUrl](modules.md#normalizeurl)
 - [promiseTimeout](modules.md#promisetimeout)
+- [readConfigFile](modules.md#readconfigfile)
 - [readJsonFile](modules.md#readjsonfile)
 - [readStreamedJSON](modules.md#readstreamedjson)
 
@@ -23,7 +25,7 @@
 
 ### defer
 
-▸ **defer**(`timeout`): `Promise`<`void`\>
+▸ **defer**(`timeout?`): `Promise`<`void`\>
 
 Returns a promise that resolves after the specified duration.
 
@@ -35,7 +37,7 @@ await defer(10 * 1000);
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `timeout` | `number` | timeout in milliseconds. |
+| `timeout?` | `number` | timeout in milliseconds. |
 
 #### Returns
 
@@ -76,6 +78,26 @@ Returns true if given value is defined.
 #### Defined in
 
 [packages/utility/src/typeguards/is-defined.ts:7](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/utility/src/typeguards/is-defined.ts#L7)
+
+___
+
+### isStartSequenceDTO
+
+▸ **isStartSequenceDTO**(`arg`): arg is StartSequenceDTO
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `arg` | `any` |
+
+#### Returns
+
+arg is StartSequenceDTO
+
+#### Defined in
+
+[packages/utility/src/typeguards/dto/sequence-start.ts:3](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/utility/src/typeguards/dto/sequence-start.ts#L3)
 
 ___
 
@@ -164,6 +186,26 @@ Promise that reject after timeout or.
 #### Defined in
 
 [packages/utility/src/promise-timeout.ts:10](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/utility/src/promise-timeout.ts#L10)
+
+___
+
+### readConfigFile
+
+▸ **readConfigFile**(`filename`): `Promise`<`any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `filename` | `string` |
+
+#### Returns
+
+`Promise`<`any`\>
+
+#### Defined in
+
+[packages/utility/src/read-config-file.ts:3](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/utility/src/read-config-file.ts#L3)
 
 ___
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1314,19 +1314,6 @@
   resolved "https://registry.yarnpkg.com/@panva/asn1.js/-/asn1.js-1.0.0.tgz#dd55ae7b8129e02049f009408b97c61ccf9032f6"
   integrity sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==
 
-"@scramjet/symbols@^0.20.1":
-  version "0.20.1"
-  resolved "https://registry.yarnpkg.com/@scramjet/symbols/-/symbols-0.20.1.tgz#51016721e3783cb71951b0d10e3af8ca3aaac967"
-  integrity sha512-nSD93orqUXxrT75o5jNb/+nBnJ9hpsYRCJaL3AoOYTeFGRukPhGotYEMUSVkxpTRE1OYttp8cEHJS4QT6peoYg==
-
-"@scramjet/types@^0.20.1":
-  version "0.20.1"
-  resolved "https://registry.yarnpkg.com/@scramjet/types/-/types-0.20.1.tgz#ceb251460dd0e507475f408d71ad20de6998ef02"
-  integrity sha512-ejE0gd/fuk9UQBI/qgKhU0+eN1FsT8pg76wWtE7POXeuZOiZea3UMTDq6axeO7X2DCnbwtgbytQL59FQqmYH0w==
-  dependencies:
-    "@scramjet/symbols" "^0.20.1"
-    http-status-codes "^2.2.0"
-
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"


### PR DESCRIPTION
## @scramjet/transform Hub - v0.22.0

New features: 

- **Infrastructure as Code mode** - allow configuring sequences that should be started automatically when STH is started.
- **Audit stream** - Adds middleware to Host API Server to intercept all requests and push their details to Audit stream.

Bugfixes and minor improvements:

- Ability to pass a RequestInit object to stream requests in Api clients (Fix ClientUtils for browser)