### PR TITLE
HostClient has getInstaceClient now

### DIFF
--- a/packages/api-client/src/host-client.ts
+++ b/packages/api-client/src/host-client.ts
@@ -1,5 +1,6 @@
 import { ClientProvider, ClientUtils, HttpClient } from "@scramjet/client-utils";
 import { STHRestAPI } from "@scramjet/types";
+import { InstanceClient } from "./instance-client";
 import { SequenceClient } from "./sequence-client";
 
 /**
@@ -51,7 +52,10 @@ export class HostClient implements ClientProvider {
      * @param {RequestInit} requestInit RequestInit object to be passed to fetch.
      * @returns {SequenceClient} Sequence client.
      */
-    async sendSequence(sequencePackage: Parameters<HttpClient["sendStream"]>[1], requestInit?: RequestInit): Promise<SequenceClient> {
+    async sendSequence(
+        sequencePackage: Parameters<HttpClient["sendStream"]>[1],
+        requestInit?: RequestInit
+    ): Promise<SequenceClient> {
         const response = await this.client.sendStream<any>("sequence", sequencePackage, requestInit, {
             parseResponse: "json",
         });
@@ -151,5 +155,15 @@ export class HostClient implements ClientProvider {
 
     async getTopics(): Promise<STHRestAPI.GetTopicsResponse> {
         return this.client.get("topics");
+    }
+
+    /**
+     * Creates InstanceClient based on current HostClient and instance id.
+     *
+     * @param id Instance id.
+     * @returns InstanceClient instance.
+     */
+    getInstanceClient(id: string) {
+        return InstanceClient.from(id, this);
     }
 }


### PR DESCRIPTION
**What?**
Added getInstanceClient method to MiddlewareApiClient (HostClient to be more specific)

**Why?** 
getInstanceClient can provide panel with InstanceClient which has kill and stop methods needed to handle instance

**Usage:**
1. Start any instance
2. Stop instance using below snippet
```ts
import { ClientUtils } from "@scramjet/client-utils";
import { MiddlewareClient } from "./middleware-client";

const token ="INSERT_ACCESS_TOKEN_HERE";
const instanceId = "INSERT_INSTANCE_ID_HERE";

try {
    (async function () {
        ClientUtils.setDefaultHeaders({
            Authorization: `Bearer ${token}`,
        });
        const middlewareClient = new MiddlewareClient("https://api.scp.ovh/api/v1");
        const spaces = await middlewareClient.getManagers();
        console.log("Space:"); // eslint-disable-line
        console.log(spaces[0]); // eslint-disable-line
        const spaceClient = middlewareClient.getManagerClient(spaces[0].id);
        const spaceHubs = await spaceClient.getHosts();
        console.log("Hub:"); // eslint-disable-line
        console.log(spaceHubs[0]); // eslint-disable-line
        const hubClient = spaceClient.getHostClient(spaceHubs[0].id);
        const instances = await hubClient.listInstances();
        console.log("Instance:"); // eslint-disable-line
        console.log(instances[0]); // eslint-disable-line
        const instanceClient = hubClient.getInstanceClient(instanceId);
        console.log(instanceClient); // eslint-disable-line
        console.log("Kill:"); // eslint-disable-line
        console.log(await instanceClient.kill()); // eslint-disable-line
    })()
        .then(console.log) // eslint-disable-line
        .catch(console.error); // eslint-disable-line
} catch (e) {
    console.log(e); // eslint-disable-line
}
```

**Gotchas:**
Do not know if user is allowed to access every InstanceClient method
