### PR TITLE
Add sequence add/del, instance start/end status change to audit stream

### DIFF
--- a/packages/types/src/messages/op-record.ts
+++ b/packages/types/src/messages/op-record.ts
@@ -1,10 +1,10 @@
-import { OpRecordCode } from "@scramjet/symbols";
+import { InstanceMessageCode, OpRecordCode, SequenceMessageCode } from "@scramjet/symbols";
 
 export type OpRecord = {
     /**
     * The type of recorded operation is identified by the code value from the OpRecord enumeration.
     */
-    opCode: OpRecordCode;
+    opCode: OpRecordCode | SequenceMessageCode | InstanceMessageCode;
 
     /**
     * The operation state from the OpState enumeration.


### PR DESCRIPTION
Add `system` messages to `AuditStream` for Sequence create/delete and Instance start/end

```
{"opState":"START","opCode":10100,"requestId":"43408159-8d54-43b1-9239-1977d536c562","requestorId":"system","rx":280,"tx":25,"receivedAt":1651965560844, "host": "2e59fbf0-6dbc-4301-95ee-abcd2aa254e5"}
{"opState":"ACTIVE","opCode":10100,"requestId":"43408159-8d54-43b1-9239-1977d536c562","requestorId":"system","rx":28461,"tx":50,"receivedAt":1651965561844, "host": "2e59fbf0-6dbc-4301-95ee-abcd2aa254e5"}

new sequence --> {"opState":"","opCode":0,"objectId":"1db331cf-2269-4e21-be0a-e9119aa71b9b","requestorId":"system","receivedAt":1651965564026, "host": "2e59fbf0-6dbc-4301-95ee-abcd2aa254e5"}

{"opState":"END","opCode":10100,"requestId":"43408159-8d54-43b1-9239-1977d536c562","requestorId":"system","rx":28461,"tx":301,"receivedAt":1651965564029, "host": "2e59fbf0-6dbc-4301-95ee-abcd2aa254e5"}
```
