### PR TITLE
CLI: Do not display a stream response when sending input to the Instance

### DIFF
--- a/packages/cli/src/lib/commands/instance.ts
+++ b/packages/cli/src/lib/commands/instance.ts
@@ -79,11 +79,8 @@ export const instance: CommandDefinition = (program) => {
         .action(async (id: string, filename: string, { contentType, end }) => {
             const instanceClient = getInstance(getInstanceId(id));
 
-            return displayEntity(
-                instanceClient.sendInput(filename
-                    ? await getReadStreamFromFile(filename)
-                    : process.stdin, {}, { type: contentType, end })
-            );
+            await instanceClient.sendInput(filename ? await getReadStreamFromFile(filename) : process.stdin, {},
+                { type: contentType, end });
         });
 
     instanceCmd


### PR DESCRIPTION
A tiny fix for the CLI displaying a PassThrough stream response when sending input to the Instance.

Before:
![Screenshot from 2022-05-10 14-19-48](https://user-images.githubusercontent.com/8177865/167635626-a56ae558-7692-4244-8843-72a5e24c53be.png)

After:
- With debug:
![Screenshot from 2022-05-10 14-20-15](https://user-images.githubusercontent.com/8177865/167635671-62d3d290-ce98-42ea-982a-a6b3451c34d6.png)
- Without debug:
![Screenshot from 2022-05-10 14-20-43](https://user-images.githubusercontent.com/8177865/167635801-de5e0d02-2a98-49a4-a299-00edbf11994a.png)

