### PR TITLE
Explicitly define adapter as one of 'docker', 'process', 'kubernetes'

### DIFF
--- a/packages/types/src/sth-configuration.ts
+++ b/packages/types/src/sth-configuration.ts
@@ -78,6 +78,8 @@ export type K8SAdapterConfiguration = {
     timeout?: string
 }
 
+export type Adapter = "docker" | "process" | "kubernetes"
+
 export type STHConfiguration = {
     /**
      * Logging level.
@@ -166,9 +168,8 @@ export type STHConfiguration = {
 
     /**
      * Which sequence and instance adapters should STH use.
-     * One of 'docker', 'process', 'kubernetes'
      */
-    runtimeAdapter: string,
+    runtimeAdapter: Adapter,
 
     /**
      * Kubernetes adapter configuration


### PR DESCRIPTION
This will be handy when using the value of this attribute to get other
attributes, like config[config.runtimeAdapter].runnerImages.python3