### PR TITLE
Fix the issue when pod was deleted before k8s client got it status

### DIFF
--- a/packages/adapters/src/kubernetes-client-adapter.ts
+++ b/packages/adapters/src/kubernetes-client-adapter.ts
@@ -111,6 +111,10 @@ class KubernetesClientAdapter {
             } catch (err: any) {
                 if (err instanceof HttpError) {
                     this.logger.error(`Status for "${podName}" pod responded with error`, err?.body?.message);
+
+                    if (err.statusCode === 404) {
+                        this.logger.error("You have deleted this pod already! Try to increase runnerExitDelay in CSIController.");
+                    }
                 } else {
                     this.logger.error(`Failed to get pod status: ${podName}.`, err);
                 }

--- a/packages/adapters/src/kubernetes-instance-adapter.ts
+++ b/packages/adapters/src/kubernetes-instance-adapter.ts
@@ -160,7 +160,8 @@ IComponent {
             return exitPodStatus.code || 137;
         }
 
-        this.logger.error("Runner stopped without issues");
+        this.logger.info("Runner stopped without issues");
+
         await this.remove(this.adapterConfig.timeout);
 
         // @TODO handle error status

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -40,7 +40,12 @@ import { cancellableDefer, CancellablePromise, defer, promiseTimeout, TypedEmitt
 import { ObjLogger } from "@scramjet/obj-logger";
 import { ReasonPhrases } from "http-status-codes";
 
-const runnerExitDelay = 11000;
+/**
+ * @TODO: Runner exits after 10secs and k8s client checks status every 500ms so we need to give it some time
+ * before we delete pod or it will fail with 404
+ * and instance adapter will throw an error even when everything was ok.
+ */
+const runnerExitDelay = 12000;
 const csiLifetimeExtensionDelay = 180e3;
 
 type Events = {


### PR DESCRIPTION
**What?**  
Increase time for InstanceAdapter to finish.

**Why?**
K8S runner pod was deleted before Pod status (Failed/Succedded) was obtained what was causing 404 and instance adapter/csic to fail

