### PR TITLE
Runner pod - support resource limits

### DIFF
--- a/packages/adapters/src/kubernetes-config-decoder.ts
+++ b/packages/adapters/src/kubernetes-config-decoder.ts
@@ -10,5 +10,9 @@ export const adapterConfigDecoder = JsonDecoder.object<K8SAdapterConfiguration>(
         node: JsonDecoder.string
     }, "K8SImagesDecoder"),
     sequencesRoot: JsonDecoder.string,
-    timeout:  JsonDecoder.optional(JsonDecoder.string)
+    timeout:  JsonDecoder.optional(JsonDecoder.string),
+    runnerResourcesRequestsMemory: JsonDecoder.optional(JsonDecoder.string),
+    runnerResourcesRequestsCpu: JsonDecoder.optional(JsonDecoder.string),
+    runnerResourcesLimitsMemory: JsonDecoder.optional(JsonDecoder.string),
+    runnerResourcesLimitsCpu: JsonDecoder.optional(JsonDecoder.string)
 }, "K8SAdapterConfiguration");

--- a/packages/adapters/src/kubernetes-instance-adapter.ts
+++ b/packages/adapters/src/kubernetes-instance-adapter.ts
@@ -66,6 +66,19 @@ IComponent {
         };
     }
 
+    private get runnerResourcesConfig() {
+        return {
+            requests: {
+                memory:  this.adapterConfig.runnerResourcesRequestsMemory || "128M",
+                cpu: this.adapterConfig.runnerResourcesRequestsCpu || "250m"
+            },
+            limits: {
+                memory: this.adapterConfig.runnerResourcesLimitsMemory || "1G",
+                cpu: this.adapterConfig.runnerResourcesLimitsCpu || "1000m"
+            }
+        };
+    }
+
     async run(config: SequenceConfig, instancesServerPort: number, instanceId: string): Promise<ExitCode> {
         if (config.type !== "kubernetes") {
             throw new Error(`Invalid config type for kubernetes adapter: ${config.type}`);
@@ -102,7 +115,8 @@ IComponent {
                     image: runnerImage,
                     stdin: true,
                     command: ["wait-for-sequence-and-start.sh"],
-                    imagePullPolicy: "Always"
+                    imagePullPolicy: "Always",
+                    resources: this.runnerResourcesConfig
                 }],
                 restartPolicy: "Never",
             },

--- a/packages/sth/src/bin/hub.ts
+++ b/packages/sth/src/bin/hub.ts
@@ -38,6 +38,10 @@ const options: STHCommandOptions = program
     .option("--k8s-runner-cleanup-timeout <timeout>", "Set timeout for deleting runner Pod after failure in ms")
     .option("--no-docker", "Run all the instances on the host machine instead of in docker containers. UNSAFE FOR RUNNING ARBITRARY CODE.", false)
     .option("--instances-server-port <port>", "Port on which server that instances connect to should run.")
+    .option("--k8s-runner-resources-requests-cpu <memory>", "Memory requests for pod CPU")
+    .option("--k8s-runner-resources-requests-memory <memory>", "Memory requests for pod memory")
+    .option("--k8s-runner-resources-limits-cpu <memory>", "Set limits for CPU")
+    .option("--k8s-runner-resources-limits-memory <memory>", "Set limits for memory")
     .parse(process.argv)
     .opts() as STHCommandOptions;
 
@@ -83,7 +87,11 @@ configService.update({
             python3: options.k8sRunnerPyImage
         },
         sequencesRoot: options.k8sSequencesRoot,
-        timeout: options.k8sRunnerCleanupTimeout
+        timeout: options.k8sRunnerCleanupTimeout,
+        runnerResourcesRequestsCpu: options.k8sRunnerResourcesRequestsCpu,
+        runnerResourcesRequestsMemory: options.k8sRunnerResourcesRequestsMemory,
+        runnerResourcesLimitsCpu: options.k8sRunnerResourcesLimitsCpu,
+        runnerResourcesLimitsMemory: options.k8sRunnerResourcesLimitsMemory
     }
 });
 

--- a/packages/types/src/sth-command-options.ts
+++ b/packages/types/src/sth-command-options.ts
@@ -25,7 +25,11 @@ export type STHCommandOptions = {
     k8sRunnerPyImage: string
     k8sSequencesRoot: string;
     docker: boolean;
-    k8sRunnerCleanupTimeout: string
+    k8sRunnerCleanupTimeout: string,
+    k8sRunnerResourcesRequestsCpu: string,
+    k8sRunnerResourcesRequestsMemory: string,
+    k8sRunnerResourcesLimitsCpu: string,
+    k8sRunnerResourcesLimitsMemory: string
     startupConfig: string;
     exitWithLastInstance: boolean;
 }

--- a/packages/types/src/sth-configuration.ts
+++ b/packages/types/src/sth-configuration.ts
@@ -75,7 +75,11 @@ export type K8SAdapterConfiguration = {
     sthPodHost: string,
     runnerImages: { python3: string, node: string },
     sequencesRoot: string,
-    timeout?: string
+    timeout?: string,
+    runnerResourcesRequestsMemory?: string,
+    runnerResourcesRequestsCpu?: string,
+    runnerResourcesLimitsMemory?: string,
+    runnerResourcesLimitsCpu?: string
 }
 
 export type STHConfiguration = {


### PR DESCRIPTION
1. Example of usage:

`DEVELOPMENT=1 yarn start:dev --runtime-adapter=kubernetes --k8s-namespace=default --k8s-sth-pod-host=sth-runner --k8s-runner-resources-requests-cpu=64m --k8s-runner-resources-requests-memory=64M --k8s-runner-resources-limits-cpu=1000m --k8s-runner-resources-limits-memory=1G`

2. To check result:
`kubectl describe pod <pod_name>`

Tested with minikube