### PR TITLE
Feat/api server op raw body

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -134,7 +134,7 @@
         "func-style" : 0,
         "id-length" : 0,
         "id-match": 0,
-        "indent": [1, 4],
+        "indent": [1, 4, { "SwitchCase": 1 }],
         "key-spacing" : [0, {"beforeColon" : true, "afterColon" : true}],
         "lines-around-comment" : 0,
         "linebreak-style" : [2, "unix"],

--- a/packages/api-server/src/handlers/op.ts
+++ b/packages/api-server/src/handlers/op.ts
@@ -28,7 +28,7 @@ export function createOperationHandler(router: SequentialCeroRouter): APIRoute["
     /**
      * Checking content-type and getting encoding from request
      * @param {IncomingMessage} req Request object.
-     * @param {boolean} rawBody Flag if the body will be parsed.
+     * @param {OpOptions} options Options for encoding getter.
      * @returns BufferEncoding string
      */
     const getEncoding = (req: IncomingMessage, { rawBody }: OpOptions = {}): BufferEncoding => {
@@ -73,7 +73,7 @@ export function createOperationHandler(router: SequentialCeroRouter): APIRoute["
      * Tries to parse data from the request body.
      *
      * @param {IncomingMessage} req Request object.
-     * @param {boolean} rawBody Flag if the body will be parsed.
+     * @param {OpOptions} options Options for data parser.
      * @returns JSON object.
      */
     const getData = async (req: IncomingMessage, { rawBody }: OpOptions = {}): Promise<object | undefined> => {
@@ -92,11 +92,15 @@ export function createOperationHandler(router: SequentialCeroRouter): APIRoute["
      * @param {IncomingMessage} req Request object.
      * @param {ServerResponse} res Server response.
      * @param {OpResolver} resolver Data callback
-     * @param {boolean} rawBody Flag if the body will be parsed.
+     * @param {OpOptions} options Handler options.
      * @returns void
      */
-    const opDataHandler = async (req: ParsedMessage, res: ServerResponse, resolver: OpResolver,
-        { rawBody }: OpOptions = {}) => {
+    const opDataHandler = async (
+        req: ParsedMessage,
+        res: ServerResponse,
+        resolver: OpResolver,
+        { rawBody }: OpOptions = {}
+    ) => {
         req.body = await getData(req, { rawBody });
 
         const result = await resolver(req, res);

--- a/packages/api-server/src/handlers/op.ts
+++ b/packages/api-server/src/handlers/op.ts
@@ -30,7 +30,7 @@ export function createOperationHandler(router: SequentialCeroRouter): APIRoute["
      * @param {boolean} rawBody Flag if the body will be parsed.
      * @returns BufferEncoding string
      */
-    const getEncoding = (req: IncomingMessage, { rawBody: boolean = false }): BufferEncoding => {
+    const getEncoding = (req: IncomingMessage, { rawBody: false }: OpOptions): BufferEncoding => {
         if (!req.headers["content-type"]) throw new CeroError("ERR_INVALID_CONTENT_TYPE");
 
         if (!rawBody) mimeAccepts(req.headers["content-type"], ["application/json", "text/json"]);
@@ -75,13 +75,12 @@ export function createOperationHandler(router: SequentialCeroRouter): APIRoute["
      * @param {boolean} rawBody Flag if the body will be parsed.
      * @returns JSON object.
      */
-    const getData = async (req: IncomingMessage, rawBody?: boolean): Promise<object | undefined> => {
-        const encoding = getEncoding(req, rawBody);
+    const getData = async (req: IncomingMessage, { rawBody }: OpOptions): Promise<object | undefined> => {
+        const encoding = getEncoding(req, { rawBody });
         const body = await getBody(req, encoding);
 
         try {
-
-            return body && rawBody ? body : JSON.parse(body);
+            return body && (rawBody ? body : JSON.parse(body));
         } catch (e: any) {
             throw new CeroError("ERR_CANNOT_PARSE_CONTENT");
         }
@@ -95,7 +94,7 @@ export function createOperationHandler(router: SequentialCeroRouter): APIRoute["
      * @param {boolean} rawBody Flag if the body will be parsed.
      * @returns void
      */
-    const opDataHandler = async (req: ParsedMessage, res: ServerResponse, resolver: OpResolver, rawBody?: boolean) => {
+    const opDataHandler = async (req: ParsedMessage, res: ServerResponse, resolver: OpResolver, { rawBody }: OpOptions) => {
         req.body = await getData(req, rawBody);
 
         const result = await resolver(req, res);

--- a/packages/api-server/src/handlers/op.ts
+++ b/packages/api-server/src/handlers/op.ts
@@ -30,7 +30,7 @@ export function createOperationHandler(router: SequentialCeroRouter): APIRoute["
      * @param {boolean} rawBody Flag if the body will be parsed.
      * @returns BufferEncoding string
      */
-    const getEncoding = (req: IncomingMessage, rawBody: boolean = false): BufferEncoding => {
+    const getEncoding = (req: IncomingMessage, { rawBody: boolean = false }): BufferEncoding => {
         if (!req.headers["content-type"]) throw new CeroError("ERR_INVALID_CONTENT_TYPE");
 
         if (!rawBody) mimeAccepts(req.headers["content-type"], ["application/json", "text/json"]);
@@ -80,11 +80,8 @@ export function createOperationHandler(router: SequentialCeroRouter): APIRoute["
         const body = await getBody(req, encoding);
 
         try {
-            if (!body) {
-                return undefined;
-            }
 
-            return rawBody ? body : JSON.parse(body);
+            return body && rawBody ? body : JSON.parse(body);
         } catch (e: any) {
             throw new CeroError("ERR_CANNOT_PARSE_CONTENT");
         }

--- a/packages/api-server/src/handlers/op.ts
+++ b/packages/api-server/src/handlers/op.ts
@@ -77,10 +77,10 @@ export function createOperationHandler(router: SequentialCeroRouter): APIRoute["
      * @returns JSON object.
      */
     const getData = async (req: IncomingMessage, { rawBody }: OpOptions = {}): Promise<object | undefined> => {
-        const encoding = getEncoding(req, { rawBody });
-        const body = await getBody(req, encoding);
-
         try {
+            const encoding = getEncoding(req, { rawBody });
+            const body = await getBody(req, encoding);
+
             return body && (rawBody ? body : JSON.parse(body));
         } catch (e: any) {
             throw new CeroError("ERR_CANNOT_PARSE_CONTENT");

--- a/packages/types/src/api-expose.ts
+++ b/packages/types/src/api-expose.ts
@@ -5,13 +5,13 @@ import { ICommunicationHandler } from "./communication-handler";
 import { ControlMessageCode, MonitoringMessageCode } from "./message-streams";
 import { MaybePromise } from "./utils";
 
-export type ParsedMessage = IncomingMessage & { body?: any, params: { [key: string]: any } | undefined };
+export type ParsedMessage = IncomingMessage & { body?: any; params: { [key: string]: any } | undefined };
 export type HttpMethod = "get" | "head" | "post" | "put" | "delete" | "connect" | "trace" | "patch";
 
 export type StreamInput =
-    ((req: ParsedMessage, res: ServerResponse) => MaybePromise<Readable>) | MaybePromise<Readable>;
-export type StreamOutput =
-    ((req: ParsedMessage, res: ServerResponse) => MaybePromise<any>) | MaybePromise<Writable>;
+    | ((req: ParsedMessage, res: ServerResponse) => MaybePromise<Readable>)
+    | MaybePromise<Readable>;
+export type StreamOutput = ((req: ParsedMessage, res: ServerResponse) => MaybePromise<any>) | MaybePromise<Writable>;
 export type GetResolver = (req: ParsedMessage) => MaybePromise<any>;
 export type OpResolver = (req: ParsedMessage, res?: ServerResponse) => MaybePromise<any>;
 
@@ -83,7 +83,12 @@ export interface APIBase {
      * @param conn the communication handler to use
      */
     op<T extends ControlMessageCode>(
-        method: HttpMethod, path: string | RegExp, message: OpResolver | T, conn?: ICommunicationHandler): void;
+        method: HttpMethod,
+        path: string | RegExp,
+        message: OpResolver | T,
+        comm?: ICommunicationHandler,
+        rawBody?: boolean
+    ): void;
 
     /**
      * Simple GET request hook for static data in monitoring stream.
@@ -92,8 +97,7 @@ export interface APIBase {
      * @param op which operation
      * @param conn the communication handler to use
      */
-    get<T extends MonitoringMessageCode>(
-        path: string | RegExp, msg: T, conn: ICommunicationHandler): void;
+    get<T extends MonitoringMessageCode>(path: string | RegExp, msg: T, conn: ICommunicationHandler): void;
 
     /**
      * Alternative GET request hook with dynamic resolution
@@ -110,11 +114,7 @@ export interface APIBase {
      * @param stream the stream that will be sent in reposnse body or a method to be called then
      * @param config configuration of the stream
      */
-    upstream(
-        path: string | RegExp,
-        stream: StreamInput,
-        config?: StreamConfig
-    ): void;
+    upstream(path: string | RegExp, stream: StreamInput, config?: StreamConfig): void;
 
     /**
      * A method that allows to consume incoming stream from the specified path on the API server
@@ -123,11 +123,7 @@ export interface APIBase {
      * @param stream the output that will be piped to from request or a method to be called then
      * @param config configuration of the stream
      */
-    downstream(
-        path: string | RegExp,
-        stream: StreamOutput,
-        config?: StreamConfig
-    ): void;
+    downstream(path: string | RegExp, stream: StreamOutput, config?: StreamConfig): void;
 
     /**
      * Allows to handle dual direction (duplex) streams.
@@ -135,10 +131,7 @@ export interface APIBase {
      * @param path the request path as string or regex
      * @param callback A method to be called when the stream is ready.
      */
-    duplex(
-        path: string | RegExp,
-        callback: (stream: Duplex, headers: IncomingHttpHeaders) => void
-    ): void;
+    duplex(path: string | RegExp, callback: (stream: Duplex, headers: IncomingHttpHeaders) => void): void;
 
     /**
      * Allows to register middlewares for specific paths, for all HTTP methods.
@@ -153,9 +146,9 @@ export interface APIExpose extends APIBase {
     /**
      * The raw HTTP server
      */
-    server: Server
-    log: DataStream
-    decorate(path: string | RegExp, ...decorators: Decorator[]): void
+    server: Server;
+    log: DataStream;
+    decorate(path: string | RegExp, ...decorators: Decorator[]): void;
 }
 
 export interface APIRoute extends APIBase {

--- a/packages/types/src/api-expose.ts
+++ b/packages/types/src/api-expose.ts
@@ -14,6 +14,7 @@ export type StreamInput =
 export type StreamOutput = ((req: ParsedMessage, res: ServerResponse) => MaybePromise<any>) | MaybePromise<Writable>;
 export type GetResolver = (req: ParsedMessage) => MaybePromise<any>;
 export type OpResolver = (req: ParsedMessage, res?: ServerResponse) => MaybePromise<any>;
+export type OpOptions = { rawBody?: boolean };
 
 export type NextCallback = (err?: Error) => void;
 export type Middleware = (req: ParsedMessage, res: ServerResponse, next: NextCallback) => void;


### PR DESCRIPTION
**What?** 
Basically it's just the rawBody flag added to the router.op method for endpoints which require raw body data.


**Why?**
Stripe webhook event signature verification is done on raw request body data. Hence the flag is needed to turn off the default JSON.parse 


**Usage:**
It's the last parameter.
```ts
        this.api.op(
            "post",
            "/webhook/payments",
            (req: ParsedMessage) => this.paymentsWebhookHandler(req),
            undefined,
            true
        );
```

**How it works:**
The handlers/op.ts was refactored. To understand it better the core feature here is parameter named rawBody. Scan code in search for that variable.