### PR TITLE
Log pretty error when pods quotas are reached

### DIFF
--- a/packages/adapters/src/kubernetes-client-adapter.ts
+++ b/packages/adapters/src/kubernetes-client-adapter.ts
@@ -4,6 +4,7 @@ import { ObjLogger } from "@scramjet/obj-logger";
 import { defer } from "@scramjet/utility";
 import { Writable, Readable } from "stream";
 import http from "http";
+import { HttpError } from "@kubernetes/client-node";
 
 const POD_STATUS_CHECK_INTERVAL_MS = 500;
 const POD_STATUS_FAIL_LIMIT = 10;
@@ -131,7 +132,11 @@ class KubernetesClientAdapter {
 
                 success = true;
             } catch (err: any) {
-                this.logger.error(`Failed to run: ${name}.`, err);
+                if (err instanceof HttpError) {
+                    this.logger.error(`Running "${name}" responded with error`, err.body.message);
+                } else {
+                    this.logger.error(`Failed to run: ${name}.`, err);
+                }
 
                 await defer(sleepMs);
 

--- a/packages/adapters/src/kubernetes-client-adapter.ts
+++ b/packages/adapters/src/kubernetes-client-adapter.ts
@@ -133,7 +133,7 @@ class KubernetesClientAdapter {
                 success = true;
             } catch (err: any) {
                 if (err instanceof HttpError) {
-                    this.logger.error(`Running "${name}" responded with error`, err.body.message);
+                    this.logger.error(`Running "${name}" responded with error`, err?.body?.message);
                 } else {
                     this.logger.error(`Failed to run: ${name}.`, err);
                 }

--- a/packages/adapters/src/kubernetes-client-adapter.ts
+++ b/packages/adapters/src/kubernetes-client-adapter.ts
@@ -116,6 +116,13 @@ class KubernetesClientAdapter {
         }
     }
 
+    async getPodTerminatedContainerReason(podName: string): Promise<string | undefined> {
+        const kubeApi = this.config.makeApiClient(k8s.CoreV1Api);
+        const response = await kubeApi.readNamespacedPod(podName, this._namespace);
+
+        return response.body.status?.containerStatuses?.[0].state?.terminated?.reason;
+    }
+
     private async runWithRetries(retries: number, name: string, callback: any) {
         let tries = 0;
         let sleepMs = 1000;

--- a/packages/adapters/src/kubernetes-instance-adapter.ts
+++ b/packages/adapters/src/kubernetes-instance-adapter.ts
@@ -149,6 +149,7 @@ IComponent {
 
         if (exitPodStatus !== "Succeeded") {
             this.logger.error("Runner stopped incorrectly", exitPodStatus);
+            this.logger.error("Container failure reason is: ", await this.kubeClient.getPodTerminatedContainerReason(runnerName));
 
             await this.remove(this.adapterConfig.timeout);
 


### PR DESCRIPTION
This PR aims to handle most of the situations when Runner Pod fails and we want to know why, in particular:
* reaching max number of Pod's in a namespace (when spawning a new Runner)
* reaching memory limits for a Pod (when Runner Pod is running)

## Verify
### 1. Reaching max number of Pod's in a namespace
You can set Pods limit applying this command:
```bash
kubectl apply -f <(cat << EOF
apiVersion: v1
kind: ResourceQuota
metadata:
  name: pods-limit
spec:
  hard:
    pods: "1"
EOF
)
``` 

Now when you start STH in a Pod on your cluster:
```bash
 DEVELOPMENT=1 yarn start:dev --runtime-adapter=kubernetes --k8s-namespace=default --k8s-sth-pod-host=sth-runner --k8s-runner-resources-requests-cpu=64m --k8s-runner-resources-requests-memory=100M --k8s-runner-resources-limits-cpu=1000m --k8s-runner-resources-limits-memory=1G
```
and try to start any sequence you should get a following log:
 
![image](https://user-images.githubusercontent.com/15108331/168629780-befc6dca-f802-4755-9003-f132d048d7c7.png)

### 2.  Reaching memory limits for Runner Pod
You can add some memory allocation code like this one, allocating 100MB to you sequence function body:
```ts
Buffer.alloc(1024 * 1024 * 100).fill(0xdeadbeef);
```

Now when you start STH in a Pod on your cluster (Note the memory limits):
```bash
DEVELOPMENT=1 yarn start:dev --runtime-adapter=kubernetes --k8s-namespace=default --k8s-sth-pod-host=sth-runner --k8s-runner-resources-requests-cpu=64m --k8s-runner-resources-requests-memory=50M --k8s-runner-resources-limits-cpu=1000m --k8s-runner-resources-limits-memory=100M 
```
and try to start this memory consuming sequence you should get a following log:

![image](https://user-images.githubusercontent.com/15108331/168845810-8240b538-95a7-4bae-b371-1901999c9c0d.png)

