### PR TITLE
[CLI] Add CLI command `si space info`

### DIFF
--- a/packages/cli/src/lib/commands/hub.ts
+++ b/packages/cli/src/lib/commands/hub.ts
@@ -94,7 +94,6 @@ export const hub: CommandDefinition = (program) => {
                 const host = hosts.find((h: any) => h.id === id);
 
                 displayObject(host);
-                displayObject(space);
             });
     }
 

--- a/packages/cli/src/lib/commands/scope.ts
+++ b/packages/cli/src/lib/commands/scope.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { CommandDefinition } from "../../types";
 import { listScopes, deleteScope, getScope, scopeExists } from "../scope";
 import { displayObject } from "../output";
@@ -27,7 +28,6 @@ export const scope: CommandDefinition = (program) => {
             const scopeConfig = getScope(name);
 
             if (!scopeConfig) {
-                // eslint-disable-next-line no-console
                 console.error(`Couldn't find scope: ${name}`);
                 return;
             }
@@ -38,6 +38,7 @@ export const scope: CommandDefinition = (program) => {
     if (isDevelopment())
         scopeCmd
             .command("add")
+            .argument("<name>")
             .option("--hub <name> <id>", "Add a Hub to specified scope")
             .option("--space <name> <apiUrl>", "Add space to specified scope")
             .description("TO BE IMPLEMENTED / Add a Hub or space to specified scope")
@@ -50,7 +51,7 @@ export const scope: CommandDefinition = (program) => {
         scopeCmd
             .command("save")
             .argument("<name>")
-            .description("TO BE IMPLEMENTED / Save current chosen space and Hub under a scope")
+            .description("TO BE IMPLEMENTED / Save current chosen space and Hub under a scope name")
             .action(() => {
             // FIXME: implement me
                 throw new Error("Implement me");
@@ -62,7 +63,6 @@ export const scope: CommandDefinition = (program) => {
         .description("Work on the selected scope")
         .action((name: string) => {
             if (!scopeExists(name)) {
-                // eslint-disable-next-line no-console
                 console.error(`Couldn't find scope: ${name}`);
                 return;
             }
@@ -75,12 +75,10 @@ export const scope: CommandDefinition = (program) => {
         .description("Delete specific scope")
         .action((name: string) => {
             if (globalConfig.getConfig().scope === name) {
-                // eslint-disable-next-line no-console
                 console.error(`WARN: can't remove scope ${name} set in configuration.`);
                 return;
             }
             if (sessionConfig.getConfig().scope === name) {
-                // eslint-disable-next-line no-console
                 console.error(`WARN: can't remove currently used scope ${name}`);
                 return;
             }

--- a/packages/cli/src/lib/commands/space.ts
+++ b/packages/cli/src/lib/commands/space.ts
@@ -31,6 +31,24 @@ export const space: CommandDefinition = (program) => {
             });
 
     spaceCmd
+        .command("info")
+        /* TODO for future use
+    .argument("[<name>|<id>]")
+    // eslint-disable-next-line max-len
+    .description("display chosen space version if a name|id is not provided it displays a version of a current space")
+    */
+        .description("Display info about the default space")
+        .action(async () => {
+            const spaceId = sessionConfig.getConfig().lastSpaceId;
+            const managerClient = getMiddlewareClient().getManagerClient(spaceId);
+            const version = await managerClient.getVersion();
+
+            displayObject({ spaceId });
+            displayObject(version);
+            displayObject(managerClient);
+        });
+
+    spaceCmd
         .command("list")
         .alias("ls")
         .description("List all existing spaces")


### PR DESCRIPTION
Click-up [task](https://app.clickup.com/t/24308805/SCP-3787)

There was no possibility to check which space the user is currently in. 
I added `si space info` command which shows space ID and other cpm info:
```
09:31 $ ts-node packages/cli/src/bin/index.ts space info
{ spaceId: 'org-895462b1-e221-48e3-a942-06bba24a6eea-manager' }
{
  service: '@scramjet/manager',
  apiVersion: 'v1',
  version: '0.22.0',
  build: '13d842b'
}
ManagerClient {
  apiBase: 'https://api.beta.scramjet.cloud/api/v1/space/org-895462b1-e221-48e3-a942-06bba24a6eea-manager/api/v1',
  client: ClientUtils {
    apiBase: 'https://api.beta.scramjet.cloud/api/v1/space/org-895462b1-e221-48e3-a942-06bba24a6eea-manager/api/v1',
    fetch: [Function (anonymous)],
    normalizeUrlFn: [Function: normalizeUrl]
  }
}
```