### PR TITLE
Tag docker images with commit, don't overwrite release tag

### DIFF
--- a/.github/workflows/build-docker-prerunner.yml
+++ b/.github/workflows/build-docker-prerunner.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: ${{ inputs.node-version }}
 
       - name: Build runner Docker image
-        run: docker build -q -t scramjetorg/pre-runner:$(jq -r .version package.json) .
+        run: docker build -q -t scramjetorg/pre-runner:$(git rev-parse HEAD) .
         working-directory: packages/pre-runner
 
       - name: Export Docker images

--- a/.github/workflows/build-docker-runner-node.yml
+++ b/.github/workflows/build-docker-runner-node.yml
@@ -29,7 +29,7 @@ jobs:
         run: scripts/run-script.js --scope packages/runner prebuild:docker
 
       - name: build runner Docker image
-        run: docker build -q -t scramjetorg/runner:$(jq -r .version package.json) -f Dockerfile ../../
+        run: docker build -q -t scramjetorg/runner:$(git rev-parse HEAD) -f Dockerfile ../../
         working-directory: packages/runner
 
       - name: Export Docker images

--- a/.github/workflows/build-docker-runner-python.yml
+++ b/.github/workflows/build-docker-runner-python.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: build runner Docker image
-        run: docker build -q -t scramjetorg/runner-py:$(jq -r .version package.json) -f Dockerfile ../../
+        run: docker build -q -t scramjetorg/runner-py:$(git rev-parse HEAD) -f Dockerfile ../../
         working-directory: packages/python-runner
 
       - name: Export Docker images

--- a/.github/workflows/build-docker-sth.yml
+++ b/.github/workflows/build-docker-sth.yml
@@ -30,7 +30,7 @@ jobs:
         run: yarn savehash
 
       - name: Build sth Docker image
-        run: scripts/run-script.js --scope @scramjet/sth build:docker -t scramjetorg/sth:$(jq -r .version package.json)
+        run: scripts/run-script.js --scope @scramjet/sth build:docker
 
       - name: Export Docker images
         run: echo "$(docker images)" |awk '/scramjet/{print $1,$2,$3,$1}' |sed 's|/|_|2' | while read repo tag id name; do docker save $id -o dockerSthImg-$name-$tag-${{ inputs.node-version }}-${{ github.event.pull_request.head.sha }}.tar $repo:$tag ; done

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -31,11 +31,11 @@ jobs:
         run: yarn build:refapps
 
       - name: build runner Docker image
-        run: docker build -q -t scramjetorg/runner:$(jq -r .version package.json) -f Dockerfile ../../
+        run: docker build -q -t scramjetorg/runner:$(git rev-parse HEAD) -f Dockerfile ../../
         working-directory: packages/runner
 
       - name: Build runner Docker image
-        run: docker build -q -t scramjetorg/pre-runner:$(jq -r .version package.json) .
+        run: docker build -q -t scramjetorg/pre-runner:$(git rev-parse HEAD) .
         working-directory: packages/pre-runner
 
       - name: npm link STH

--- a/.github/workflows/test-bdd-docker.yml
+++ b/.github/workflows/test-bdd-docker.yml
@@ -74,6 +74,9 @@ jobs:
 
       - name: Run BDD tests
       # SCRAMJET_SPAWN_JS will run cli test from dist directory
-        run: RUNTIME_ADAPTER=docker SCRAMJET_TEST_LOG=1 SCRAMJET_SPAWN_JS=1 yarn ${{ inputs.test-name }} -t "not @not-github"
+        run: RUNNER_IMGS_TAG=$(git rev-parse HEAD) yarn ${{ inputs.test-name }} -t "not @not-github"
         env:
+          RUNTIME_ADAPTER: docker
+          SCRAMJET_TEST_LOG: 1
+          SCRAMJET_SPAWN_JS: 1
           NODE_OPTIONS: "--trace-warnings"

--- a/bdd/lib/host-utils.ts
+++ b/bdd/lib/host-utils.ts
@@ -106,6 +106,14 @@ export class HostUtils {
             command.push(`--runtime-adapter=${process.env.RUNTIME_ADAPTER}`);
         if (extraArgs.length) command.push(...extraArgs);
 
+        if (process.env.RUNNER_IMGS_TAG) {
+            command.push(
+                `--runner-image=scramjetorg/runner:${process.env.RUNNER_IMGS_TAG}`,
+                `--prerunner-image=scramjetorg/pre-runner:${process.env.RUNNER_IMGS_TAG}`,
+                `--runner-py-image=scramjetorg/runner-py:${process.env.RUNNER_IMGS_TAG}`
+            );
+        }
+
         if (process.env.SCRAMJET_TEST_LOG) {
             // eslint-disable-next-line no-console
             console.log("Spawning with command:", ...command);

--- a/packages/pre-runner/package.json
+++ b/packages/pre-runner/package.json
@@ -7,7 +7,7 @@
     "prepare-sample-tar": "mkdir -p sample-package && tar -zcvf ./sample-package/package.tar.gz -C ../../dist/reference-apps/hello-alice-out .",
     "test": "echo \"Warning: no test specified\"",
     "test:docker": "yarn prepare-sample-tar && cat sample-package/package.tar.gz | docker run -i --name pre-runner -v prerunner-$(git rev-parse --short HEAD):/package scramjetorg/pre-runner:$(git rev-parse HEAD)",
-    "clean:docker": "docker rm -f scramjetorg/pre-runner; docker volume rm scramjetorg/prerunner-$(git rev-parse --short HEAD)",
+    "clean:docker": "docker rm -f scramjetorg/pre-runner; docker volume rm scramjetorg/prerunner-$(git rev-parse HEAD)",
     "clean": "rm -rf ./dist .bic_cache"
   },
   "assets": [

--- a/packages/pre-runner/package.json
+++ b/packages/pre-runner/package.json
@@ -3,10 +3,10 @@
   "version": "0.24.1",
   "description": "This package is part of Scramjet Transform Hub. The package identifies the sequences and returns the information to back STH.",
   "scripts": {
-    "build:docker": "docker build -t scramjetorg/pre-runner:$npm_package_version .",
+    "build:docker": "docker build -t scramjetorg/pre-runner:$(git rev-parse HEAD) .",
     "prepare-sample-tar": "mkdir -p sample-package && tar -zcvf ./sample-package/package.tar.gz -C ../../dist/reference-apps/hello-alice-out .",
     "test": "echo \"Warning: no test specified\"",
-    "test:docker": "yarn prepare-sample-tar && cat sample-package/package.tar.gz | docker run -i --name pre-runner -v prerunner-$(git rev-parse --short HEAD):/package ${SCRAMJET_INT_REPO_PATH}scramjetorg/pre-runner:$npm_package_version",
+    "test:docker": "yarn prepare-sample-tar && cat sample-package/package.tar.gz | docker run -i --name pre-runner -v prerunner-$(git rev-parse --short HEAD):/package scramjetorg/pre-runner:$(git rev-parse HEAD)",
     "clean:docker": "docker rm -f scramjetorg/pre-runner; docker volume rm scramjetorg/prerunner-$(git rev-parse --short HEAD)",
     "clean": "rm -rf ./dist .bic_cache"
   },

--- a/packages/python-runner/package.json
+++ b/packages/python-runner/package.json
@@ -8,7 +8,7 @@
     "build:only": "pip3 install --upgrade -r requirements.txt --target dist",
     "build": "yarn build:only",
     "clean": "rm -rf dist/",
-    "build:docker": "docker build -t scramjetorg/runner-py:$npm_package_version -f Dockerfile ../../"
+    "build:docker": "docker build -t scramjetorg/runner-py:$(git rev-parse HEAD) -f Dockerfile ../../"
   },
   "assets": [
     "hardcoded_magic_values.py",

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -6,10 +6,10 @@
   "scripts": {
     "build": "../../scripts/build-all.js --config-name=tsconfig.build.json --copy-dist",
     "prebuild:docker": "cd ../.. && scripts/build-all.js --no-install --link-packages -d packages/runner -o ./dist/docker-runner/ --ts-config tsconfig.build.json",
-    "build:docker": "docker build -t scramjetorg/runner:$npm_package_version -f Dockerfile ../../",
+    "build:docker": "docker build -t scramjetorg/runner:$(git rev-parse HEAD) -f Dockerfile ../../",
     "build:docs": "typedoc",
     "start": "ts-node ./src/index",
-    "test:docker": "docker run -i --name runner -v prerunner-$(git rev-parse --short HEAD):/package scramjetorg/runner:$npm_package_version",
+    "test:docker": "docker run -i --name runner -v prerunner-$(git rev-parse --short HEAD):/package scramjetorg/runner:$(git rev-parse HEAD)",
     "clean": "rm -rf ./dist .bic_cache",
     "clean:docker": "docker rm -f runner; docker volume rm prerunner-$(git rev-parse --short HEAD)"
   },

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -11,7 +11,7 @@
     "start": "ts-node ./src/index",
     "test:docker": "docker run -i --name runner -v prerunner-$(git rev-parse --short HEAD):/package scramjetorg/runner:$(git rev-parse HEAD)",
     "clean": "rm -rf ./dist .bic_cache",
-    "clean:docker": "docker rm -f runner; docker volume rm prerunner-$(git rev-parse --short HEAD)"
+    "clean:docker": "docker rm -f runner; docker volume rm prerunner-$(git rev-parse HEAD)"
   },
   "author": "Scramjet <opensource@scramjet.org>",
   "license": "MIT",

--- a/packages/sth/package.json
+++ b/packages/sth/package.json
@@ -11,7 +11,7 @@
     "start": "ts-node ./src/index",
     "build": "../../scripts/build-all.js --config-name=tsconfig.build.json --copy-dist",
     "prebuild:docker": "cd ../.. && scripts/build-all.js --no-install --link-packages -d packages/sth --ts-config tsconfig.build.json",
-    "build:docker": "docker build -t scramjetorg/sth:$npm_package_version -f Dockerfile ../../",
+    "build:docker": "docker build -t scramjetorg/sth:$(git rev-parse HEAD) -f Dockerfile ../../",
     "clean": "rm -rf ./dist .bic_cache",
     "test": "echo no tests yet -- # npm run test:ava",
     "test:ava": "ava"


### PR DESCRIPTION
**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Do not "reuse" docker tags, especially release tags. Tag images with current commit ID.

**Why?**  <!-- What is this needed for? You can link to an issue. -->
Once a "release" tag (like 0.24.1) is used on an image, it should never
be used on other images to avoid confusion and wrong deployments.
Using a commit ID to tag images will make it easy to refer to specific images elsewhere.

**Usage:**
<!-- Example (if applicable), how to verify (if not covered by tests). -->
Running `yarn build:docker` e.g. in runner package should result in something like
```
...
Successfully tagged runner:df744aae095832a1ac2c8577ad1c49d3fb434745
```
Indicating it was done on commit df744aae.