### PR TITLE
Show error if sequence package does not exist in CLI sequence send

### DIFF
--- a/packages/cli/src/lib/commands/sequence.ts
+++ b/packages/cli/src/lib/commands/sequence.ts
@@ -7,16 +7,20 @@ import { CommandDefinition } from "../../types";
 import { isDevelopment } from "../../utils/isDevelopment";
 import { getHostClient, getInstance, getReadStreamFromFile, packAction } from "../common";
 import { getPackagePath, getSequenceId, sessionConfig } from "../config";
-import { displayEntity, displayMessage, displayObject } from "../output";
+import { displayEntity, displayError, displayMessage, displayObject } from "../output";
 
 const sendPackage = async (sequencePackage: string) => {
-    const seq = await getHostClient().sendSequence(
-        await getReadStreamFromFile(getPackagePath(sequencePackage))
-    );
+    try {
+        const seq = await getHostClient().sendSequence(
+            await getReadStreamFromFile(getPackagePath(sequencePackage))
+        );
 
-    sessionConfig.setLastSequenceId(seq.id);
+        sessionConfig.setLastSequenceId(seq.id);
 
-    return displayObject(seq);
+        return displayObject(seq);
+    } catch (e: any) {
+        return displayError(e);
+    }
 };
 
 const startSequence = async (id: string, { configFile, configString, args, outputTopic, inputTopic }:

--- a/packages/cli/src/lib/output.ts
+++ b/packages/cli/src/lib/output.ts
@@ -70,3 +70,9 @@ export function displayMessage(message: string, ...args: any[]): void {
         console.error(">", inspect(a));
     }
 }
+
+export function displayError(error: Error | string) {
+    const message = error instanceof Error ? error.message : error;
+
+    console.error("\x1b[31m%s\x1b[0m", "Error:", message);
+}


### PR DESCRIPTION
The error handling was already in-place, it was only missing proper error printing.

Once #491 is merged we can reuse the `displayError` function.