### PR TITLE
Add a PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default.md
@@ -1,5 +1,1 @@
-# Description
-Please include a summary of the change.
-
-# Fixes/Implements
-Please provide here links to issues/features.
+../pull_request_template.md

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+<!-- If writing isn't your strength, ask @jan-warchol for help ;) -->
+<!-- (or join our Discord https://discord.com/invite/ngXmwvjSYF)  -->
+
+
+**What?**  <!-- Two-sentence summary, understandable for a junior. -->
+
+
+**Why?**  <!-- What is this needed for? You can link to an issue. -->
+
+
+**Usage:**
+<!-- Example (if applicable), how to verify (if not covered by tests). -->
+- 
+- 
+- 
+
+<!--------------------- For non-trivial changes: ---------------------->
+
+**How it works:**
+<!-- Share some starting points for understanding the code. -->
+- 
+- 
+- 
+
+**Gotchas:**
+<!-- Any known shortcomings, alternatives to consider, future todos... -->
+- 
+- 
+- 
+
+<!-- PS try to make PR title suitable for pasting into CHANGELOG.md. -->
+<!-- Thanks! -->


### PR DESCRIPTION
**What?**
Add a pull request template. Also remove old template directory, which works only when a query param is specified in URL.

**Why?**
A template should make it easier to write good PR descriptions. With good PR descriptions:
- reviews should be easier, faster and more thorough
- **keeping up to date** should be easier - we don't have time to read all PRs, but we should be able to read all PR descriptions, and **brief yet informative descriptions should give us just enough insight into what's happening in the project.**
- making release notes will be easier & faster

**Usage:**
- This will be enabled automatically once merged to repo's default branch.

<!-- PS try to make PR title suitable for pasting into CHANGELOG.md. --> 
<!-- Thanks! -->
