### PR TITLE
GHA workflow for publishing to NPM & Docker Hub

### DIFF
--- a/.github/workflows/_main_sth-build-test-node-14.yml
+++ b/.github/workflows/_main_sth-build-test-node-14.yml
@@ -33,8 +33,6 @@ jobs:
 
   build-docker-runner-py-image:
     uses: ./.github/workflows/build-docker-runner-python.yml
-    with:
-      node-version: 14.x
 
   build-docker-pre-runner-image:
     uses: ./.github/workflows/build-docker-prerunner.yml

--- a/.github/workflows/_main_sth-build-test-node-16.yml
+++ b/.github/workflows/_main_sth-build-test-node-16.yml
@@ -33,8 +33,6 @@ jobs:
 
   build-docker-runner-py-image:
     uses: ./.github/workflows/build-docker-runner-python.yml
-    with:
-      node-version: 16.x
 
   build-docker-pre-runner-image:
     uses: ./.github/workflows/build-docker-prerunner.yml

--- a/.github/workflows/build-docker-prerunner.yml
+++ b/.github/workflows/build-docker-prerunner.yml
@@ -22,19 +22,25 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
 
-      - name: Build runner Docker image
-        run: docker build -q -t scramjetorg/pre-runner:$(git rev-parse HEAD) .
+      - name: Build image
+        run: docker build -t scramjetorg/pre-runner:$(git rev-parse HEAD) .
         working-directory: packages/pre-runner
 
-      - name: Export Docker images
-        run: echo "$(docker images)" |awk '/scramjet/{print $1,$2,$3,$1}' |sed 's|/|_|2' | while read repo tag id name; do docker save $id -o dockerPreRunnerImg-$name-$tag-${{ inputs.node-version }}-${{ github.event.pull_request.head.sha }}.tar $repo:$tag ; done
+      - name: Export image
+        run: >
+          docker images |
+          awk '/scramjet/{print $1,$2,$3}' |
+          sed 's|/| |' |
+          while read repo name tag id; do
+            docker save $repo/$name:$tag -o $repo-$name-$tag-node-${{ inputs.node-version }}-docker-image.tar
+          done
 
-      - name: Zip Docker images
-        run: pigz docker*Img*.tar
+      - name: Zip image
+        run: pigz *-docker-image.tar
 
-      - name: Archive production artifacts
+      - name: Upload image as an artifact
         uses: actions/upload-artifact@v2
         with:
-          name:  dockerPreRunnerImg-${{ inputs.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
+          name: pre-runner-image
           path: '*.tar.gz'
           retention-days: 1

--- a/.github/workflows/build-docker-prerunner.yml
+++ b/.github/workflows/build-docker-prerunner.yml
@@ -7,6 +7,11 @@ on:
         required: false
         default: '16.x'
         type: string
+      git-revision:
+        required: false
+        default: ${{ github.sha }}
+        type: string
+
 
 jobs:
   build-docker-prerunner-image:
@@ -16,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.git-revision }}
 
       - name: Setup Nodejs ${{ inputs.node-version }}
         uses: actions/setup-node@v2

--- a/.github/workflows/build-docker-runner-node.yml
+++ b/.github/workflows/build-docker-runner-node.yml
@@ -23,24 +23,30 @@ jobs:
           node-version: ${{ inputs.node-version }}
 
       - name: Install dependencies
-        run: yarn install --ignore-engines  --frozen-lockfile --prefer-offline --silent
+        run: yarn install --ignore-engines --frozen-lockfile --prefer-offline
 
       - name: Prebuild packages
         run: scripts/run-script.js --scope packages/runner prebuild:docker
 
-      - name: build runner Docker image
-        run: docker build -q -t scramjetorg/runner:$(git rev-parse HEAD) -f Dockerfile ../../
+      - name: Build image
+        run: docker build -t scramjetorg/runner:$(git rev-parse HEAD) -f Dockerfile ../../
         working-directory: packages/runner
 
-      - name: Export Docker images
-        run: echo "$(docker images)" |awk '/scramjet/{print $1,$2,$3,$1}' |sed 's|/|_|2' | while read repo tag id name; do docker save $id -o dockerRunnerImg-$name-$tag-${{ inputs.node-version }}-${{ github.event.pull_request.head.sha }}.tar $repo:$tag ; done
+      - name: Export image
+        run: >
+          docker images |
+          awk '/scramjet/{print $1,$2,$3}' |
+          sed 's|/| |' |
+          while read repo name tag id; do
+            docker save $repo/$name:$tag -o $repo-$name-$tag-node-${{ inputs.node-version }}-docker-image.tar
+          done
 
-      - name: Zip Docker images
-        run: pigz docker*Img*.tar
+      - name: Zip image
+        run: pigz *-docker-image.tar
 
-      - name: Archive production artifacts
+      - name: Upload image as an artifact
         uses: actions/upload-artifact@v2
         with:
-          name:  dockerRunnerImg-${{ inputs.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
+          name: runner-node-image
           path: '*.tar.gz'
           retention-days: 1

--- a/.github/workflows/build-docker-runner-node.yml
+++ b/.github/workflows/build-docker-runner-node.yml
@@ -7,6 +7,11 @@ on:
         required: false
         default: '16.x'
         type: string
+      git-revision:
+        required: false
+        default: ${{ github.sha }}
+        type: string
+
 
 jobs:
   build-docker-runner-node-image:
@@ -16,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.git-revision }}
 
       - name: Setup Nodejs ${{ inputs.node-version }}
         uses: actions/setup-node@v2

--- a/.github/workflows/build-docker-runner-python.yml
+++ b/.github/workflows/build-docker-runner-python.yml
@@ -7,6 +7,10 @@ on:
         required: false
         default: '3.9'
         type: string
+      git-revision:
+        required: false
+        default: ${{ github.sha }}
+        type: string
 
 jobs:
   build-docker-runner-python-image:
@@ -16,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.git-revision }}
 
       - name: Build image
         run: docker build -t scramjetorg/runner-py:$(git rev-parse HEAD) -f Dockerfile ../../

--- a/.github/workflows/build-docker-runner-python.yml
+++ b/.github/workflows/build-docker-runner-python.yml
@@ -3,10 +3,6 @@ name: Build Runner Docker Image Python
 on:
   workflow_call:
     inputs:
-      node-version:
-        required: false
-        default: '16.x'
-        type: string
       python-version:
         required: false
         default: '3.9'
@@ -21,19 +17,25 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: build runner Docker image
-        run: docker build -q -t scramjetorg/runner-py:$(git rev-parse HEAD) -f Dockerfile ../../
+      - name: Build image
+        run: docker build -t scramjetorg/runner-py:$(git rev-parse HEAD) -f Dockerfile ../../
         working-directory: packages/python-runner
 
-      - name: Export Docker images
-        run: echo "$(docker images)" |awk '/scramjet/{print $1,$2,$3,$1}' |sed 's|/|_|2' | while read repo tag id name; do docker save $id -o dockerRunnerPyImg-$name-$tag-${{ inputs.python-version }}-${{ github.event.pull_request.head.sha }}.tar $repo:$tag ; done
+      - name: Export image
+        run: >
+          docker images |
+          awk '/scramjet/{print $1,$2,$3}' |
+          sed 's|/| |' |
+          while read repo name tag id; do
+            docker save $repo/$name:$tag -o $repo-$name-$tag-docker-image.tar
+          done
 
-      - name: Zip Docker images
-        run: pigz docker*Img*.tar
+      - name: Zip image
+        run: pigz *-docker-image.tar
 
-      - name: Archive production artifacts
+      - name: Upload image as an artifact
         uses: actions/upload-artifact@v2
         with:
-          name:  dockerRunnerPyImg-${{ inputs.python-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
+          name: runner-python-image
           path: '*.tar.gz'
           retention-days: 1

--- a/.github/workflows/build-docker-sth.yml
+++ b/.github/workflows/build-docker-sth.yml
@@ -7,6 +7,10 @@ on:
         required: false
         default: '16.x'
         type: string
+      git-revision:
+        required: false
+        default: ${{ github.sha }}
+        type: string
 
 jobs:
   build-docker-sth-image:
@@ -16,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.git-revision }}
 
       - name: Setup Nodejs ${{ inputs.node-version }}
         uses: actions/setup-node@v2

--- a/.github/workflows/build-docker-sth.yml
+++ b/.github/workflows/build-docker-sth.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: ${{ inputs.node-version }}
 
       - name: Install dependencies
-        run: yarn install --ignore-engines  --frozen-lockfile --prefer-offline --silent
+        run: yarn install --ignore-engines --frozen-lockfile --prefer-offline
 
       - name: Update saved git hash
         run: yarn savehash
@@ -32,15 +32,21 @@ jobs:
       - name: Build sth Docker image
         run: scripts/run-script.js --scope @scramjet/sth build:docker
 
-      - name: Export Docker images
-        run: echo "$(docker images)" |awk '/scramjet/{print $1,$2,$3,$1}' |sed 's|/|_|2' | while read repo tag id name; do docker save $id -o dockerSthImg-$name-$tag-${{ inputs.node-version }}-${{ github.event.pull_request.head.sha }}.tar $repo:$tag ; done
+      - name: Export image
+        run: >
+          docker images |
+          awk '/scramjet/{print $1,$2,$3}' |
+          sed 's|/| |' |
+          while read repo name tag id; do
+            docker save $repo/$name:$tag -o $repo-$name-$tag-node-${{ inputs.node-version }}-docker-image.tar
+          done
 
-      - name: Zip Docker images
-        run: pigz docker*Img*.tar
+      - name: Zip image
+        run: pigz *-docker-image.tar
 
-      - name: Archive production artifacts
+      - name: Upload image as an artifact
         uses: actions/upload-artifact@v2
         with:
-          name:  dockerSthImg-${{ inputs.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
+          name: sth-image
           path: '*.tar.gz'
           retention-days: 1

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,125 @@
+name: Publish new release to NPM and Docker hub
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        type: string
+        description: Version tag (without leading 'v')
+
+
+jobs:
+  sth-image:
+    uses: ./.github/workflows/build-docker-sth.yml
+    with:
+      git-revision: v${{ inputs.version }}
+
+  runner-image:
+    uses: ./.github/workflows/build-docker-runner-node.yml
+    with:
+      git-revision: v${{ inputs.version }}
+
+  runner-py-image:
+    uses: ./.github/workflows/build-docker-runner-python.yml
+    with:
+      git-revision: v${{ inputs.version }}
+
+  pre-runner-image:
+    uses: ./.github/workflows/build-docker-prerunner.yml
+    with:
+      git-revision: v${{ inputs.version }}
+
+
+  docker-hub-publish:
+    name: Push images to Docker Hub
+    needs: [sth-image, runner-image, runner-py-image, pre-runner-image]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: v${{ inputs.version }}
+
+      - name: Get release version number & commit
+        run: |
+          echo "COMMIT_ID=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
+
+      - name: Download docker images
+        uses: actions/download-artifact@v3
+        with:
+          path: docker-images
+
+      - name: Unzip docker images
+        run: pigz -d docker-images/*/*-docker-image.tar.gz
+
+      - name: Load docker images
+        run: ls -1 docker-images/*/*-docker-image.tar | while read line; do docker load -i $line; done
+
+      - name: Tag images with release version
+        run: |
+          docker tag scramjetorg/sth:$COMMIT_ID scramjetorg/sth:latest
+          docker tag scramjetorg/sth:$COMMIT_ID scramjetorg/sth:$RELEASE_VERSION
+          docker tag scramjetorg/runner:$COMMIT_ID scramjetorg/runner:latest
+          docker tag scramjetorg/runner:$COMMIT_ID scramjetorg/runner:$RELEASE_VERSION
+          docker tag scramjetorg/runner-py:$COMMIT_ID scramjetorg/runner-py:latest
+          docker tag scramjetorg/runner-py:$COMMIT_ID scramjetorg/runner-py:$RELEASE_VERSION
+          docker tag scramjetorg/pre-runner:$COMMIT_ID scramjetorg/pre-runner:latest
+          docker tag scramjetorg/pre-runner:$COMMIT_ID scramjetorg/pre-runner:$RELEASE_VERSION
+
+      - name: List docker images for inspection
+        run: docker image ls
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: scramjetci
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Push images to Docker Hub
+        run: |
+          docker push scramjetorg/sth:latest
+          docker push scramjetorg/sth:$RELEASE_VERSION
+          docker push scramjetorg/runner:latest
+          docker push scramjetorg/runner:$RELEASE_VERSION
+          docker push scramjetorg/runner-py:latest
+          docker push scramjetorg/runner-py:$RELEASE_VERSION
+          docker push scramjetorg/pre-runner:latest
+          docker push scramjetorg/pre-runner:$RELEASE_VERSION
+
+
+  npm-publish:
+    name: Publish packages to NPM
+    needs: [docker-hub-publish]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Nodejs 16
+        uses: actions/setup-node@v2
+        with:
+          cache: 'yarn'
+          node-version: 16
+
+      - name: Configure npm registry access
+        run: |
+          echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }} > ~/.npmrc
+          echo always-auth=true >> ~/.npmrc
+          echo @scramjet:registry=https://registry.npmjs.org/ >> ~/.npmrc
+          chmod 600 ~/.npmrc
+
+      - name: Install dependencies
+        run: yarn install --ignore-engines  --frozen-lockfile --prefer-offline --silent
+
+      - name: Update saved git hash for marking build version
+        run: yarn savehash
+
+      - name: Build packages in publication mode
+        run: yarn pack:pub
+
+      - name: Publish packages to NPM
+        run: ./scripts/publish-order-dist-packages.js -s -p

--- a/.github/workflows/test-bdd-docker.yml
+++ b/.github/workflows/test-bdd-docker.yml
@@ -37,29 +37,29 @@ jobs:
         with:
           name: dist-refapps-${{ github.event.pull_request.head.sha }}-${{ inputs.node-version }}.tar.gz
 
-      - name: Download dockerImg Runner Node artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: dockerRunnerImg-${{ inputs.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
-
-      - name: Download dockerImg Runner Python artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: dockerRunnerPyImg-${{ inputs.python-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
-
-      - name: Download dockerPreRunnerImg artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: dockerPreRunnerImg-${{ inputs.node-version }}-${{ github.event.pull_request.head.sha }}.tar.gz
-
-      - name: Unzip dockerImg-${{ github.event.pull_request.head.sha }}-${{ inputs.node-version }}.tar.gz artifact
-        run: pigz -d docker*Img*.tar.gz
-
       - name: Unzip dist-${{ github.event.pull_request.head.sha }}-${{ inputs.node-version }}.tar.gz artifact
-        run: ls dist*tar.gz |xargs -n1 tar -I pigz -xf
+        run: ls dist*tar.gz | xargs -n1 tar -I pigz -xf
 
-      - name: Load Docker images
-        run: ls -1  docker*Img*.tar| while read line; do docker load -i $line; done
+      - name: Download node runner artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: runner-node-image
+
+      - name: Download python runner artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: runner-python-image
+
+      - name: Download pre-runner artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: pre-runner-image
+
+      - name: Unzip docker images from artifacts
+        run: pigz -d *-docker-image.tar.gz
+
+      - name: Load docker images
+        run: ls -1 *-docker-image.tar | while read line; do docker load -i $line; done
 
       - name: Setup Nodejs ${{ inputs.node-version }}
         uses: actions/setup-node@v2


### PR DESCRIPTION
<!-- If writing isn't your strength, ask @jan-warchol for help ;) -->
<!-- (or join our Discord https://discord.com/invite/ngXmwvjSYF)  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
* Refactor docker image building workflows a bit (first commit)
* Add a new manually triggered workflow that builds npm packages and docker images for specified release tag, and then pushes them to NPM registry and Docker Hub, respectively (second commit)

**Why?**  <!-- What is this needed for? You can link to an issue. -->
Migrate release publishing job from Jenkins to GHA; we want to deprecate Jenkins. https://app.clickup.com/t/24308805/SCP-3841


**Usage:**
<!-- Example (if applicable), how to verify (if not covered by tests). -->
After the workflow will be merged to the default branch, it will be possible to trigger it from the "actions" tab. Unfortunately manually triggered workflows cannot be ran until they are on default branch.

<!--------------------- For non-trivial changes: ---------------------->

**How it works:**
<!-- Share some starting points for understanding the code. -->
about refactor:
- don't parameterize python runner with node version
- show docker build output and yarn install output
- simplify artifact names (detailed info about the images is already
  included in the filename inside the artifact - making the artifact
  name simpler will make downloading it simpler, too, as we won't have
  to construct a complicated name).

new workflow
- trigger docker builds for all major components
- then collect images, tag them with release version and push
- one job for building packages and publishing to NPM (after images are pushed successfully)
