### PR TITLE
CLI Configuration using profiles

### DIFF
--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -6,7 +6,7 @@ This feature checks CLI functionalities
     Scenario: E2E-010 TC-001 CLI displays help, version, hub load
         Given host is running
         Then I set json format
-        Then I use apiUrl in config
+        Then I set apiUrl in config
         When I execute CLI with "--help" arguments
         Then I get a help information
         When I execute CLI with "--version" arguments
@@ -19,7 +19,7 @@ This feature checks CLI functionalities
     Scenario: E2E-010 TC-002 Pack Sequence
         Given host is running
         Then I set json format
-        Then I use apiUrl in config
+        Then I set apiUrl in config
         When I execute CLI with "seq pack ../packages/reference-apps/transform-function  -o ../packages/reference-apps/transform-function.tar.gz" arguments
         Then I get location "../packages/reference-apps/transform-function.tar.gz" of compressed directory
         And host is still running
@@ -28,7 +28,7 @@ This feature checks CLI functionalities
     Scenario: E2E-010 TC-003 Send, list and delete Sequence
         Given host is running
         Then I set json format
-        Then I use apiUrl in config
+        Then I set apiUrl in config
         When I execute CLI with "config print" arguments
         When I execute CLI with "seq send ../packages/reference-apps/hello-alice-out.tar.gz" arguments
         Then I get Sequence id
@@ -41,7 +41,7 @@ This feature checks CLI functionalities
     Scenario: E2E-010 TC-004 Get Instance info, health, kill Instance
         Given host is running
         Then I set json format
-        Then I use apiUrl in config
+        Then I set apiUrl in config
         When I execute CLI with "seq send ../packages/reference-apps/hello-alice-out.tar.gz" arguments
         Then I get Sequence id
         Then I start Sequence
@@ -55,7 +55,7 @@ This feature checks CLI functionalities
     Scenario: E2E-010 TC-005 Get 404 on health endpoint for finished Instance
         Given host is running
         Then I set json format
-        Then I use apiUrl in config
+        Then I set apiUrl in config
         When I execute CLI with "seq send ../packages/reference-apps/inert-function.tar.gz" arguments
         Then I get Sequence id
         Then I start Sequence
@@ -67,7 +67,7 @@ This feature checks CLI functionalities
     Scenario: E2E-010 TC-006 Get log from Instance
         Given host is running
         Then I set json format
-        Then I use apiUrl in config
+        Then I set apiUrl in config
         When I execute CLI with "seq send ../packages/reference-apps/inert-function.tar.gz" arguments
         Then I get Sequence id
         Then I start Sequence
@@ -80,7 +80,7 @@ This feature checks CLI functionalities
     Scenario: E2E-010 TC-007 Send input data to Instance
         Given host is running
         Then I set json format
-        Then I use apiUrl in config
+        Then I set apiUrl in config
         When I execute CLI with "seq send ../packages/reference-apps/checksum-sequence.tar.gz" arguments
         Then I get Sequence id
         Then I start Sequence
@@ -93,7 +93,7 @@ This feature checks CLI functionalities
     Scenario: E2E-010 TC-008 Send input data to Instance and close input stream
         Given host is running
         Then I set json format
-        Then I use apiUrl in config
+        Then I set apiUrl in config
         When I execute CLI with "seq send ../packages/reference-apps/checksum-sequence.tar.gz" arguments
         Then I get Sequence id
         Then I start Sequence
@@ -107,7 +107,7 @@ This feature checks CLI functionalities
     Scenario: E2E-010 TC-009 List Instances and stop Instance
         Given host is running
         Then I set json format
-        Then I use apiUrl in config
+        Then I set apiUrl in config
         When I execute CLI with "seq send ../packages/reference-apps/hello-alice-out.tar.gz" arguments
         Then I get Sequence id
         Then I start Sequence
@@ -120,7 +120,7 @@ This feature checks CLI functionalities
     Scenario: E2E-010 TC-010 Send event
         Given host is running
         Then I set json format
-        Then I use apiUrl in config
+        Then I set apiUrl in config
         When I execute CLI with "seq send ../packages/reference-apps/event-sequence-v2.tar.gz" arguments
         Then I get Sequence id
         Then I start Sequence
@@ -133,7 +133,7 @@ This feature checks CLI functionalities
     Scenario: E2E-010 TC-011 Start Sequence with multiple JSON arguments
         Given host is running
         Then I set json format
-        Then I use apiUrl in config
+        Then I set apiUrl in config
         When I execute CLI with "seq send ../packages/reference-apps/args-to-output.tar.gz" arguments
         Then I get Sequence id
         Then I start Sequence with options "--args [\"Hello\",123,{\"abc\":456},[\"789\"]]"
@@ -148,7 +148,7 @@ This feature checks CLI functionalities
     Scenario: E2E-010 TC-012 Deploy Sequence with multiple JSON arguments
         Given host is running
         Then I set json format
-        Then I use apiUrl in config
+        Then I set apiUrl in config
         When I execute CLI with "seq deploy data/sequences/args-to-output --args [\"Hello\",123,{\"abc\":456},[\"789\"]]" arguments
         Then I get Instance id after deployment
         And I get Instance output without waiting for the end
@@ -160,7 +160,7 @@ This feature checks CLI functionalities
     Scenario: E2E-010 TC-013 Check minus replacements with a Sequence
         Given host is running
         Then I set json format
-        Then I use apiUrl in config
+        Then I set apiUrl in config
         When I execute CLI with "seq pack data/sequences/simple-stdio -o data/simple-stdio.tar.gz" arguments
         And I execute CLI with "seq send -" arguments
         And I execute CLI with "seq start -" arguments
@@ -176,7 +176,7 @@ This feature checks CLI functionalities
     Scenario: E2E-010 TC-014 API to API
         Given host is running
         Then I set json format
-        Then I use apiUrl in config
+        Then I set apiUrl in config
         When I execute CLI with "topic send cities features/e2e/cities.json" arguments
         Then I execute CLI with "topic get cities" arguments without waiting for the end
         Then confirm data named "nyc-city-nl" will be received
@@ -186,7 +186,7 @@ This feature checks CLI functionalities
     Scenario: E2E-010 TC-015 Instance to API
         Given host is running
         Then I set json format
-        Then I use apiUrl in config
+        Then I set apiUrl in config
         When I execute CLI with "seq send ../packages/reference-apps/endless-names-output.tar.gz" arguments
         Then I get Sequence id
         When I start Sequence with options "--output-topic names5"
@@ -199,7 +199,7 @@ This feature checks CLI functionalities
     Scenario: E2E-010 TC-016 API to Instance
         Given host is running
         Then I set json format
-        Then I use apiUrl in config
+        Then I set apiUrl in config
         When I execute CLI with "topic send names6 features/e2e/data.json" arguments
         When I execute CLI with "seq send ../packages/reference-apps/hello-input-out.tar.gz" arguments
         Then I get Sequence id
@@ -216,7 +216,7 @@ This feature checks CLI functionalities
     Scenario: E2E-010 TC-017 Instance to Instance
         Given host is running
         Then I set json format
-        Then I use apiUrl in config
+        Then I set apiUrl in config
         When I execute CLI with "seq prune -f" arguments
         When I execute CLI with "seq send ../packages/reference-apps/endless-names-output.tar.gz" arguments
         When I execute CLI with "seq send ../packages/reference-apps/hello-input-out.tar.gz" arguments
@@ -235,7 +235,7 @@ This feature checks CLI functionalities
     Scenario: E2E-010 TC-018 Rename topic output
         Given host is running
         Then I set json format
-        Then I use apiUrl in config
+        Then I set apiUrl in config
         When I execute CLI with "seq send ../packages/reference-apps/endless-names-output.tar.gz" arguments
         Then I get Sequence id
         Then I start Sequence with options "--output-topic names2"
@@ -248,7 +248,7 @@ This feature checks CLI functionalities
     Scenario: E2E-010 TC-019 Rename topic input
         Given host is running
         Then I set json format
-        Then I use apiUrl in config
+        Then I set apiUrl in config
         When I execute CLI with "topic send names4 features/e2e/data.json" arguments
         When I execute CLI with "seq send ../packages/reference-apps/hello-input-out.tar.gz" arguments
         Then I get Sequence id

--- a/bdd/features/e2e/E2E-014-python.feature
+++ b/bdd/features/e2e/E2E-014-python.feature
@@ -49,7 +49,7 @@ Feature: Test our shiny new Python runner
     Scenario: E2E-014 TC-014 Rename topic output and input
         Given host is running
         Then I set json format
-        Then I use apiUrl in config
+        Then I set apiUrl in config
         When I execute CLI with "seq send ../packages/reference-apps/python-topic-producer.tar.gz" arguments
         Then I get Sequence id
         Then I start Sequence with options "--output-topic names3"

--- a/bdd/step-definitions/e2e/cli.ts
+++ b/bdd/step-definitions/e2e/cli.ts
@@ -28,10 +28,10 @@ When("I set json format", { timeout: 30000 }, async function() {
     assert.equal(res.stdio[2], 0);
 });
 
-When("I use apiUrl in config", { timeout: 30000 }, async function() {
+When("I set apiUrl in config", { timeout: 30000 }, async function() {
     const res = (this as CustomWorld).cliResources;
 
-    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "config", "use", "apiUrl", `${process.env.LOCAL_HOST_BASE_URL}`]);
+    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "config", "set", "apiUrl", `${process.env.LOCAL_HOST_BASE_URL}`]);
 
     if (process.env.SCRAMJET_TEST_LOG) {
         console.error(res.stdio);

--- a/bdd/step-definitions/e2e/cli.ts
+++ b/bdd/step-definitions/e2e/cli.ts
@@ -20,7 +20,7 @@ const si = process.env.SCRAMJET_SPAWN_JS
 When("I set json format", { timeout: 30000 }, async function() {
     const res = (this as CustomWorld).cliResources;
 
-    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "config", "set", "json", `{ "format": "json"}`]);
+    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "config", "set", "log", "--format", "json"]);
 
     if (process.env.SCRAMJET_TEST_LOG) {
         console.error(res.stdio);

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,7 +12,7 @@
     "build": "../../scripts/build-all.js --config-name=tsconfig.build.json --copy-dist",
     "clean": "rm -rf ./dist .bic_cache",
     "cloc": "cloc src --fullpath --include-lang TypeScript --not-match-d \"(node_modules|test|dist|bdd)\" --by-percent cm",
-    "test": "echo no tests yet -- # npm run test:ava",
+    "test": "npm run test:ava",
     "test:ava": "ava",
     "preinstall": "tar --version 2>&1 >/dev/null"
   },
@@ -30,7 +30,8 @@
     "find-package-json": "^1.2.0",
     "minimatch": "^3.1.2",
     "scramjet": "^4.36.6",
-    "tar": "^6.1.11"
+    "tar": "^6.1.11",
+    "validator": "^13.7.0"
   },
   "devDependencies": {
     "@scramjet/types": "^0.24.3",
@@ -38,6 +39,7 @@
     "@types/minimatch": "^3.0.5",
     "@types/node": "15.12.5",
     "@types/tar": "^4.0.5",
+    "@types/validator": "^13.7.2",
     "ava": "^3.15.0",
     "ts-node": "^10.7.0",
     "typedoc": "^0.22.15",

--- a/packages/cli/src/bin/index.ts
+++ b/packages/cli/src/bin/index.ts
@@ -47,16 +47,13 @@ const initPlatform = async () => {
     await initPlatform();
 
     for (const command of Object.values(commands)) command(program);
-    if (process.argv.includes("--config-path")) {
-        profileManager.setFlagProfilePathSource();
-    }
 
     program
         .description(
             "This is a Scramjet Command Line Interface to communicate with Transform Hub and Cloud Platform.")
         .version(`CLI version: ${version}`, "-v, --version", "Display current CLI version")
-        .option("--config <name>", "Set global configuration profile", (name) => profileManager.setFlagProfile(name))
-        .option("--config-path <path>", "Set global configuration from file", (path) => profileManager.setFlagProfilePath(path))
+        .option("--config <name>", "Set global configuration profile")
+        .option("--config-path <path>", "Set global configuration from file")
         .addHelpCommand(false)
         .addHelpText("beforeAll", `Current profile: ${profileManager.getProfileName()}`)
         .addHelpText(

--- a/packages/cli/src/bin/index.ts
+++ b/packages/cli/src/bin/index.ts
@@ -4,66 +4,30 @@
 import findPackage from "find-package-json";
 import commander from "commander";
 import completionMixin, { Command } from "commander-completion";
-import { ClientError, ClientUtils } from "@scramjet/client-utils";
+import { ClientUtils } from "@scramjet/client-utils";
 
+import { errorHandler } from "../lib/errorHandler";
 import { commands } from "../lib/commands/index";
 import { setPlatformDefaults } from "../lib/platform";
-import { globalConfig } from "../lib/config";
+import { initConfig, profileConfig, profileManager } from "../lib/config";
 import { initPaths } from "../lib/paths";
 import chalk from "chalk";
+import { isProductionEnv } from "../types";
 
 const version = findPackage(__dirname).next().value?.version || "unknown";
 const CommandClass = completionMixin(commander).Command;
 
-async function jsonize(err: ClientError) {
-    if (!err.toJSON) return undefined;
-
-    return await err.toJSON().then((body) => body).catch(() => undefined);
-}
-
-const getExitCode = (_err: ClientError) => 1;
 const program = new CommandClass() as Command;
-const errorHandler = async (err: ClientError) => {
-    process.exitCode = getExitCode(err);
-    const { format, debug } = globalConfig.getConfig();
 
-    if (globalConfig.isJsonFormat(format)) {
-        // TODO Check if it is a CLI or an API Client Error.
-        console.log(
-            JSON.stringify({
-                error: true,
-                code: err?.code,
-                stack: debug ? err?.stack : undefined,
-                message: err?.message,
-                reason: err?.reason?.message,
-                apiStatusCode: err?.status,
-                apiError: await jsonize(err),
-            })
-        );
-    } else if (err) {
-        console.error(err.stack);
-
-        if (err.reason) {
-            console.error("Caused by:");
-            console.error(err.reason.stack);
-        }
-    }
-    process.exit();
-};
-
-/**
- * Start commander using defined config {@link Apple.seeds}
- */
-(async () => {
-    initPaths();
-    const { token, env, middlewareApiUrl } = globalConfig.getConfig();
+const initPlatform = async () => {
+    const { token, env, middlewareApiUrl } = profileConfig.getConfig();
 
     /**
      * Set the default values for platform only when all required settings
      * are provided in the global-config.json file.
      * Do not set the default platform values when displaying the help commands.
      */
-    if (token && globalConfig.isProductionEnv(env) && middlewareApiUrl &&
+    if (token && isProductionEnv(env) && middlewareApiUrl &&
         !process.argv.includes((program as any)._helpShortFlag) &&
         !process.argv.includes((program as any)._helpLongFlag)) {
         ClientUtils.setDefaultHeaders({
@@ -72,14 +36,29 @@ const errorHandler = async (err: ClientError) => {
 
         await setPlatformDefaults();
     }
+};
+
+/**
+ * Start commander using defined config {@link Apple.seeds}
+ */
+(async () => {
+    initPaths();
+    initConfig();
+    await initPlatform();
 
     for (const command of Object.values(commands)) command(program);
+    if (process.argv.includes("--config-path")) {
+        profileManager.setFlagProfilePathSource();
+    }
 
     program
         .description(
             "This is a Scramjet Command Line Interface to communicate with Transform Hub and Cloud Platform.")
         .version(`CLI version: ${version}`, "-v, --version", "Display current CLI version")
+        .option("--config <name>", "Set global configuration profile", (name) => profileManager.setFlagProfile(name))
+        .option("--config-path <path>", "Set global configuration from file", (path) => profileManager.setFlagProfilePath(path))
         .addHelpCommand(false)
+        .addHelpText("beforeAll", `Current profile: ${profileManager.getProfileName()}`)
         .addHelpText(
             "afterAll",
             chalk.greenBright("\nTo find out more about CLI, please check out our docs at https://hub.scramjet.org/docs/cli\n"))

--- a/packages/cli/src/bin/index.ts
+++ b/packages/cli/src/bin/index.ts
@@ -24,7 +24,7 @@ const initPlatform = async () => {
 
     /**
      * Set the default values for platform only when all required settings
-     * are provided in the global-config.json file.
+     * are provided in the profile configuration.
      * Do not set the default platform values when displaying the help commands.
      */
     if (token && isProductionEnv(env) && middlewareApiUrl &&

--- a/packages/cli/src/lib/commands/config.ts
+++ b/packages/cli/src/lib/commands/config.ts
@@ -19,8 +19,11 @@ export const config: CommandDefinition = (program) => {
         middlewareApiUrl: defaulMiddlewareApiUrl,
         env: defaultEnv,
         token: defaultToken,
-        debug: defaultDebug,
-        format: defaultFormat } = defaultConfig;
+        log:{
+            debug: defaultDebug,
+            format: defaultFormat
+        }
+    } = defaultConfig;
 
     const configCmd = program
         .command("config")
@@ -36,7 +39,11 @@ export const config: CommandDefinition = (program) => {
         .action(() => {
             const configuration = profileConfig.getConfig();
 
-            displayObject(configuration, configuration.format);
+            if (profileManager.isPathSource())
+                displayMessage(`Current configuration: ${profileConfig.path}\n`);
+            else
+                displayMessage(`Current profile: ${profileManager.getProfileName()}\n`);
+            displayObject(configuration, configuration.log.format);
         });
 
     const setCmd = configCmd

--- a/packages/cli/src/lib/commands/config.ts
+++ b/packages/cli/src/lib/commands/config.ts
@@ -3,7 +3,7 @@
 import { CommandDefinition } from "../../types";
 import { stringToBoolean } from "../../utils/stringToBoolean";
 import { ProfileConfig, profileConfig, profileManager, siConfig } from "../config";
-import { displayError, displayMessage, displayObject } from "../output";
+import { displayMessage, displayObject } from "../output";
 import commander from "commander";
 import { defaultConfigName, listDirFileNames, profileExists, profileNameToPath, profileRemove, profilesDir } from "../paths";
 
@@ -56,12 +56,15 @@ export const config: CommandDefinition = (program) => {
         .argument("<json>")
         .description("Set configuration properties from a json object")
         .action(json => {
+            let jsonConfig = {};
+
             try {
-                if (!profileConfig.setConfig(JSON.parse(json))) {
-                    displayError("Invalid configuration in json object");
-                }
+                jsonConfig = JSON.parse(json);
             } catch (_) {
-                displayError("Parsing error: Invalid JSON format");
+                throw new Error("Parsing error: Invalid JSON format");
+            }
+            if (!profileConfig.setConfig(jsonConfig)) {
+                throw new Error("Invalid configuration in json object");
             }
         });
 
@@ -71,7 +74,7 @@ export const config: CommandDefinition = (program) => {
         .description("Specify the Hub API Url")
         .action(url => {
             if (!profileConfig.setApiUrl(url)) {
-                displayError("Invalid url");
+                throw new Error("Invalid url");
             }
         });
 
@@ -85,14 +88,14 @@ export const config: CommandDefinition = (program) => {
                 const debugVal = stringToBoolean(debug);
 
                 if (typeof debugVal === "undefined") {
-                    displayError("Invalid debug value");
+                    throw new Error("Invalid debug value");
                 }
                 if (!profileConfig.setDebug(debugVal as boolean)) {
-                    displayError("Unable to set debug value");
+                    throw new Error("Unable to set debug value");
                 }
             }
             if (newFormat && !profileConfig.setFormat(newFormat)) {
-                displayError("Unable to set format value");
+                throw new Error("Unable to set format value");
             }
         });
 
@@ -102,7 +105,7 @@ export const config: CommandDefinition = (program) => {
         .description("Specify middleware API url")
         .action(url => {
             if (!profileConfig.setMiddlewareApiUrl(url)) {
-                displayError("Invalid url");
+                throw new Error("Invalid url");
             }
         });
 
@@ -112,7 +115,7 @@ export const config: CommandDefinition = (program) => {
         .description("Specify default scope that should be used when session start")
         .action(scope => {
             if (!profileConfig.setScope(scope)) {
-                displayError(`Invalid name: ${scope}`);
+                throw new Error(`Invalid name: ${scope}`);
             }
         });
 
@@ -122,7 +125,7 @@ export const config: CommandDefinition = (program) => {
         .description("Specify platform authorization token")
         .action(token => {
             if (!profileConfig.setToken(token)) {
-                displayError("Invalid token");
+                throw new Error("Invalid token");
             }
         });
 
@@ -132,7 +135,7 @@ export const config: CommandDefinition = (program) => {
         .description("Specify the environment")
         .action(env => {
             if (!profileConfig.setEnv(env)) {
-                displayError("Invalid environment");
+                throw new Error("Invalid environment");
             }
         });
 
@@ -143,7 +146,7 @@ export const config: CommandDefinition = (program) => {
 
     const resetValue = (defaultValue: any, setCallback: (val: typeof defaultValue) => boolean) => {
         if (!setCallback(defaultValue)) {
-            displayError("Reset failed.");
+            throw new Error("Reset failed.");
         }
     };
 
@@ -222,8 +225,7 @@ export const config: CommandDefinition = (program) => {
         .action((name) => {
             if (!profileExists(name)) throw Error(`Unknown profile: ${name}`);
             if (name === defaultConfigName) {
-                displayError(`You can't remove ${defaultConfigName} profile`);
-                return;
+                throw new Error(`You can't remove ${defaultConfigName} profile`);
             }
             profileRemove(name);
         });

--- a/packages/cli/src/lib/commands/hub.ts
+++ b/packages/cli/src/lib/commands/hub.ts
@@ -12,9 +12,6 @@ import { getMiddlewareClient } from "../platform";
  * @param {Command} program Commander object.
  */
 export const hub: CommandDefinition = (program) => {
-    const { env, format } = profileConfig.getConfig();
-    const isProductionEnviroment = isProductionEnv(env);
-
     const hubCmd = program
         .command("hub")
         .addHelpCommand(false)
@@ -26,7 +23,7 @@ export const hub: CommandDefinition = (program) => {
     */
         .description("Allows to run programs in different data centers, computers or devices in local network");
 
-    if (isDevelopment() && isProductionEnviroment) {
+    if (isDevelopment() && isProductionEnv(profileConfig.env)) {
         hubCmd
             .command("create")
             .argument("<name>")
@@ -39,7 +36,7 @@ export const hub: CommandDefinition = (program) => {
             });
     }
 
-    if (isProductionEnviroment) {
+    if (isProductionEnv(profileConfig.env)) {
         hubCmd
             .command("use")
             .argument("<name|id>")
@@ -59,7 +56,7 @@ export const hub: CommandDefinition = (program) => {
             });
     }
 
-    if (isProductionEnviroment) {
+    if (isProductionEnv(profileConfig.env)) {
         hubCmd
             .command("list")
             .alias("ls")
@@ -75,11 +72,11 @@ export const hub: CommandDefinition = (program) => {
                 const managerClient = getMiddlewareClient().getManagerClient(space);
                 const hosts = await managerClient.getHosts();
 
-                displayObject(hosts, format);
+                displayObject(hosts, profileConfig.format);
             });
     }
 
-    if (isProductionEnviroment) {
+    if (isProductionEnv(profileConfig.env)) {
         hubCmd
             .command("info")
         /* TODO for future use
@@ -93,7 +90,7 @@ export const hub: CommandDefinition = (program) => {
                 const hosts = await managerClient.getHosts();
                 const host = hosts.find((h: any) => h.id === id);
 
-                displayObject(host, format);
+                displayObject(host, profileConfig.format);
             });
     }
 
@@ -105,10 +102,10 @@ export const hub: CommandDefinition = (program) => {
     hubCmd
         .command("load")
         .description("Monitor CPU, memory and disk usage on the Hub")
-        .action(async () => displayEntity(getHostClient().getLoadCheck(), format));
+        .action(async () => displayEntity(getHostClient().getLoadCheck(), profileConfig.format));
 
     hubCmd
         .command("version")
         .description("Display version of the default Hub")
-        .action(async () => displayEntity(getHostClient().getVersion(), format));
+        .action(async () => displayEntity(getHostClient().getVersion(), profileConfig.format));
 };

--- a/packages/cli/src/lib/commands/hub.ts
+++ b/packages/cli/src/lib/commands/hub.ts
@@ -3,7 +3,7 @@ import { CommandDefinition, isProductionEnv } from "../../types";
 import { isDevelopment } from "../../utils/envs";
 import { getHostClient } from "../common";
 import { profileConfig, sessionConfig } from "../config";
-import { displayEntity, displayObject, displayStream } from "../output";
+import { displayEntity, displayError, displayObject, displayStream } from "../output";
 import { getMiddlewareClient } from "../platform";
 
 /**
@@ -48,7 +48,7 @@ export const hub: CommandDefinition = (program) => {
                 const host = hosts.find((h: any) => h.id === id);
 
                 if (!host) {
-                    console.error("Host not found");
+                    displayError("Host not found");
                     return;
                 }
                 managerClient.getHostClient(id);
@@ -65,7 +65,7 @@ export const hub: CommandDefinition = (program) => {
                 const space = sessionConfig.getConfig().lastSpaceId;
 
                 if (!space) {
-                    console.error("No space selected");
+                    displayError("No space selected");
                     return;
                 }
 

--- a/packages/cli/src/lib/commands/index.ts
+++ b/packages/cli/src/lib/commands/index.ts
@@ -1,4 +1,4 @@
-import { CommandDefinition } from "../../types";
+import { CommandDefinition, isProductionEnv } from "../../types";
 import { config } from "./config";
 import { hub } from "./hub";
 import { instance } from "./instance";
@@ -9,16 +9,16 @@ import { topic } from "./topic";
 import { completion } from "./completion";
 import { util } from "./util";
 import { init } from "./init";
-import { isDevelopment } from "../../utils/isDevelopment";
-import { globalConfig } from "../config";
+import { isDevelopment } from "../../utils/envs";
+import { profileConfig } from "../config";
 
-const isProductionEnv = globalConfig.isProductionEnv(globalConfig.getEnv());
+const isProdEnv = isProductionEnv(profileConfig.getEnv());
 
 export const commands: CommandDefinition[] = [
     hub,
     config,
-    isProductionEnv ? scope : () => {},
-    isProductionEnv ? space : () => {},
+    isProdEnv ? scope : () => {},
+    isProdEnv ? space : () => {},
     sequence,
     instance,
     topic,

--- a/packages/cli/src/lib/commands/instance.ts
+++ b/packages/cli/src/lib/commands/instance.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { CommandDefinition } from "../../types";
 import { attachStdio, getHostClient, getInstance, getReadStreamFromFile } from "../common";
-import { getInstanceId, sessionConfig } from "../config";
+import { getInstanceId, profileConfig, sessionConfig } from "../config";
 import { displayEntity, displayStream } from "../output";
 
 /**
@@ -10,6 +10,8 @@ import { displayEntity, displayStream } from "../output";
  * @param {Command} program Commander object.
  */
 export const instance: CommandDefinition = (program) => {
+    // const { format } = profileConfig.getConfig();
+
     const instanceCmd = program
         .command("instance [command]")
         .addHelpCommand(false)
@@ -21,7 +23,7 @@ export const instance: CommandDefinition = (program) => {
         .command("list")
         .alias("ls")
         .description("List the Instances")
-        .action(async () => displayEntity(getHostClient().listInstances()));
+        .action(async () => displayEntity(getHostClient().listInstances(), profileConfig.getConfig().format));
 
     instanceCmd
         .command("use")
@@ -34,13 +36,15 @@ export const instance: CommandDefinition = (program) => {
         .command("health")
         .argument("<id>", "Instance id or '-' for the last one started")
         .description("Display Instance health status")
-        .action((id: string) => displayEntity(getInstance(getInstanceId(id)).getHealth()));
+        .action((id: string) => displayEntity(getInstance(getInstanceId(id)).getHealth(),
+            profileConfig.getConfig().format));
 
     instanceCmd
         .command("info")
         .argument("<id>", "Instance id or '-' for the last one started or selected")
         .description("Display the info about the Instance")
-        .action(async (id: string) => displayEntity(getHostClient().getInstanceInfo(getInstanceId(id))));
+        .action(async (id: string) => displayEntity(getHostClient().getInstanceInfo(getInstanceId(id)),
+            profileConfig.getConfig().format));
 
     instanceCmd
         .command("log")
@@ -54,7 +58,8 @@ export const instance: CommandDefinition = (program) => {
         .command("kill")
         .argument("<id>", "Instance id or '-' for the last one started")
         .description("Kill the Instance without waiting for the unfinished task")
-        .action(async (id: string) => displayEntity(getInstance(getInstanceId(id)).kill()));
+        .action(async (id: string) => displayEntity(getInstance(getInstanceId(id)).kill(),
+            profileConfig.getConfig().format));
 
     /**
      * @canCallKeepAlive
@@ -67,7 +72,8 @@ export const instance: CommandDefinition = (program) => {
         .argument("<timeout>", "Timeout in milliseconds")
         .description("End the Instance gracefully waiting for the unfinished tasks")
         .action(async (id: string, timeout: string) =>
-            displayEntity(getInstance(getInstanceId(id)).stop(+timeout, true)));
+            displayEntity(getInstance(getInstanceId(id)).stop(+timeout, true),
+                profileConfig.getConfig().format));
 
     instanceCmd
         .command("input")
@@ -117,7 +123,8 @@ export const instance: CommandDefinition = (program) => {
         .action(async (id: string, eventName: string, message: string) => {
             const instanceClient = getInstance(getInstanceId(id));
 
-            return displayEntity(instanceClient.sendEvent(eventName, message));
+            return displayEntity(instanceClient.sendEvent(eventName, message),
+                profileConfig.getConfig().format);
         });
 
     eventCmd
@@ -130,8 +137,9 @@ export const instance: CommandDefinition = (program) => {
         .description("Get the last event occurrence (will wait for the first one if not yet retrieved)")
         .action(async (id: string, event: string, { next, stream }) => {
             if (stream) return displayStream(getInstance(getInstanceId(id)).getEventStream(event));
-            if (next) return displayEntity(getInstance(getInstanceId(id)).getNextEvent(event));
-            return displayEntity(getInstance(getInstanceId(id)).getEvent(event));
+            if (next) return displayEntity(getInstance(getInstanceId(id)).getNextEvent(event),
+                profileConfig.getConfig().format);
+            return displayEntity(getInstance(getInstanceId(id)).getEvent(event), profileConfig.getConfig().format);
         });
 
     instanceCmd
@@ -142,11 +150,8 @@ export const instance: CommandDefinition = (program) => {
         .action(async (id: string, file: string) => {
             const instanceClient = getInstance(getInstanceId(id));
 
-            return displayEntity(instanceClient.sendStdin(
-                file
-                    ? await getReadStreamFromFile(file)
-                    : process.stdin
-            ));
+            return displayEntity(instanceClient.sendStdin(file ? await getReadStreamFromFile(file) : process.stdin),
+                profileConfig.getConfig().format);
         });
 
     instanceCmd

--- a/packages/cli/src/lib/commands/instance.ts
+++ b/packages/cli/src/lib/commands/instance.ts
@@ -10,8 +10,6 @@ import { displayEntity, displayStream } from "../output";
  * @param {Command} program Commander object.
  */
 export const instance: CommandDefinition = (program) => {
-    // const { format } = profileConfig.getConfig();
-
     const instanceCmd = program
         .command("instance [command]")
         .addHelpCommand(false)
@@ -23,7 +21,7 @@ export const instance: CommandDefinition = (program) => {
         .command("list")
         .alias("ls")
         .description("List the Instances")
-        .action(async () => displayEntity(getHostClient().listInstances(), profileConfig.getConfig().format));
+        .action(async () => displayEntity(getHostClient().listInstances(), profileConfig.format));
 
     instanceCmd
         .command("use")
@@ -37,14 +35,14 @@ export const instance: CommandDefinition = (program) => {
         .argument("<id>", "Instance id or '-' for the last one started")
         .description("Display Instance health status")
         .action((id: string) => displayEntity(getInstance(getInstanceId(id)).getHealth(),
-            profileConfig.getConfig().format));
+            profileConfig.format));
 
     instanceCmd
         .command("info")
         .argument("<id>", "Instance id or '-' for the last one started or selected")
         .description("Display the info about the Instance")
         .action(async (id: string) => displayEntity(getHostClient().getInstanceInfo(getInstanceId(id)),
-            profileConfig.getConfig().format));
+            profileConfig.format));
 
     instanceCmd
         .command("log")
@@ -59,7 +57,7 @@ export const instance: CommandDefinition = (program) => {
         .argument("<id>", "Instance id or '-' for the last one started")
         .description("Kill the Instance without waiting for the unfinished task")
         .action(async (id: string) => displayEntity(getInstance(getInstanceId(id)).kill(),
-            profileConfig.getConfig().format));
+            profileConfig.format));
 
     /**
      * @canCallKeepAlive
@@ -73,7 +71,7 @@ export const instance: CommandDefinition = (program) => {
         .description("End the Instance gracefully waiting for the unfinished tasks")
         .action(async (id: string, timeout: string) =>
             displayEntity(getInstance(getInstanceId(id)).stop(+timeout, true),
-                profileConfig.getConfig().format));
+                profileConfig.format));
 
     instanceCmd
         .command("input")
@@ -124,7 +122,7 @@ export const instance: CommandDefinition = (program) => {
             const instanceClient = getInstance(getInstanceId(id));
 
             return displayEntity(instanceClient.sendEvent(eventName, message),
-                profileConfig.getConfig().format);
+                profileConfig.format);
         });
 
     eventCmd
@@ -138,8 +136,8 @@ export const instance: CommandDefinition = (program) => {
         .action(async (id: string, event: string, { next, stream }) => {
             if (stream) return displayStream(getInstance(getInstanceId(id)).getEventStream(event));
             if (next) return displayEntity(getInstance(getInstanceId(id)).getNextEvent(event),
-                profileConfig.getConfig().format);
-            return displayEntity(getInstance(getInstanceId(id)).getEvent(event), profileConfig.getConfig().format);
+                profileConfig.format);
+            return displayEntity(getInstance(getInstanceId(id)).getEvent(event), profileConfig.format);
         });
 
     instanceCmd
@@ -151,7 +149,7 @@ export const instance: CommandDefinition = (program) => {
             const instanceClient = getInstance(getInstanceId(id));
 
             return displayEntity(instanceClient.sendStdin(file ? await getReadStreamFromFile(file) : process.stdin),
-                profileConfig.getConfig().format);
+                profileConfig.format);
         });
 
     instanceCmd

--- a/packages/cli/src/lib/commands/scope.ts
+++ b/packages/cli/src/lib/commands/scope.ts
@@ -2,8 +2,8 @@
 import { CommandDefinition } from "../../types";
 import { listScopes, deleteScope, getScope, scopeExists } from "../scope";
 import { displayObject } from "../output";
-import { globalConfig, sessionConfig } from "../config";
-import { isDevelopment } from "../../utils/isDevelopment";
+import { profileConfig } from "../config";
+import { isDevelopment } from "../../utils/envs";
 
 /**
  * Initializes `scope` command.
@@ -32,7 +32,7 @@ export const scope: CommandDefinition = (program) => {
                 return;
             }
 
-            displayObject(scopeConfig);
+            displayObject(scopeConfig, profileConfig.getConfig().format);
         });
 
     if (isDevelopment())
@@ -66,7 +66,7 @@ export const scope: CommandDefinition = (program) => {
                 console.error(`Couldn't find scope: ${name}`);
                 return;
             }
-            sessionConfig.setScope(name);
+            profileConfig.setScope(name);
         });
 
     scopeCmd
@@ -74,11 +74,11 @@ export const scope: CommandDefinition = (program) => {
         .argument("<name>")
         .description("Delete specific scope")
         .action((name: string) => {
-            if (globalConfig.getConfig().scope === name) {
+            if (profileConfig.getConfig().scope === name) {
                 console.error(`WARN: can't remove scope ${name} set in configuration.`);
                 return;
             }
-            if (sessionConfig.getConfig().scope === name) {
+            if (profileConfig.getConfig().scope === name) {
                 console.error(`WARN: can't remove currently used scope ${name}`);
                 return;
             }

--- a/packages/cli/src/lib/commands/scope.ts
+++ b/packages/cli/src/lib/commands/scope.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { CommandDefinition } from "../../types";
 import { listScopes, deleteScope, getScope, scopeExists } from "../scope";
-import { displayObject } from "../output";
+import { displayError, displayObject } from "../output";
 import { profileConfig } from "../config";
 import { isDevelopment } from "../../utils/envs";
 
@@ -28,7 +28,7 @@ export const scope: CommandDefinition = (program) => {
             const scopeConfig = getScope(name);
 
             if (!scopeConfig) {
-                console.error(`Couldn't find scope: ${name}`);
+                displayError(`Couldn't find scope: ${name}`);
                 return;
             }
 
@@ -63,7 +63,7 @@ export const scope: CommandDefinition = (program) => {
         .description("Work on the selected scope")
         .action((name: string) => {
             if (!scopeExists(name)) {
-                console.error(`Couldn't find scope: ${name}`);
+                displayError(`Couldn't find scope: ${name}`);
                 return;
             }
             profileConfig.setScope(name);
@@ -75,11 +75,11 @@ export const scope: CommandDefinition = (program) => {
         .description("Delete specific scope")
         .action((name: string) => {
             if (profileConfig.getConfig().scope === name) {
-                console.error(`WARN: can't remove scope ${name} set in configuration.`);
+                displayError(`Can't remove scope ${name} set in configuration.`);
                 return;
             }
             if (profileConfig.getConfig().scope === name) {
-                console.error(`WARN: can't remove currently used scope ${name}`);
+                displayError(`Can't remove currently used scope ${name}`);
                 return;
             }
             deleteScope(name);

--- a/packages/cli/src/lib/commands/scope.ts
+++ b/packages/cli/src/lib/commands/scope.ts
@@ -32,7 +32,7 @@ export const scope: CommandDefinition = (program) => {
                 return;
             }
 
-            displayObject(scopeConfig, profileConfig.getConfig().format);
+            displayObject(scopeConfig, profileConfig.format);
         });
 
     if (isDevelopment())

--- a/packages/cli/src/lib/commands/sequence.ts
+++ b/packages/cli/src/lib/commands/sequence.ts
@@ -7,13 +7,13 @@ import { createWriteStream, lstatSync } from "fs";
 import { readFile } from "fs/promises";
 import { resolve } from "path";
 import { PassThrough } from "stream";
-import { CommandDefinition } from "../../types";
-import { isDevelopment } from "../../utils/isDevelopment";
+import { CommandDefinition, displayFormat } from "../../types";
+import { isDevelopment } from "../../utils/envs";
 import { getHostClient, getInstance, getReadStreamFromFile, packAction } from "../common";
-import { getPackagePath, getSequenceId, sessionConfig } from "../config";
+import { getPackagePath, getSequenceId, profileConfig, sessionConfig } from "../config";
 import { displayEntity, displayError, displayMessage, displayObject } from "../output";
 
-const sendPackage = async (sequencePackage: string) => {
+const sendPackage = async (sequencePackage: string, format: displayFormat) => {
     try {
         const sequencePath = getPackagePath(sequencePackage);
         const seq = await getHostClient().sendSequence(
@@ -22,7 +22,7 @@ const sendPackage = async (sequencePackage: string) => {
 
         sessionConfig.setLastSequenceId(seq.id);
 
-        return displayObject(seq);
+        return displayObject(seq, format);
     } catch (e: any) {
         return displayError(e);
     }
@@ -38,6 +38,7 @@ const startSequence = async (
             inputTopic?: string,
             limits?: InstanceLimits
         }
+    , format: displayFormat
 ) => {
     if (configFile && configString) {
         console.error("Provide one source of configuration");
@@ -59,7 +60,7 @@ const startSequence = async (
         const instance = await sequenceClient.start({ appConfig, args, outputTopic, inputTopic, limits });
 
         sessionConfig.setLastInstanceId(instance.id);
-        return displayObject(instance);
+        return displayObject(instance, format);
     } catch (error: any) {
         displayError(error);
         return process.exit(1);
@@ -91,7 +92,7 @@ export const sequence: CommandDefinition = (program) => {
         .command("list")
         .alias("ls")
         .description("Lists all available Sequences")
-        .action(async () => displayEntity(getHostClient().listSequences()));
+        .action(async () => displayEntity(getHostClient().listSequences(), profileConfig.getConfig().format));
 
     sequenceCmd
         .command("pack")
@@ -126,7 +127,7 @@ export const sequence: CommandDefinition = (program) => {
         .command("send")
         .argument("<package>", "The file to upload or '-' to use the last packed")
         .description("Send the Sequence package to the Hub")
-        .action(async (sequencePackage: string) => sendPackage(sequencePackage));
+        .action(async (sequencePackage: string) => sendPackage(sequencePackage, profileConfig.getConfig().format));
 
     sequenceCmd
         .command("use")
@@ -152,7 +153,8 @@ export const sequence: CommandDefinition = (program) => {
             const args = parseSequenceArgs(argsStr);
             const limits = limitsStr ? JSON.parse(limitsStr) : {};
 
-            await startSequence(id, { configFile, configString, args, outputTopic, inputTopic, limits });
+            await startSequence(id, { configFile, configString, args, outputTopic, inputTopic, limits },
+                profileConfig.getConfig().format);
         });
 
     type DeployArgs = {
@@ -181,6 +183,7 @@ export const sequence: CommandDefinition = (program) => {
                 output.pipe(createWriteStream(outputPath));
                 sessionConfig.setLastPackagePath(outputPath);
             }
+            const { format } = profileConfig.getConfig();
 
             if (lstatSync(path).isDirectory()) {
                 await packAction(path, { output });
@@ -188,24 +191,26 @@ export const sequence: CommandDefinition = (program) => {
 
                 sessionConfig.setLastSequenceId(seq.id);
             } else
-                await sendPackage(path);
+                await sendPackage(path, format);
             const args = parseSequenceArgs(argsStr);
 
-            await startSequence("-", { configFile, configString, args });
+            await startSequence("-", { configFile, configString, args }, format);
         });
 
     sequenceCmd
         .command("get")
         .argument("<id>", "Sequence id to start or '-' for the last uploaded")
         .description("Obtain a basic information about the Sequence")
-        .action(async (id: string) => displayEntity(getHostClient().getSequence(getSequenceId(id))));
+        .action(async (id: string) => displayEntity(getHostClient().getSequence(getSequenceId(id)),
+            profileConfig.getConfig().format));
 
     sequenceCmd
         .command("delete")
         .alias("rm")
         .argument("<id>", "The Sequence id to remove or '-' for the last uploaded")
         .description("Delete the Sequence from the Hub")
-        .action(async (id: string) => displayEntity(getHostClient().deleteSequence(getSequenceId(id))));
+        .action(async (id: string) => displayEntity(getHostClient().deleteSequence(getSequenceId(id)),
+            profileConfig.getConfig().format));
 
     sequenceCmd
         .command("prune")

--- a/packages/cli/src/lib/commands/sequence.ts
+++ b/packages/cli/src/lib/commands/sequence.ts
@@ -92,7 +92,7 @@ export const sequence: CommandDefinition = (program) => {
         .command("list")
         .alias("ls")
         .description("Lists all available Sequences")
-        .action(async () => displayEntity(getHostClient().listSequences(), profileConfig.getConfig().format));
+        .action(async () => displayEntity(getHostClient().listSequences(), profileConfig.format));
 
     sequenceCmd
         .command("pack")
@@ -127,7 +127,7 @@ export const sequence: CommandDefinition = (program) => {
         .command("send")
         .argument("<package>", "The file to upload or '-' to use the last packed")
         .description("Send the Sequence package to the Hub")
-        .action(async (sequencePackage: string) => sendPackage(sequencePackage, profileConfig.getConfig().format));
+        .action(async (sequencePackage: string) => sendPackage(sequencePackage, profileConfig.format));
 
     sequenceCmd
         .command("use")
@@ -154,7 +154,7 @@ export const sequence: CommandDefinition = (program) => {
             const limits = limitsStr ? JSON.parse(limitsStr) : {};
 
             await startSequence(id, { configFile, configString, args, outputTopic, inputTopic, limits },
-                profileConfig.getConfig().format);
+                profileConfig.format);
         });
 
     type DeployArgs = {
@@ -183,7 +183,7 @@ export const sequence: CommandDefinition = (program) => {
                 output.pipe(createWriteStream(outputPath));
                 sessionConfig.setLastPackagePath(outputPath);
             }
-            const { format } = profileConfig.getConfig();
+            const { log:{ format } } = profileConfig.getConfig();
 
             if (lstatSync(path).isDirectory()) {
                 await packAction(path, { output });
@@ -202,7 +202,7 @@ export const sequence: CommandDefinition = (program) => {
         .argument("<id>", "Sequence id to start or '-' for the last uploaded")
         .description("Obtain a basic information about the Sequence")
         .action(async (id: string) => displayEntity(getHostClient().getSequence(getSequenceId(id)),
-            profileConfig.getConfig().format));
+            profileConfig.format));
 
     sequenceCmd
         .command("delete")
@@ -210,7 +210,7 @@ export const sequence: CommandDefinition = (program) => {
         .argument("<id>", "The Sequence id to remove or '-' for the last uploaded")
         .description("Delete the Sequence from the Hub")
         .action(async (id: string) => displayEntity(getHostClient().deleteSequence(getSequenceId(id)),
-            profileConfig.getConfig().format));
+            profileConfig.format));
 
     sequenceCmd
         .command("prune")

--- a/packages/cli/src/lib/commands/sequence.ts
+++ b/packages/cli/src/lib/commands/sequence.ts
@@ -41,7 +41,7 @@ const startSequence = async (
     , format: displayFormat
 ) => {
     if (configFile && configString) {
-        console.error("Provide one source of configuration");
+        displayError("Provide one source of configuration");
         return Promise.resolve();
     }
 
@@ -51,7 +51,7 @@ const startSequence = async (
         if (configString) appConfig = JSON.parse(configString);
         if (configFile) appConfig = JSON.parse(await readFile(configFile, "utf-8"));
     } catch (_) {
-        console.error("Unable to read configuration");
+        displayError("Unable to read configuration");
         return Promise.reject();
     }
     const sequenceClient = SequenceClient.from(getSequenceId(id), getHostClient());

--- a/packages/cli/src/lib/commands/space.ts
+++ b/packages/cli/src/lib/commands/space.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { CommandDefinition } from "../../types";
-import { isDevelopment } from "../../utils/isDevelopment";
-import { sessionConfig } from "../config";
+import { isDevelopment } from "../../utils/envs";
+import { profileConfig, sessionConfig } from "../config";
 import { displayObject } from "../output";
 import { getMiddlewareClient } from "../platform";
 
@@ -43,7 +43,7 @@ export const space: CommandDefinition = (program) => {
             const managerClient = getMiddlewareClient().getManagerClient(spaceId);
             const version = await managerClient.getVersion();
 
-            displayObject({ spaceId, version, managerClient });
+            displayObject({ spaceId, version, managerClient }, profileConfig.getConfig().format);
         });
 
     spaceCmd
@@ -54,7 +54,7 @@ export const space: CommandDefinition = (program) => {
             const mwClient = getMiddlewareClient();
             const managers = await mwClient.getManagers();
 
-            return displayObject(managers);
+            return displayObject(managers, profileConfig.getConfig().format);
         });
 
     spaceCmd
@@ -65,7 +65,7 @@ export const space: CommandDefinition = (program) => {
             const mwClient = getMiddlewareClient();
             const managerClient = mwClient.getManagerClient(name);
 
-            displayObject({ name, ...await managerClient.getVersion() });
+            displayObject({ name, ...await managerClient.getVersion() }, profileConfig.getConfig().format);
             sessionConfig.setLastSpaceId(name);
         });
 

--- a/packages/cli/src/lib/commands/space.ts
+++ b/packages/cli/src/lib/commands/space.ts
@@ -43,7 +43,7 @@ export const space: CommandDefinition = (program) => {
             const managerClient = getMiddlewareClient().getManagerClient(spaceId);
             const version = await managerClient.getVersion();
 
-            displayObject({ spaceId, version, managerClient }, profileConfig.getConfig().format);
+            displayObject({ spaceId, version, managerClient }, profileConfig.format);
         });
 
     spaceCmd
@@ -54,7 +54,7 @@ export const space: CommandDefinition = (program) => {
             const mwClient = getMiddlewareClient();
             const managers = await mwClient.getManagers();
 
-            return displayObject(managers, profileConfig.getConfig().format);
+            return displayObject(managers, profileConfig.format);
         });
 
     spaceCmd
@@ -65,7 +65,7 @@ export const space: CommandDefinition = (program) => {
             const mwClient = getMiddlewareClient();
             const managerClient = mwClient.getManagerClient(name);
 
-            displayObject({ name, ...await managerClient.getVersion() }, profileConfig.getConfig().format);
+            displayObject({ name, ...await managerClient.getVersion() }, profileConfig.format);
             sessionConfig.setLastSpaceId(name);
         });
 

--- a/packages/cli/src/lib/commands/topic.ts
+++ b/packages/cli/src/lib/commands/topic.ts
@@ -1,6 +1,7 @@
 import { CommandDefinition } from "../../types";
-import { isDevelopment } from "../../utils/isDevelopment";
+import { isDevelopment } from "../../utils/envs";
 import { getHostClient, getReadStreamFromFile } from "../common";
+import { profileConfig } from "../config";
 import { displayEntity, displayStream } from "../output";
 
 /**
@@ -63,5 +64,5 @@ export const topic: CommandDefinition = (program) => {
 
     topicCmd.command("ls")
         .description("List information about topics")
-        .action(async () => displayEntity(getHostClient().getTopics()));
+        .action(async () => displayEntity(getHostClient().getTopics(), profileConfig.getConfig().format));
 };

--- a/packages/cli/src/lib/commands/topic.ts
+++ b/packages/cli/src/lib/commands/topic.ts
@@ -64,5 +64,5 @@ export const topic: CommandDefinition = (program) => {
 
     topicCmd.command("ls")
         .description("List information about topics")
-        .action(async () => displayEntity(getHostClient().getTopics(), profileConfig.getConfig().format));
+        .action(async () => displayEntity(getHostClient().getTopics(), profileConfig.format));
 };

--- a/packages/cli/src/lib/common.ts
+++ b/packages/cli/src/lib/common.ts
@@ -23,9 +23,8 @@ let hostClient: HostClient;
 export const getHostClient = (): HostClient => {
     if (hostClient) return hostClient;
 
-    const { apiUrl } = profileConfig.getConfig();
+    const { apiUrl, env, log: { debug } } = profileConfig.getConfig();
     const { lastSpaceId, lastHubId } = sessionConfig.getConfig();
-    const { env, debug } = profileConfig.getConfig();
 
     if (isDevelopmentEnv(env)) {
         hostClient = new HostClient(apiUrl);
@@ -77,14 +76,12 @@ export const getInstance = (id: string) => InstanceClient.from(id, getHostClient
  * @returns {Promise<void>} Promise resolving when all stdio streams finish.
  */
 export const attachStdio = (instanceClient: InstanceClient) => {
-    const { format } = profileConfig.getConfig();
-
     return displayEntity(
         Promise.all([
             instanceClient.sendStdin(process.stdin),
             instanceClient.getStream("stdout").then((out) => out.pipe(process.stdout)),
             instanceClient.getStream("stderr").then((err) => err.pipe(process.stderr)),
-        ]).then(() => undefined), format);
+        ]).then(() => undefined), profileConfig.format);
 };
 
 /**

--- a/packages/cli/src/lib/common.ts
+++ b/packages/cli/src/lib/common.ts
@@ -2,7 +2,7 @@ import { InstanceClient, HostClient } from "@scramjet/api-client";
 import { access, readdir } from "fs/promises";
 import { createReadStream, constants, PathLike } from "fs";
 import { resolve } from "path";
-import { displayEntity } from "./output";
+import { displayEntity, displayError, displayMessage } from "./output";
 import { c } from "tar";
 import { StringStream } from "scramjet";
 import { filter as mmfilter } from "minimatch";
@@ -39,21 +39,18 @@ export const getHostClient = (): HostClient => {
             ok(result) {
                 const { status, statusText, url } = result;
 
-                // eslint-disable-next-line no-console
-                console.error("Request ok:", url, `status: ${status} ${statusText}`);
+                displayMessage(`Request ok: ${url} status: ${status} ${statusText}`);
             },
             end(result) {
                 const { url, type } = result;
 
-                // eslint-disable-next-line no-console
-                console.error("Response ended:", url, { type });
+                displayMessage(`Response ended: ${url} ${{ type }}`);
             },
             error(error) {
                 const { code, reason: result } = error;
                 const { message } = result || {};
 
-                // eslint-disable-next-line no-console
-                console.error(`Request failed with code "${code}" status: ${message}`);
+                displayError(`Request failed with code "${code}" status: ${message}`);
             },
         });
     }

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -198,10 +198,14 @@ export class ProfileConfig extends DefaultFileConfig {
     set readOnly(readOnly: boolean) { this.readOnlyConfig = readOnly; }
     get readOnly() { return this.readOnlyConfig; }
 
-    checkIfWritable() { if (this.readOnlyConfig) throw Error("Unable to write for read only configuration"); }
+    checkIfWritable() { 
+        if (this.readOnlyConfig) throw Error("Unable to write for read only configuration"); 
+    }
+
     setConfig(config: any): boolean {
         this.checkIfWritable();
         if (typeof config !== "object" || !this.validateConfigPart(config)) return false;
+        
         const { log: currentLog, ...currentConfig } = this.getConfig();
         const { log: newLog, ...newConfig } = config;
         const overlap = { ...currentConfig, ...newConfig, log: { ...currentLog, ...newLog } };
@@ -268,7 +272,14 @@ export class ProfileConfig extends DefaultFileConfig {
         if (!super.validateConfigValue(key, value)) return false;
 
         switch (key) {
-            case "apiUrl": return isUrl(value);
+            case "apiUrl": 
+                return isUrl(value, {
+                    protocols: ['http','https'], 
+                    require_tld: false, 
+                    require_protocol: true, 
+                    require_port: true, 
+                    allow_underscores: true 
+                });
             case "log": {
                 for (const [logKey, logValue] of Object.entries(value)) {
                     if (!this.validateConfigLogValue(logKey, logValue)) return false;

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -1,7 +1,11 @@
 import { existsSync, writeFileSync, readFileSync } from "fs";
 import { normalizeUrl } from "@scramjet/utility";
-import { globalConfigFile, sessionConfigFile } from "./paths";
-import { configEnv, configFormat, GlobalConfigEntity, isConfigEnv, isConfigFormat, SessionConfigEntity } from "../types";
+import { createSessionDirIfNotExists, defaultConfigName, defaultConfigProfileFile, profileExists, profileNameToPath, sessionConfigFile, siConfigFile } from "./paths";
+import { configEnv, isConfigEnv, isConfigFormat, ProfileConfigEntity, SiConfigEntity, SessionConfigEntity } from "../types";
+import isUrl from "validator/lib/isURL";
+import isJWT from "validator/lib/isJWT";
+import { envs } from "../utils/envs";
+import { displayError } from "./output";
 
 abstract class Config {
     abstract getConfig(): any | null;
@@ -104,20 +108,37 @@ class DefaultFileConfig extends FileConfig {
     }
 }
 
-const JWS_REGEX = /^[a-zA-Z0-9\-_]+?\.[a-zA-Z0-9\-_]+?\.([a-zA-Z0-9\-_]+)?$/;
-const isJWT = (value: string) => Boolean(value.match(JWS_REGEX));
-const isValidUrl = (value: any) => {
-    try {
-        new URL(value);
-        return true;
-    } catch (_) {
-        return false;
-    }
-};
+// Config class for internal use only
+export class SiConfig extends DefaultFileConfig {
+    constructor(configFile: string) {
+        const siDefaultConfig: SiConfigEntity = {
+            profile: "",
+        };
 
-class GlobalConfig extends DefaultFileConfig {
-    constructor() {
-        const defaultGlobalConfig: GlobalConfigEntity = {
+        super(configFile, siDefaultConfig);
+        if (this.isValid()) return;
+        else if (this.writeConfig(siDefaultConfig))
+            this.setFilePath(configFile);
+    }
+    getConfig(): SiConfigEntity {
+        return super.getConfig();
+    }
+    setProfile(profile: string) {
+        return this.setConfigValue("profile", profile) as boolean;
+    }
+
+    validateConfigValue(key: string, value: any): boolean {
+        return super.validateConfigValue(key, value);
+    }
+}
+
+export const siConfig = new SiConfig(siConfigFile);
+
+export class ProfileConfig extends DefaultFileConfig {
+    protected readOnlyConfig: boolean;
+
+    constructor(configFile: string, readOnly: boolean = false) {
+        const profileConfig: ProfileConfigEntity = {
             configVersion: 1,
             apiUrl: "http://127.0.0.1:8000/api/v1",
             debug: false,
@@ -128,58 +149,65 @@ class GlobalConfig extends DefaultFileConfig {
             token: "",
         };
 
-        super(globalConfigFile, defaultGlobalConfig);
+        super(configFile, profileConfig);
+        this.readOnlyConfig = readOnly;
     }
-    getConfig(): GlobalConfigEntity {
+    getConfig(): ProfileConfigEntity {
         return super.getConfig();
     }
-    setConfig(config: any): boolean {
+    validateConfig(config: any) {
+        if (typeof config !== "object") return false;
+        if (config.length !== this.defaultConfig.length) return false;
         for (const [key, value] of Object.entries(config)) {
             if (!this.validateConfigValue(key, value)) return false;
         }
+        return true;
+    }
+    set readOnly(readOnly: boolean) { this.readOnlyConfig = readOnly; }
+    get readOnly() { return this.readOnlyConfig; }
+
+    checkIfWritable() { if (this.readOnlyConfig) throw Error("Unable to write for read only configuration"); }
+    setConfig(config: any): boolean {
+        this.checkIfWritable();
+        if (!this.validateConfig(config)) return false;
         const overlap = { ...this.getConfig(), ...config };
 
         return this.writeConfig(overlap);
     }
 
-    getDefaultConfig(): GlobalConfigEntity {
+    getDefaultConfig(): ProfileConfigEntity {
         return super.getDefaultConfig();
     }
     getEnv(): configEnv {
         return this.getConfig().env;
     }
-    isDevelopmentEnv(env: configEnv): boolean {
-        return env === "development";
-    }
-    isProductionEnv(env: configEnv): boolean {
-        return env === "production";
-    }
-    isJsonFormat(format: configFormat):boolean {
-        return format === "json";
-    }
-    isPrettyFormat(format: configFormat):boolean {
-        return format === "pretty";
-    }
 
     setApiUrl(apiUrl: string): boolean {
+        this.checkIfWritable();
         return this.setConfigValue("apiUrl", normalizeUrl(apiUrl)) as boolean;
     }
     setDebug(debug: boolean): boolean {
+        this.checkIfWritable();
         return this.setConfigValue("debug", debug) as boolean;
     }
     setFormat(format: string): boolean {
+        this.checkIfWritable();
         return this.setConfigValue("format", format) as boolean;
     }
     setMiddlewareApiUrl(middlewareApiUrl: string): boolean {
+        this.checkIfWritable();
         return this.setConfigValue("middlewareApiUrl", normalizeUrl(middlewareApiUrl)) as boolean;
     }
     setEnv(env: configEnv): boolean {
+        this.checkIfWritable();
         return this.setConfigValue("env", env) as boolean;
     }
     setScope(scope: string): boolean {
+        this.checkIfWritable();
         return this.setConfigValue("scope", scope) as boolean;
     }
     setToken(token: string): boolean {
+        this.checkIfWritable();
         return this.setConfigValue("token", token) as boolean;
     }
 
@@ -190,11 +218,11 @@ class GlobalConfig extends DefaultFileConfig {
             return false;
         }
         switch (key) {
-            case "apiUrl": return isValidUrl(value);
+            case "apiUrl": return isUrl(value);
             case "format": return isConfigFormat(value);
             case "middlewareApiUrl": {
                 if (value === this.defaultConfig.middlewareApiUrl) return true;
-                return isValidUrl(value);
+                return isUrl(value);
             }
             case "env" : return isConfigEnv(value);
             case "token": {
@@ -210,13 +238,11 @@ class GlobalConfig extends DefaultFileConfig {
 class SessionConfig extends DefaultFileConfig {
     constructor() {
         const defaultSessionConfig: SessionConfigEntity = {
-            apiUrl: new GlobalConfig().getConfig().apiUrl,
             lastPackagePath: "",
             lastInstanceId: "",
             lastSequenceId: "",
             lastSpaceId: "",
             lastHubId: "",
-            scope: "",
         };
 
         super(sessionConfigFile, defaultSessionConfig);
@@ -224,11 +250,12 @@ class SessionConfig extends DefaultFileConfig {
     getConfig(): SessionConfigEntity {
         return super.getConfig();
     }
-    getDefaultConfig(): GlobalConfigEntity {
+    getDefaultConfig(): SessionConfigEntity {
         return super.getDefaultConfig();
     }
-    setApiUrl(apiUrl: string): boolean {
-        return this.setConfigValue("apiUrl", apiUrl) as boolean;
+    writeConfig(config: any): boolean {
+        createSessionDirIfNotExists();
+        return super.writeConfig(config);
     }
     setLastPackagePath(lastPackagePath: string): boolean {
         return this.setConfigValue("lastPackagePath", lastPackagePath) as boolean;
@@ -245,25 +272,118 @@ class SessionConfig extends DefaultFileConfig {
     setLastHubId(lastHubId: string): boolean {
         return this.setConfigValue("lastHubId", lastHubId) as boolean;
     }
-    setScope(scope: string): boolean {
-        return this.setConfigValue("scope", scope) as boolean;
-    }
-
-    validateConfigValue(key: string, value: any): boolean {
-        const valid = super.validateConfigValue(key, value);
-
-        if (!valid) {
-            return false;
-        }
-        switch (key) {
-            case "apiUrl": return isValidUrl(value);
-            default:
-                return true;
-        }
-    }
 }
 
-export const globalConfig = new GlobalConfig();
+const profileSource = {
+    default: 1,
+    config: 2,
+    envProfile: 3,
+    envProfilePath: 4,
+    flagProfile: 5,
+    flagProfilePath: 6,
+} as const;
+
+type ProfileSourceKeys = keyof typeof profileSource;
+type ProfileSourceValues = typeof profileSource[ProfileSourceKeys];
+
+export class ProfileManager {
+    protected source: ProfileSourceValues;
+    protected profile: ProfileConfig;
+
+    constructor() {
+        this.source = profileSource.default;
+        this.profile = new ProfileConfig(defaultConfigProfileFile);
+    }
+    isPathSource() {
+        return this.source === profileSource.envProfilePath || this.source === profileSource.flagProfilePath;
+    }
+    getProfileName():string {
+        if (this.isPathSource())
+            return "user configuration file";
+        return siConfig.getConfig().profile;
+    }
+    setFlagProfilePathSource() {
+        this.source = profileSource.flagProfilePath;
+    }
+    getProfileConfig(): ProfileConfig {
+        return this.profile;
+    }
+    setDefaultProfile() {
+        if (!this.validSourcePrecedence(profileSource.default)) return;
+        this.source = profileSource.default;
+        this.profile.setFilePath(defaultConfigProfileFile);
+    }
+    setConfigProfile(name: string) {
+        if (!this.validSourcePrecedence(profileSource.config)) return;
+        if (this.setProfileFromName(name)) this.source = profileSource.config;
+    }
+    setEnvProfile(name: string) {
+        if (!this.validSourcePrecedence(profileSource.envProfile)) return;
+        if (this.setProfileFromName(name)) this.source = profileSource.envProfile;
+    }
+    setEnvProfilePath(path: string) {
+        if (!this.validSourcePrecedence(profileSource.envProfilePath)) return;
+        if (this.setProfileFromFile(path)) this.source = profileSource.envProfilePath;
+    }
+    setFlagProfile(name: string) {
+        if (!this.validSourcePrecedence(profileSource.flagProfile)) return;
+        if (this.setProfileFromName(name)) this.source = profileSource.flagProfile;
+    }
+    setFlagProfilePath(path: string) {
+        if (!this.validSourcePrecedence(profileSource.flagProfilePath)) return;
+        if (this.setProfileFromFile(path)) this.source = profileSource.flagProfilePath;
+    }
+
+    protected validSourcePrecedence(incomingSource: ProfileSourceValues) {
+        return incomingSource >= this.source;
+    }
+
+    protected setProfileFromName(profileName: string):boolean {
+        if (!profileExists(profileName)) throw Error(`Unable to find profile: ${profileName}`);
+        this.profile.readOnly = false;
+        this.profile.setFilePath(profileNameToPath(profileName));
+        return true;
+    }
+
+    protected setProfileFromFile = (path:string):boolean => {
+        const fileConfig = JSON.parse(readFileSync(path, "utf-8"));
+
+        if (!this.profile.validateConfig(fileConfig)) throw Error("Invalid config file");
+        this.profile.readOnly = true;
+        this.profile.setFilePath(path);
+        return true;
+    };
+}
+
+export const profileManager = new ProfileManager();
+export const profileConfig = profileManager.getProfileConfig();
+
+const createDefaultProfileIfNotExist = () => {
+    const defaultProfile = new ProfileConfig(defaultConfigProfileFile);
+
+    if (defaultProfile.isValid()) return;
+    defaultProfile.writeConfig(defaultProfile.getDefaultConfig());
+    defaultProfile.setFilePath(defaultConfigProfileFile);
+};
+
+export const initConfig = () => {
+    createDefaultProfileIfNotExist();
+    let { profile } = siConfig.getConfig();
+
+    try {
+        if (!profile || !profileExists(profile)) {
+            siConfig.setProfile(defaultConfigName);
+            profile = defaultConfigName;
+        }
+    } catch (e: any) {
+        displayError(e);
+    }
+
+    if (envs.siConfigPathEnv) profileManager.setEnvProfilePath(envs.siConfigPathEnv);
+    else if (envs.siConfigEnv) profileManager.setEnvProfile(envs.siConfigEnv);
+    else profileManager.setConfigProfile(profile);
+};
+
 export const sessionConfig = new SessionConfig();
 
 const getDashDefaultValue = (id: string, def: string) => {

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -76,8 +76,7 @@ abstract class FileConfig extends Config {
             this.writeConfig(conf);
             return true;
         }
-        // eslint-disable-next-line no-console
-        console.error(`WARN: Unknown config entry: ${key}`);
+        displayError(`Unknown config entry: ${key}`);
         return false;
     }
 }
@@ -198,14 +197,14 @@ export class ProfileConfig extends DefaultFileConfig {
     set readOnly(readOnly: boolean) { this.readOnlyConfig = readOnly; }
     get readOnly() { return this.readOnlyConfig; }
 
-    checkIfWritable() { 
-        if (this.readOnlyConfig) throw Error("Unable to write for read only configuration"); 
+    checkIfWritable() {
+        if (this.readOnlyConfig) throw Error("Unable to write for read only configuration");
     }
 
     setConfig(config: any): boolean {
         this.checkIfWritable();
         if (typeof config !== "object" || !this.validateConfigPart(config)) return false;
-        
+
         const { log: currentLog, ...currentConfig } = this.getConfig();
         const { log: newLog, ...newConfig } = config;
         const overlap = { ...currentConfig, ...newConfig, log: { ...currentLog, ...newLog } };
@@ -272,13 +271,13 @@ export class ProfileConfig extends DefaultFileConfig {
         if (!super.validateConfigValue(key, value)) return false;
 
         switch (key) {
-            case "apiUrl": 
+            case "apiUrl":
                 return isUrl(value, {
-                    protocols: ['http','https'], 
-                    require_tld: false, 
-                    require_protocol: true, 
-                    require_port: true, 
-                    allow_underscores: true 
+                    protocols: ["http", "https"],
+                    require_tld: false,
+                    require_protocol: true,
+                    require_port: true,
+                    allow_underscores: true
                 });
             case "log": {
                 for (const [logKey, logValue] of Object.entries(value)) {

--- a/packages/cli/src/lib/errorHandler.ts
+++ b/packages/cli/src/lib/errorHandler.ts
@@ -1,0 +1,34 @@
+/* eslint-disable no-console */
+
+import { ClientError } from "@scramjet/client-utils";
+import { profileConfig } from "./config";
+import { displayError, displayMessage, displayObject } from "./output";
+
+async function jsonize(err: ClientError) {
+    if (!err.toJSON) return undefined;
+
+    return await err.toJSON().then((body) => body).catch(() => undefined);
+}
+
+const getExitCode = (_err: ClientError | Error) => 1;
+
+export const errorHandler = async (err: Error) => {
+    process.exitCode = getExitCode(err);
+    const { format, debug } = profileConfig.getConfig();
+
+    if (err instanceof ClientError) {
+        displayObject({
+            error: true,
+            code: err?.code,
+            stack: debug ? err?.stack : undefined,
+            message: err?.message,
+            reason: err?.reason?.message,
+            apiStatusCode: err?.status,
+            apiError: await jsonize(err),
+        }, format);
+    } else if (err instanceof Error) {
+        displayError(err);
+        if (debug) displayMessage(err.stack as string);
+    } else displayMessage(err);
+    process.exit();
+};

--- a/packages/cli/src/lib/errorHandler.ts
+++ b/packages/cli/src/lib/errorHandler.ts
@@ -14,7 +14,7 @@ const getExitCode = (_err: ClientError | Error) => 1;
 
 export const errorHandler = async (err: Error) => {
     process.exitCode = getExitCode(err);
-    const { format, debug } = profileConfig.getConfig();
+    const { log:{ format, debug } } = profileConfig.getConfig();
 
     if (err instanceof ClientError) {
         displayObject({

--- a/packages/cli/src/lib/output.ts
+++ b/packages/cli/src/lib/output.ts
@@ -1,18 +1,17 @@
 /* eslint-disable no-console */
 import { Readable, Stream, Writable } from "stream";
-import { globalConfig } from "./config";
 import { MaybePromise } from "@scramjet/types";
 import { inspect } from "util";
+import { displayFormat, isJsonFormat } from "../types";
 
 /**
  * Displays object.
  *
  * @param object returned object form
+ * @param format format of displayed data: pretty|json
  */
-export function displayObject(object: any) {
-    const { format } = globalConfig.getConfig();
-
-    if (globalConfig.isJsonFormat(format)) {
+export function displayObject(object: any, format: displayFormat) {
+    if (isJsonFormat(format)) {
         console.log(JSON.stringify(object));
     } else {
         console.dir(object);
@@ -50,8 +49,9 @@ export async function displayStream(
  * Displays response data.
  *
  * @param response Response object with data to be displayed.
+ * @param format format of displayed data: pretty|json
  */
-export async function displayEntity(response: MaybePromise<any>): Promise<void> {
+export async function displayEntity(response: MaybePromise<any>, format: displayFormat): Promise<void> {
     // todo: different displays depending on _program.opts().format
     const res = await Promise.resolve(response).catch((e: any) => {
         throw e;
@@ -61,7 +61,7 @@ export async function displayEntity(response: MaybePromise<any>): Promise<void> 
         return;
     }
 
-    displayObject(res);
+    displayObject(res, format);
 }
 
 export function displayMessage(message: string, ...args: any[]): void {

--- a/packages/cli/src/lib/paths.ts
+++ b/packages/cli/src/lib/paths.ts
@@ -1,35 +1,45 @@
 import { homedir, tmpdir } from "os";
-import { resolve } from "path";
+import { basename, resolve } from "path";
 import { existsSync, mkdirSync, readdirSync, rmSync } from "fs";
 import { sessionId } from "../utils/sessionId";
 
 export const configFileExt = ".json";
-export const procPath = "/proc";
 
 export const siDir = resolve(homedir(), "./.si");
 export const scopesDir = resolve(siDir, "./scopes");
-
-export const globalConfigFile = resolve(siDir, `global-config${configFileExt}`);
-
-export const siTempDir = resolve(tmpdir(), "./.si");
+export const profilesDir = resolve(siDir, "./profiles");
+export const siTempDir = resolve(tmpdir(), "./.si-tmp");
 export const sessionDir = resolve(siTempDir, `./${sessionId()}`);
 export const sessionConfigFile = resolve(sessionDir, `./session-config${configFileExt}`);
+export const siConfigFile = resolve(siDir, `si-config${configFileExt}`);
 
-export const simplyfyPath = (path: string) => {
-    if (path.startsWith(homedir())) return path.replace(homedir(), "~");
-    return path;
+export const defaultConfigName = "default";
+export const defaultConfigProfileFile = resolve(profilesDir, `${defaultConfigName}${configFileExt}`);
+
+export const listDirFileNames = (dir: string) => {
+    if (!existsSync(dir)) throw Error(`Unable to find directory: ${dir}`);
+    return readdirSync(dir).map((file) => basename(file, configFileExt));
 };
+
+export const profileExists = (name: string) => listDirFileNames(profilesDir).includes(name);
+export const profileNameToPath = (name:string) => resolve(profilesDir, `${name}${configFileExt}`);
+export const profileRemove = (name:string) => rmSync(profileNameToPath(name));
 
 const initDir = (dir: string) => {
     if (existsSync(dir)) return;
     const result = mkdirSync(dir, { recursive: true });
 
     if (result === undefined) {
-        // eslint-disable-next-line no-console
-        console.error(`WARN: Couldn't create directory ${dir}.`);
+        throw Error(`Couldn't create directory ${dir}`);
     }
 };
 
+export const createSessionDirIfNotExists = () => {
+    if (!existsSync(sessionDir))
+        initDir(sessionDir);
+};
+
+const procPath = "/proc";
 /**
  * Checks existing si session directories and compares it with list of running sessions.
  * If session no longer exists responding dir is being removed.
@@ -47,12 +57,11 @@ const clearUnusedSessionDirs = () => {
 };
 
 /**
- * Initializes paths required in project, and clean unused ones
+ * Initializes paths required in project
  */
 export const initPaths = () => {
     clearUnusedSessionDirs();
-
     initDir(siDir);
+    initDir(profilesDir);
     initDir(scopesDir);
-    initDir(sessionDir);
 };

--- a/packages/cli/src/lib/platform/common.ts
+++ b/packages/cli/src/lib/platform/common.ts
@@ -7,7 +7,7 @@ import { profileConfig, sessionConfig } from "../config";
  * @returns {MiddlewareClient} Host client.
  */
 export const getMiddlewareClient = (): MiddlewareClient => {
-    const { middlewareApiUrl, debug } = profileConfig.getConfig();
+    const { middlewareApiUrl, log:{ debug } } = profileConfig.getConfig();
 
     if (!middlewareApiUrl) {
         throw new Error("Middleware API URL is not specified");

--- a/packages/cli/src/lib/platform/common.ts
+++ b/packages/cli/src/lib/platform/common.ts
@@ -1,5 +1,6 @@
 import { MiddlewareClient } from "@scramjet/middleware-api-client";
 import { profileConfig, sessionConfig } from "../config";
+import { displayError, displayMessage } from "../output";
 
 /**
  * Returns host client for host pointed by command options.
@@ -20,15 +21,13 @@ export const getMiddlewareClient = (): MiddlewareClient => {
             ok(result: any) {
                 const { status, statusText, url } = result;
 
-                // eslint-disable-next-line no-console
-                console.error("Request ok:", url, `status: ${status} ${statusText}`);
+                displayMessage(`Request ok: ${url} status: ${status} ${statusText}`);
             },
             error(error: any) {
                 const { code, reason: result } = error;
                 const { message } = result || {};
 
-                // eslint-disable-next-line no-console
-                console.error(`Request failed with code "${code}" status: ${message}`);
+                displayError(`Request failed with code "${code}" status: ${message}`);
             },
         });
     }
@@ -63,13 +62,10 @@ export const setPlatformDefaults = async () => {
         sessionConfig.setLastSpaceId(selectedManager.id);
         sessionConfig.setLastHubId(selectedHost.id);
 
-        // eslint-disable-next-line no-console
-        console.log(`Defaults set to: Space: ${selectedManager.id}, Hub: ${selectedHost.id}`);
-
+        displayMessage(`Defaults set to: Space: ${selectedManager.id}, Hub: ${selectedHost.id}`);
         return true;
     } catch (_) {
-        // eslint-disable-next-line no-console
-        console.error("Warning: Unable to set platform defaults\n");
+        displayError("Unable to set platform defaults\n");
         return false;
     }
 };

--- a/packages/cli/src/lib/platform/common.ts
+++ b/packages/cli/src/lib/platform/common.ts
@@ -1,5 +1,5 @@
 import { MiddlewareClient } from "@scramjet/middleware-api-client";
-import { globalConfig, sessionConfig } from "../config";
+import { profileConfig, sessionConfig } from "../config";
 
 /**
  * Returns host client for host pointed by command options.
@@ -7,7 +7,7 @@ import { globalConfig, sessionConfig } from "../config";
  * @returns {MiddlewareClient} Host client.
  */
 export const getMiddlewareClient = (): MiddlewareClient => {
-    const { middlewareApiUrl, debug } = globalConfig.getConfig();
+    const { middlewareApiUrl, debug } = profileConfig.getConfig();
 
     if (!middlewareApiUrl) {
         throw new Error("Middleware API URL is not specified");
@@ -37,9 +37,9 @@ export const getMiddlewareClient = (): MiddlewareClient => {
 };
 
 export const setPlatformDefaults = async () => {
-    const session = sessionConfig.getConfig();
+    const { lastSpaceId, lastHubId } = sessionConfig.getConfig();
 
-    if (session.lastSpaceId || session.lastHubId) {
+    if (lastSpaceId || lastHubId) {
         return false;
     }
 

--- a/packages/cli/src/lib/scope.ts
+++ b/packages/cli/src/lib/scope.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
-import { existsSync, rmSync, readdirSync, readFileSync } from "fs";
+import { existsSync, rmSync, readFileSync } from "fs";
 import { basename, format } from "path";
-import { scopesDir, configFileExt } from "./paths";
+import { scopesDir, configFileExt, listDirFileNames } from "./paths";
 
 const getScopePath = (scopeName: string) => {
     const scopePath = format({ dir: scopesDir, name: scopeName, ext: configFileExt });
@@ -15,8 +15,7 @@ const getScopePath = (scopeName: string) => {
  * Prints list of available scopes
  */
 export const listScopes = () => {
-    if (existsSync(scopesDir))
-        readdirSync(scopesDir).forEach((scopeFile) => console.log(basename(scopeFile, configFileExt)));
+    listDirFileNames(scopesDir).forEach((scopeFile) => console.log(basename(scopeFile, configFileExt)));
 };
 
 /**

--- a/packages/cli/src/lib/scope.ts
+++ b/packages/cli/src/lib/scope.ts
@@ -1,13 +1,14 @@
 /* eslint-disable no-console */
 import { existsSync, rmSync, readFileSync } from "fs";
 import { basename, format } from "path";
+import { displayError, displayMessage } from "./output";
 import { scopesDir, configFileExt, listDirFileNames } from "./paths";
 
 const getScopePath = (scopeName: string) => {
     const scopePath = format({ dir: scopesDir, name: scopeName, ext: configFileExt });
 
     if (existsSync(scopePath)) return scopePath;
-    console.error(`WARN: Couldn't find scope ${scopeName}.`);
+    displayError(`Couldn't find scope ${scopeName}.`);
     return null;
 };
 
@@ -15,7 +16,7 @@ const getScopePath = (scopeName: string) => {
  * Prints list of available scopes
  */
 export const listScopes = () => {
-    listDirFileNames(scopesDir).forEach((scopeFile) => console.log(basename(scopeFile, configFileExt)));
+    listDirFileNames(scopesDir).forEach((scopeFile) => displayMessage(basename(scopeFile, configFileExt)));
 };
 
 /**
@@ -34,7 +35,7 @@ export const getScope = (scopeName: string) => {
 
         return scopeConfig;
     } catch {
-        console.error(`WARN: Parse error in config at ${scopePath}.`);
+        displayError(`Parse error in scope config at ${scopePath}.`);
         return null;
     }
 };

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -9,14 +9,23 @@ export type CommandDefinition = (program: Command) => void;
 
 export type configEnv = "development" | "production";
 export const isConfigEnv = (env: string) => ["development", "production"].includes(env);
-export type configFormat = "pretty" | "json";
-export const isConfigFormat = (format: string) => ["pretty", "json"].includes(format);
+export const isDevelopmentEnv = (env: configEnv): boolean => { return env === "development"; };
+export const isProductionEnv = (env: configEnv): boolean => { return env === "production"; };
 
-export interface GlobalConfigEntity {
+export type displayFormat = "pretty" | "json";
+export const isConfigFormat = (format: string) => ["pretty", "json"].includes(format);
+export const isJsonFormat = (format: displayFormat):boolean => { return format === "json"; };
+export const isPrettyFormat = (format: displayFormat):boolean => { return format === "pretty"; };
+
+export interface SiConfigEntity {
+    profile: string;
+}
+
+export interface ProfileConfigEntity {
     configVersion: number;
     apiUrl: string;
     debug: boolean;
-    format: configFormat;
+    format: displayFormat;
     middlewareApiUrl: string;
     env: configEnv;
     scope: string;
@@ -24,11 +33,9 @@ export interface GlobalConfigEntity {
 }
 
 export interface SessionConfigEntity {
-    apiUrl: string;
     lastPackagePath: string;
     lastInstanceId: string;
     lastSequenceId: string;
     lastSpaceId: string,
     lastHubId: string,
-    scope: string;
 }

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -24,12 +24,14 @@ export interface SiConfigEntity {
 export interface ProfileConfigEntity {
     configVersion: number;
     apiUrl: string;
-    debug: boolean;
-    format: displayFormat;
     middlewareApiUrl: string;
     env: configEnv;
     scope: string;
     token: string,
+    log: {
+        debug: boolean;
+        format: displayFormat;
+    }
 }
 
 export interface SessionConfigEntity {

--- a/packages/cli/src/utils/envs.ts
+++ b/packages/cli/src/utils/envs.ts
@@ -1,0 +1,7 @@
+export const envs = {
+    nodeEnv: process.env.NODE_ENV,
+    siConfigEnv:  process.env.SI_CONFIG,
+    siConfigPathEnv:  process.env.SI_CONFIG_PATH,
+};
+
+export const isDevelopment = () => envs.nodeEnv === "development";

--- a/packages/cli/src/utils/isDevelopment.ts
+++ b/packages/cli/src/utils/isDevelopment.ts
@@ -1,1 +1,0 @@
-export const isDevelopment = () => process.env.NODE_ENV === "development";

--- a/packages/cli/test/cliProcess.ts
+++ b/packages/cli/test/cliProcess.ts
@@ -1,0 +1,21 @@
+import { resolve as pathResolve } from "path";
+import { exec } from "child_process";
+
+type CliResult = {code: number, error: any, stdout: string | Buffer, stderr: string | Buffer};
+
+const cli = (args :string[] = [], env?: NodeJS.ProcessEnv):
+    Promise<CliResult> => {
+    return new Promise(resolve => {
+        exec(`ts-node ${pathResolve("./src/bin/index.ts")} ${args.join(" ")}`,
+            { env },
+            (error, stdout, stderr) => {
+                resolve({
+                    code: error && error.code ? error.code : 0,
+                    error,
+                    stdout,
+                    stderr });
+            });
+    });
+};
+
+export default cli;

--- a/packages/cli/test/config.spec.ts
+++ b/packages/cli/test/config.spec.ts
@@ -15,7 +15,6 @@ test("CliConfig validation test", t => {
         });
     };
 
-    const validFormat = ["json", "pretty"];
     const validEnv = ["production", "development"];
     const validToken = ["eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkphbiBLb3dhbHNraSIsImlhdCI6MTUxNjIzOTAyMn0.tgHyqtA_hPO94mvcY_zLpHBwvQeaYK7_9mgqjgFlZvQ"];
@@ -27,7 +26,6 @@ test("CliConfig validation test", t => {
     const invalidDataWithEmpty = [...invalidData, ""];
 
     testConfigValidation("apiUrl", validUrl, invalidUrl);
-    testConfigValidation("format", validFormat, invalidDataWithEmpty);
     testConfigValidation("middlewareApiUrl", [...validUrl, ""], middlewareInvalidUrl);
     testConfigValidation("env", validEnv, invalidDataWithEmpty);
     testConfigValidation("token", validToken, invalidData);

--- a/packages/cli/test/config.spec.ts
+++ b/packages/cli/test/config.spec.ts
@@ -1,0 +1,34 @@
+import { ProfileConfig } from "../src";
+
+import test from "ava";
+import { defaultConfigProfileFile } from "../src/lib/paths";
+
+test("CliConfig validation test", t => {
+    const cliConfig = new ProfileConfig(defaultConfigProfileFile);
+
+    const testConfigValidation = (key: string, validData: any[], invalidData: any[]) => {
+        validData.forEach(valid => {
+            t.truthy(cliConfig.validateConfigValue(key, valid), `${key} ${valid} truthy failed`);
+        });
+        invalidData.forEach(invalid => {
+            t.falsy(cliConfig.validateConfigValue(key, invalid), `${key} ${invalid} falsy failed`);
+        });
+    };
+
+    const validFormat = ["json", "pretty"];
+    const validEnv = ["production", "development"];
+    const validToken = ["eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkphbiBLb3dhbHNraSIsImlhdCI6MTUxNjIzOTAyMn0.tgHyqtA_hPO94mvcY_zLpHBwvQeaYK7_9mgqjgFlZvQ"];
+    const validUrl = ["http://127.0.0.1:8000/api/v1", "http://www.scramjet.org"];
+
+    const middlewareInvalidUrl = ["127.0.0", "someText", 123];
+    const invalidUrl = [...middlewareInvalidUrl, ""];
+    const invalidData = ["someText", " ", 123, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkphbiBLb3dhbHNraSIsImlhdCI6MTUxNjIzOTAyMn0tgHyqtA_hPO94mvcY_zLpHBwvQeaYK7_9mgqjgFlZv"];
+    const invalidDataWithEmpty = [...invalidData, ""];
+
+    testConfigValidation("apiUrl", validUrl, invalidUrl);
+    testConfigValidation("format", validFormat, invalidDataWithEmpty);
+    testConfigValidation("middlewareApiUrl", [...validUrl, ""], middlewareInvalidUrl);
+    testConfigValidation("env", validEnv, invalidDataWithEmpty);
+    testConfigValidation("token", validToken, invalidData);
+});


### PR DESCRIPTION
This PR changes configuration handling in CLI package.

Most important changes made to configuration:
-There are 3 configuration types inside CLI for different purpose:
	a) Profile configuration- all configurations that can be manipulated and set by user.
	b) Session configuration- configuration used inside of CLI to handle all lastSequenceId, lastInstanceId etc. Configuration is kept alive in terminal (shell session time of live) that uses CLI (as outcome every terminal will have it's own lastXXX params).
	c) Si configuration- global configuration used by all CLI processes.
-Profile configuration can be provided in two ways: 
	a) path to outside configuration file provided by user (read only file, requires all configuration fields in file)
	b) profile name to configuration handled and manipulated by CLI resources filesg
-There is always at least a default profile file.
-Order of precedence for profile configuration is added (If profile config is set with many options only highest precedence is used): 
	1) `si someCliCommand --config-path some/path/toFile`
	2) `si someCliCommand  --config profileName`
	3) process.env: `SI_CONFIG_PATH=some/path/toFile si someCliCommand` 
	4) process.env: `SI_CONFIG=profileName  si someCliCommand`
	5) `si config profile use profileName` (sets default profile to use by all CLI instances)
	6) if no other method is used default profile is used inside CLI
-User calling i.e. `si config set xxx` changes value in currently used profile (default profile aswell), if config is provided from user file exception is thrown.
-Displayed messages are formated with `si config set log --format json/pretty` options
-if error ocured stack trace can be shown/hide with `si config log --debug true/false` (or 1/0, TRUE/FALSE)

Additionoal changes:
-added validation of config fields with js validator package
-errorHandler moved to separate file for readability, and upgraded to use debug and format options from config.
-small readability fixes
-list of profiles is sorted alphabeticallly
-format and debug options in profile config are now nested in log object (i.e. log: {debug: true, format: "json"}) to match CLI api structure
-all logging messages through out the aplication is now handled by displayError, displayMessage methods instead of console.log