### PR TITLE
Handle Runner failure and Sequence errors on Sequence start

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "lint:dedupe": "scripts/dedupe.js",
     "start": "node dist/sth/bin/hub.js",
     "start:dev": "ts-node packages/sth/src/bin/hub.ts",
+    "start:dev:cli": "ts-node packages/cli/src/bin/index.ts",
     "install:clean": "yarn clean && yarn clean:modules && yarn install",
     "postinstall": "lerna link",
     "prepare": "npx husky install",

--- a/packages/api-client/src/sequence-client.ts
+++ b/packages/api-client/src/sequence-client.ts
@@ -59,7 +59,7 @@ export class SequenceClient {
         );
 
         if (response.result === "error") {
-            return Promise.reject({ error: response.error });
+            return Promise.reject(response.error);
         }
 
         return InstanceClient.from(response.id, this.host);

--- a/packages/cli/src/lib/commands/sequence.ts
+++ b/packages/cli/src/lib/commands/sequence.ts
@@ -7,7 +7,7 @@ import { CommandDefinition } from "../../types";
 import { isDevelopment } from "../../utils/isDevelopment";
 import { getHostClient, getInstance, getReadStreamFromFile, packAction } from "../common";
 import { getPackagePath, getSequenceId, sessionConfig } from "../config";
-import { displayEntity, displayMessage, displayObject } from "../output";
+import { displayEntity, displayError, displayMessage, displayObject } from "../output";
 
 const sendPackage = async (sequencePackage: string) => {
     const seq = await getHostClient().sendSequence(
@@ -38,10 +38,15 @@ const startSequence = async (id: string, { configFile, configString, args, outpu
     }
     const sequenceClient = SequenceClient.from(getSequenceId(id), getHostClient());
 
-    const instance = await sequenceClient.start({ appConfig, args, outputTopic, inputTopic });
+    try {
+        const instance = await sequenceClient.start({ appConfig, args, outputTopic, inputTopic });
 
-    sessionConfig.setLastInstanceId(instance.id);
-    return displayObject(instance);
+        sessionConfig.setLastInstanceId(instance.id);
+        return displayObject(instance);
+    } catch (error: any) {
+        displayError(error);
+        process.exit(1);
+    }
 };
 
 function parseSequenceArgs(argsStr: string | undefined): any[] {

--- a/packages/cli/src/lib/commands/sequence.ts
+++ b/packages/cli/src/lib/commands/sequence.ts
@@ -45,7 +45,7 @@ const startSequence = async (id: string, { configFile, configString, args, outpu
         return displayObject(instance);
     } catch (error: any) {
         displayError(error);
-        process.exit(1);
+        return process.exit(1);
     }
 };
 

--- a/packages/cli/src/lib/output.ts
+++ b/packages/cli/src/lib/output.ts
@@ -70,3 +70,9 @@ export function displayMessage(message: string, ...args: any[]): void {
         console.error(">", inspect(a));
     }
 }
+
+export function displayError(error: Error | string) {
+    const message = error instanceof Error ? error.message : error;
+
+    console.error("\x1b[31m%s\x1b[0m", "Error:", message);
+}

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -261,6 +261,7 @@ export class CSIController extends TypedEmitter<Events> {
     }
 
     private mapRunnerExitCode(exitcode: number) {
+        // eslint-disable-next-line default-case
         switch (exitcode) {
         case RunnerExitCode.INVALID_ENV_VARS: {
             return Promise.reject("Runner was started with invalid configuration. This is probably a bug in STH.");
@@ -273,11 +274,11 @@ export class CSIController extends TypedEmitter<Events> {
         }
         }
 
-        if(exitcode > 0) {
-            return Promise.reject('Runner failed')
+        if (exitcode > 0) {
+            return Promise.reject("Runner failed");
         }
 
-        return Promise.resolve()
+        return Promise.resolve();
     }
 
     async cleanup() {
@@ -401,7 +402,7 @@ export class CSIController extends TypedEmitter<Events> {
             this.hookupStreams(streams);
             this.createInstanceAPIRouter();
 
-            await once(this, "pang")
+            await once(this, "pang");
             this.initResolver?.res();
         } catch (e: any) {
             this.initResolver?.rej(e);

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -401,9 +401,8 @@ export class CSIController extends TypedEmitter<Events> {
             this.hookupStreams(streams);
             this.createInstanceAPIRouter();
 
-            await once(this, "pang").then(() => {
-                this.initResolver?.res();
-            });
+            await once(this, "pang")
+            this.initResolver?.res();
         } catch (e: any) {
             this.initResolver?.rej(e);
         }

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -271,10 +271,13 @@ export class CSIController extends TypedEmitter<Events> {
         case RunnerExitCode.SEQUENCE_FAILED_ON_START: {
             return Promise.reject("Sequence failed on start");
         }
-        default: {
-            return Promise.resolve();
         }
+
+        if(exitcode > 0) {
+            return Promise.reject('Runner failed')
         }
+
+        return Promise.resolve()
     }
 
     async cleanup() {

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -650,12 +650,6 @@ export class Host implements IComponent {
             this.logger.error("CSIController errored", err);
         });
 
-        await csic.start();
-
-        this.logger.trace("CSIController started", id);
-
-        sequence.instances.add(id);
-
         csic.on("pang", (data) => {
             // @TODO REFACTOR possibly send only one PANG in Runner and throw on more pangs
             this.logger.trace("PANG received", data);
@@ -751,6 +745,12 @@ export class Host implements IComponent {
                 ) as Readable).unpipe(csic.getInputStream()!);
             }
         });
+
+        await csic.start();
+
+        this.logger.trace("CSIController started", id);
+
+        sequence.instances.add(id);
 
         return csic;
     }

--- a/packages/symbols/src/runner-exit-code.ts
+++ b/packages/symbols/src/runner-exit-code.ts
@@ -1,4 +1,5 @@
 export enum RunnerExitCode {
     INVALID_ENV_VARS = 20,
     INVALID_SEQUENCE_PATH = 21,
+    SEQUENCE_FAILED_ON_START = 22,
 }


### PR DESCRIPTION
This addresses both: https://app.clickup.com/t/24308805/SCP-3756 and https://app.clickup.com/t/24308805/SCP-3757

Now starting a sequence through API or CLI should properly exit with error in the following cases:
1. Runner process exited with non zero code before receiving PANG message
2. Sequence entrypoint file throws when importing it (e.g. syntax errors)
3. Sequence is an empty array 

## Verify
### 1. Crashing runner process
1. Add somewhere in global scope of `packages/runner/src/runner.ts`
```ts
throw new Error("OOOPS");
``` 
2. Run STH: 
```bash
yarn start:dev
```
3. In a new terminal run CLI:
```
npx ts-node packages/cli/src/bin/index.ts seq send ./packages/reference-apps/hello-alice-out.tar.gz
npx ts-node packages/cli/src/bin/index.ts seq start -
```
4. You should get similar output:
![image](https://user-images.githubusercontent.com/15108331/167836617-07d1f990-9617-4fd4-b308-794c46db293b.png)

### 2. Sequence entrypoint file is invalid
1. Add somewhere in global scope of some ref-app and then build it
```ts
throw new Error("OOOPS");
``` 
2. Run STH: 
```bash
yarn start:dev
```
3. In a new terminal run CLI:
```bash
npx ts-node packages/reference-apps/<path-to-your-sequence>
npx ts-node packages/cli/src/bin/index.ts seq start -
```
4. You should get similar output:
![image](https://user-images.githubusercontent.com/15108331/167837147-562ff332-e8f6-4061-a2ca-e52d7fcd39f7.png)

### 3. Empty sequence
Do the same as in 2nd test, just export an empty array:
```ts
const app: any[] = []
export default app;
```