### PR TITLE
Share docker images via repository instead of artifacts

### DIFF
--- a/.github/workflows/build-docker-prerunner.yml
+++ b/.github/workflows/build-docker-prerunner.yml
@@ -8,6 +8,9 @@ on:
         default: '16.x'
         type: string
 
+env:
+  nexus_repo: repo.int.scp.ovh
+
 jobs:
   build-docker-prerunner-image:
     name: Build pre-runner docker image (Nodejs ${{ inputs.node-version }})
@@ -23,18 +26,16 @@ jobs:
           node-version: ${{ inputs.node-version }}
 
       - name: Build runner Docker image
-        run: docker build -q -t scramjetorg/pre-runner:$(git rev-parse HEAD) .
+        run: docker build -q -t ${{ env.nexus_repo }}/pre-runner:$(git rev-parse HEAD) .
         working-directory: packages/pre-runner
 
-      - name: Export Docker images
-        run: echo "$(docker images)" |awk '/scramjet/{print $1,$2,$3,$1}' |sed 's|/|_|2' | while read repo tag id name; do docker save $id -o dockerPreRunnerImg-$name-$tag-${{ inputs.node-version }}-${{ github.event.pull_request.head.sha }}.tar $repo:$tag ; done
-
-      - name: Zip Docker images
-        run: pigz docker*Img*.tar
-
-      - name: Archive production artifacts
-        uses: actions/upload-artifact@v2
+      - name: Login to ${{ env.nexus_repo }}
+        uses: docker/login-action@v1
         with:
-          name:  dockerPreRunnerImg-${{ inputs.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
-          path: '*.tar.gz'
-          retention-days: 1
+          registry: ${{ env.nexus_repo }}
+          username: ${{ secrets.NEXUS_USER }}
+          password: ${{ secrets.NEXUS_PASS }}
+
+      - name: Push image to nexus
+        run: docker push ${{ env.nexus_repo }}/pre-runner:$(git rev-parse HEAD)
+        working-directory: sth/

--- a/.github/workflows/test-bdd-docker.yml
+++ b/.github/workflows/test-bdd-docker.yml
@@ -18,6 +18,9 @@ on:
         required: true
         type: string
 
+env:
+  nexus_repo: repo.int.scp.ovh
+
 jobs:
   test-bdd-sth:
     name: ${{ inputs.test-title }} (${{ inputs.test-name }}, Adapter "docker", Nodejs ${{ inputs.node-version }})
@@ -47,10 +50,15 @@ jobs:
         with:
           name: dockerRunnerPyImg-${{ inputs.python-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
 
-      - name: Download dockerPreRunnerImg artifact
-        uses: actions/download-artifact@v2
+      - name: Login to ${{ env.nexus_repo }}
+        uses: docker/login-action@v1
         with:
-          name: dockerPreRunnerImg-${{ inputs.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
+          registry: ${{ env.nexus_repo }}
+          username: ${{ secrets.NEXUS_USER }}
+          password: ${{ secrets.NEXUS_PASS }}
+
+      - name: Pull pre-runner image
+        run: docker pull ${{ env.nexus_repo }}/pre-runner:${{ github.event.pull_request.head.sha }}
 
       - name: Unzip dockerImg-${{ github.event.pull_request.head.sha }}-${{ inputs.node-version }}.tar.gz artifact
         run: pigz -d docker*Img*.tar.gz


### PR DESCRIPTION
<!-- If writing isn't your strength, ask @jan-warchol for help ;) -->
<!-- (or join our Discord https://discord.com/invite/ngXmwvjSYF)  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Instead of wrapping docker images in an artifact, use our nexus repo for publishing them in build jobs and pulling in test jobs.

**Why?**  <!-- What is this needed for? You can link to an issue. -->
This way docker images can be easily shared in jobs across repositories. E.g. images built here could then be used in CPM CI (potential speed gains).


**Gotchas:**
<!-- Any known shortcomings, alternatives to consider, future todos... -->
- this is just an example for pre-runner. It will have to be done for other components once we agree on a direction.
- this requires configuring GHA of this repo with secrets for accessing nexus repo.
- this PR depends on https://github.com/scramjetorg/transform-hub/pull/539

<!-- PS try to make PR title suitable for pasting into CHANGELOG.md. -->
<!-- Thanks! -->
