### PR TITLE
Update build-all

### DIFF
--- a/scripts/build-all.js
+++ b/scripts/build-all.js
@@ -132,6 +132,7 @@ console.time(BUILD_NAME);
         const outDir = resolve(opts.root, opts.outdir);
         const prepacks = packages.map((root) => new PrePack({
             cwd: root,
+            rootDir: opts.root,
             outDir,
             log: () => 0,
             distPackDir: opts.outdir,


### PR DESCRIPTION
**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Add missing `root` option handling.

**Why?**  <!-- What is this needed for? You can link to an issue. -->
Looks like this was accidentally omitted.
