### PR TITLE
HostClient has getSequenceClient now

### DIFF
--- a/packages/api-client/src/host-client.ts
+++ b/packages/api-client/src/host-client.ts
@@ -166,4 +166,14 @@ export class HostClient implements ClientProvider {
     getInstanceClient(id: string) {
         return InstanceClient.from(id, this);
     }
+
+    /**
+     * Creates SequenceClient based on current HostClient and instance id.
+     *
+     * @param id Sequence id.
+     * @returns SequenceClient instance.
+     */
+    getSequenceClient(id: string) {
+        return SequenceClient.from(id, this);
+    }
 }


### PR DESCRIPTION
**What?**
Added getSequenceClient method to MiddlewareApiClient (HostClient to be more specific)

**Why?**
getSequenceClient can provide panel with SequenceClient which has start method needed to handle sequence

**Usage:**
1. Send any sequence
2. Start sequence using below snippet
```ts
import { ClientUtils } from "@scramjet/client-utils";
import { MiddlewareClient } from "./middleware-client";

const token ="INSERT_ACCESS_TOKEN_HERE";

try {
    (async function () {
        ClientUtils.setDefaultHeaders({
            Authorization: `Bearer ${token}`,
        });
        const middlewareClient = new MiddlewareClient("https://api.scp.ovh/api/v1");
        const spaces = await middlewareClient.getManagers();
        console.log("Space:"); // eslint-disable-line
        console.log(spaces[0]); // eslint-disable-line
        const spaceClient = middlewareClient.getManagerClient(spaces[0].id);
        const spaceHubs = await spaceClient.getHosts();
        console.log("Hub:"); // eslint-disable-line
        console.log(spaceHubs[0]); // eslint-disable-line
        const hubClient = spaceClient.getHostClient(spaceHubs[0].id);
        const sequences = await hubClient.listSequences();
        console.log("Sequences:"); // eslint-disable-line
        console.log(sequences[0]); // eslint-disable-line
        const sequenceClient = hubClient.getSequenceClient(sequences[0].id);
        console.log(sequenceClient); // eslint-disable-line
        console.log("Kill:"); // eslint-disable-line
        console.log(await sequenceClient.start({ appConfig: {} })); // eslint-disable-line
    })()
        .then(console.log) // eslint-disable-line
        .catch(console.error); // eslint-disable-line
} catch (e) {
    console.log(e); // eslint-disable-line
}
```

**Gotchas:**
Do not know if user is allowed to access every SequenceClient method
