### PR TITLE
Instance status have two new statuses: stopping and killing.

### DIFF
--- a/packages/types/src/instance.ts
+++ b/packages/types/src/instance.ts
@@ -1,2 +1,2 @@
 export type InstanceId = string;
-export type InstanceStatus = "initializing" | "starting" | "running" | "finishing" | "ended" | "errored";
+export type InstanceStatus = "initializing" | "starting" | "running" | "stopping" | "killing" | "completed" | "errored";


### PR DESCRIPTION
**What?** 
Changed Instance lifecycle status. It was:
"initializing" | "starting" | "running" | "finishing" | "ended" | "errored"
now it's:
"initializing" | "starting" | "running" | "stopping" | "killing" | "completed" | "errored"

Added more info in instance/kill instance/stop responses. There will be instance.getInfo() since getInfo is not async anymore.
Kill method response will have killing status and Stop method will have stopping status along with other instance information.


**Why?** 
That change is filling the status gap between kill request and new status beeing set.


**Usage:**
```bash
# setup MW, MM and start a Hub
yarn start:dev:multi-manager
SCRAMJET_MM_URL=http://localhost:11000 ts-node cpm/packages/middleware/src/bin/start.ts --idkfa
curl -X POST 'localhost:11000/api/v1/start'   -H 'Accept: */*'   -H 'Content-Type: application/json'   -d '{"manager": {"id": "mgr-1"}}'
yarn start:dev:sth --cpm-url="localhost:11000" --cpm-id="mgr-1" --id hub-1
# send an example sequence
cat hello.tar.gz | curl -X POST --data-binary @- localhost:7000/api/v1/space/mgr-1/api/v1/sth/hub-1/api/v1/sequence -H "Content-Type:application/octet-stream" --verbose
# check if the sequence is in place
curl 'localhost:7000/api/v1/space/mgr-1/api/v1/sth/hub-1/api/v1/sequences'
# start the sequence
curl -X POST --header 'content-type: application/json' --data-raw '{"appConfig": {},"args": []}' 'localhost:7000/api/v1/space/mgr-1/api/v1/sth/hub-1/api/v1/sequence/SEQUENCE_ID/start' --verbose
# check the instances notice the status
curl 'localhost:7000/api/v1/space/mgr-1/api/v1/sth/hub-1/api/v1/instances'
# kill the instance
curl -X POST --header 'content-type: application/json' 'localhost:7000/api/v1/space/mgr-1/api/v1/sth/hub-1/api/v1/instance/INSTANCE_ID/_kill'
# check if the instance changed it's status
curl 'localhost:7000/api/v1/space/mgr-1/api/v1/sth/hub-1/api/v1/instances'
```
