### PR TITLE
Return actual exit code rather than undefined

### DIFF
--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -327,7 +327,7 @@ export class CSIController extends TypedEmitter<Events> {
             return Promise.reject({ message: "Runner failed", exitcode });
         }
 
-        return Promise.resolve();
+        return Promise.resolve(exitcode);
     }
 
     async cleanup() {


### PR DESCRIPTION
**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Fix instancePromise return value in case of success (which is used for determining instance status, returned e.g. by `si inst info`).

**Why?**  <!-- What is this needed for? You can link to an issue. -->
mapRunnerExitCode() sets return value of instancePromise, which is used
in main() to determine instance status. undefined value is interpreted
as failure, we need to return 0 to indicate successful exit.
