### PR TITLE
Prepare release 0.24.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,8 +170,10 @@ Bugfixes and minor improvements:
 - Fix CLI errors on Windows
 - AuditStream limit info
 - Remove zombie instances
+- Update missing types for kill/stop responses
+- Restore instances details in /instances endpoint
+- Fix si seq prune command
 
-
-## @scramjet/transform Hub - v0.24.2
+## @scramjet/transform Hub - v0.24.3
 
 This is the last release in changelog.

--- a/docs/adapters/classes/DockerodeDockerHelper.md
+++ b/docs/adapters/classes/DockerodeDockerHelper.md
@@ -64,7 +64,7 @@ Object with container's standard I/O streams.
 
 #### Defined in
 
-[dockerode-docker-helper.ts:269](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L269)
+[dockerode-docker-helper.ts:278](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L278)
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 #### Defined in
 
-[dockerode-docker-helper.ts:361](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L361)
+[dockerode-docker-helper.ts:370](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L370)
 
 ___
 
@@ -152,7 +152,7 @@ ___
 
 #### Defined in
 
-[dockerode-docker-helper.ts:365](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L365)
+[dockerode-docker-helper.ts:374](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L374)
 
 ___
 
@@ -180,7 +180,7 @@ Volume name.
 
 #### Defined in
 
-[dockerode-docker-helper.ts:233](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L233)
+[dockerode-docker-helper.ts:242](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L242)
 
 ___
 
@@ -204,7 +204,7 @@ ___
 
 #### Defined in
 
-[dockerode-docker-helper.ts:347](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L347)
+[dockerode-docker-helper.ts:356](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L356)
 
 ___
 
@@ -224,7 +224,7 @@ ___
 
 #### Defined in
 
-[dockerode-docker-helper.ts:169](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L169)
+[dockerode-docker-helper.ts:178](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L178)
 
 ___
 
@@ -242,7 +242,7 @@ ___
 
 #### Defined in
 
-[dockerode-docker-helper.ts:342](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L342)
+[dockerode-docker-helper.ts:351](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L351)
 
 ___
 
@@ -262,7 +262,7 @@ Lists existing volumes
 
 #### Defined in
 
-[dockerode-docker-helper.ts:254](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L254)
+[dockerode-docker-helper.ts:263](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L263)
 
 ___
 
@@ -289,7 +289,7 @@ Fetches the image from repo
 
 #### Defined in
 
-[dockerode-docker-helper.ts:175](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L175)
+[dockerode-docker-helper.ts:184](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L184)
 
 ___
 
@@ -317,7 +317,7 @@ Promise which resolves when container has been removed.
 
 #### Defined in
 
-[dockerode-docker-helper.ts:155](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L155)
+[dockerode-docker-helper.ts:164](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L164)
 
 ___
 
@@ -345,7 +345,7 @@ Promise which resolves when volume has been removed.
 
 #### Defined in
 
-[dockerode-docker-helper.ts:250](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L250)
+[dockerode-docker-helper.ts:259](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L259)
 
 ___
 
@@ -373,7 +373,7 @@ Starts container.
 
 #### Defined in
 
-[dockerode-docker-helper.ts:279](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L279)
+[dockerode-docker-helper.ts:288](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L288)
 
 ___
 
@@ -429,7 +429,7 @@ Promise which resolves with container statistics.
 
 #### Defined in
 
-[dockerode-docker-helper.ts:165](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L165)
+[dockerode-docker-helper.ts:174](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L174)
 
 ___
 
@@ -514,7 +514,7 @@ Container exit code.
 
 #### Defined in
 
-[dockerode-docker-helper.ts:336](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L336)
+[dockerode-docker-helper.ts:345](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L345)
 
 ## Constructors
 
@@ -558,4 +558,4 @@ ___
 
 #### Defined in
 
-[dockerode-docker-helper.ts:173](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L173)
+[dockerode-docker-helper.ts:182](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/dockerode-docker-helper.ts#L182)

--- a/docs/api-client/classes/InstanceClient.md
+++ b/docs/api-client/classes/InstanceClient.md
@@ -161,7 +161,7 @@ Promise resolving to event data.
 
 #### Defined in
 
-[api-client/src/instance-client.ts:119](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L119)
+[api-client/src/instance-client.ts:121](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L121)
 
 ___
 
@@ -185,7 +185,7 @@ stream of events from Instance
 
 #### Defined in
 
-[api-client/src/instance-client.ts:129](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L129)
+[api-client/src/instance-client.ts:131](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L131)
 
 ___
 
@@ -203,7 +203,7 @@ Promise resolving to Instance health.
 
 #### Defined in
 
-[api-client/src/instance-client.ts:138](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L138)
+[api-client/src/instance-client.ts:140](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L140)
 
 ___
 
@@ -221,7 +221,7 @@ Promise resolving to Instance info.
 
 #### Defined in
 
-[api-client/src/instance-client.ts:147](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L147)
+[api-client/src/instance-client.ts:149](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L149)
 
 ___
 
@@ -245,7 +245,7 @@ Promise resolving to event data.
 
 #### Defined in
 
-[api-client/src/instance-client.ts:108](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L108)
+[api-client/src/instance-client.ts:110](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L110)
 
 ___
 
@@ -270,25 +270,32 @@ Promise resolving to readable stream.
 
 #### Defined in
 
-[api-client/src/instance-client.ts:158](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L158)
+[api-client/src/instance-client.ts:160](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L160)
 
 ___
 
 ### kill
 
-▸ **kill**(): `Promise`<`ControlMessageResponse`\>
+▸ **kill**(`opts?`): `Promise`<`Instance`\>
 
 Send kill command to Instance
 
+#### Parameters
+
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `opts` | `Object` | `undefined` | Options. |
+| `opts.removeImmediately` | `boolean` | `false` | If true, Instance lifetime extension delay will be bypassed. |
+
 #### Returns
 
-`Promise`<`ControlMessageResponse`\>
+`Promise`<`Instance`\>
 
 Promise resolving to kill Instance result.
 
 #### Defined in
 
-[api-client/src/instance-client.ts:74](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L74)
+[api-client/src/instance-client.ts:76](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L76)
 
 ___
 
@@ -313,7 +320,7 @@ Promise resolving to send event result.
 
 #### Defined in
 
-[api-client/src/instance-client.ts:90](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L90)
+[api-client/src/instance-client.ts:92](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L92)
 
 ___
 
@@ -339,7 +346,7 @@ Promise resolving to send stream result.
 
 #### Defined in
 
-[api-client/src/instance-client.ts:183](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L183)
+[api-client/src/instance-client.ts:185](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L185)
 
 ___
 
@@ -363,7 +370,7 @@ Promise resolving to send stream result.
 
 #### Defined in
 
-[api-client/src/instance-client.ts:193](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L193)
+[api-client/src/instance-client.ts:195](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L195)
 
 ___
 
@@ -390,13 +397,13 @@ Promise resolving to send stream result.
 
 #### Defined in
 
-[api-client/src/instance-client.ts:171](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L171)
+[api-client/src/instance-client.ts:173](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L173)
 
 ___
 
 ### stop
 
-▸ **stop**(`timeout`, `canCallKeepalive`): `Promise`<`ControlMessageResponse`\>
+▸ **stop**(`timeout`, `canCallKeepalive`): `Promise`<`Instance`\>
 
 Send stop command to Instance.
 
@@ -409,7 +416,7 @@ Send stop command to Instance.
 
 #### Returns
 
-`Promise`<`ControlMessageResponse`\>
+`Promise`<`Instance`\>
 
 Promise resolving to stop Instance result.
 

--- a/docs/host/classes/CSIController.md
+++ b/docs/host/classes/CSIController.md
@@ -85,6 +85,7 @@ Handles all Instance lifecycle, exposes instance's HTTP API.
 
 - [endOfSequence](CSIController.md#endofsequence)
 - [instanceAdapter](CSIController.md#instanceadapter)
+- [isRunning](CSIController.md#isrunning)
 - [lastStats](CSIController.md#laststats)
 
 ## Properties
@@ -95,7 +96,7 @@ Handles all Instance lifecycle, exposes instance's HTTP API.
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:138](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L138)
+[packages/host/src/lib/csi-controller.ts:140](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L140)
 
 ___
 
@@ -105,7 +106,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:108](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L108)
+[packages/host/src/lib/csi-controller.ts:110](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L110)
 
 ___
 
@@ -115,7 +116,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:107](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L107)
+[packages/host/src/lib/csi-controller.ts:109](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L109)
 
 ___
 
@@ -125,7 +126,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:85](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L85)
+[packages/host/src/lib/csi-controller.ts:87](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L87)
 
 ___
 
@@ -135,7 +136,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:158](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L158)
+[packages/host/src/lib/csi-controller.ts:160](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L160)
 
 ___
 
@@ -145,7 +146,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:88](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L88)
+[packages/host/src/lib/csi-controller.ts:90](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L90)
 
 ___
 
@@ -155,7 +156,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:128](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L128)
+[packages/host/src/lib/csi-controller.ts:130](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L130)
 
 ___
 
@@ -165,7 +166,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:102](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L102)
+[packages/host/src/lib/csi-controller.ts:104](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L104)
 
 ___
 
@@ -182,7 +183,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:101](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L101)
+[packages/host/src/lib/csi-controller.ts:103](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L103)
 
 ___
 
@@ -192,7 +193,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:104](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L104)
+[packages/host/src/lib/csi-controller.ts:106](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L106)
 
 ___
 
@@ -221,7 +222,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:90](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L90)
+[packages/host/src/lib/csi-controller.ts:92](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L92)
 
 ___
 
@@ -238,7 +239,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:100](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L100)
+[packages/host/src/lib/csi-controller.ts:102](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L102)
 
 ___
 
@@ -250,7 +251,7 @@ Topic to which the input stream should be routed
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:118](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L118)
+[packages/host/src/lib/csi-controller.ts:120](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L120)
 
 ___
 
@@ -260,7 +261,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:86](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L86)
+[packages/host/src/lib/csi-controller.ts:88](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L88)
 
 ___
 
@@ -270,7 +271,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:83](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L83)
+[packages/host/src/lib/csi-controller.ts:85](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L85)
 
 ___
 
@@ -280,7 +281,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:105](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L105)
+[packages/host/src/lib/csi-controller.ts:107](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L107)
 
 ___
 
@@ -292,7 +293,7 @@ Logger.
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:125](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L125)
+[packages/host/src/lib/csi-controller.ts:127](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L127)
 
 ___
 
@@ -304,7 +305,7 @@ Topic to which the output stream should be routed
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:113](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L113)
+[packages/host/src/lib/csi-controller.ts:115](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L115)
 
 ___
 
@@ -314,7 +315,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:97](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L97)
+[packages/host/src/lib/csi-controller.ts:99](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L99)
 
 ___
 
@@ -324,7 +325,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:98](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L98)
+[packages/host/src/lib/csi-controller.ts:100](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L100)
 
 ___
 
@@ -334,7 +335,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:89](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L89)
+[packages/host/src/lib/csi-controller.ts:91](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L91)
 
 ___
 
@@ -344,7 +345,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:84](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L84)
+[packages/host/src/lib/csi-controller.ts:86](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L86)
 
 ___
 
@@ -354,7 +355,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:87](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L87)
+[packages/host/src/lib/csi-controller.ts:89](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L89)
 
 ___
 
@@ -364,7 +365,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:96](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L96)
+[packages/host/src/lib/csi-controller.ts:98](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L98)
 
 ___
 
@@ -374,7 +375,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:82](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L82)
+[packages/host/src/lib/csi-controller.ts:84](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L84)
 
 ## Methods
 
@@ -419,7 +420,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:331](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L331)
+[packages/host/src/lib/csi-controller.ts:343](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L343)
 
 ___
 
@@ -433,7 +434,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:476](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L476)
+[packages/host/src/lib/csi-controller.ts:491](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L491)
 
 ___
 
@@ -496,7 +497,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:337](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L337)
+[packages/host/src/lib/csi-controller.ts:351](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L351)
 
 ___
 
@@ -510,7 +511,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:647](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L647)
+[packages/host/src/lib/csi-controller.ts:676](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L676)
 
 ___
 
@@ -524,7 +525,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:665](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L665)
+[packages/host/src/lib/csi-controller.ts:694](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L694)
 
 ___
 
@@ -538,7 +539,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:669](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L669)
+[packages/host/src/lib/csi-controller.ts:698](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L698)
 
 ___
 
@@ -570,7 +571,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:661](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L661)
+[packages/host/src/lib/csi-controller.ts:690](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L690)
 
 ___
 
@@ -590,7 +591,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:439](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L439)
+[packages/host/src/lib/csi-controller.ts:454](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L454)
 
 ___
 
@@ -610,7 +611,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:464](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L464)
+[packages/host/src/lib/csi-controller.ts:479](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L479)
 
 ___
 
@@ -630,7 +631,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:719](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L719)
+[packages/host/src/lib/csi-controller.ts:748](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L748)
 
 ___
 
@@ -650,7 +651,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:674](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L674)
+[packages/host/src/lib/csi-controller.ts:703](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L703)
 
 ___
 
@@ -670,7 +671,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:692](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L692)
+[packages/host/src/lib/csi-controller.ts:721](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L721)
 
 ___
 
@@ -684,7 +685,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:290](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L290)
+[packages/host/src/lib/csi-controller.ts:297](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L297)
 
 ___
 
@@ -704,7 +705,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:356](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L356)
+[packages/host/src/lib/csi-controller.ts:371](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L371)
 
 ___
 
@@ -718,7 +719,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:348](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L348)
+[packages/host/src/lib/csi-controller.ts:363](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L363)
 
 ___
 
@@ -792,7 +793,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:205](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L205)
+[packages/host/src/lib/csi-controller.ts:208](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L208)
 
 ___
 
@@ -1076,7 +1077,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:190](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L190)
+[packages/host/src/lib/csi-controller.ts:193](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L193)
 
 ___
 
@@ -1090,7 +1091,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:234](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L234)
+[packages/host/src/lib/csi-controller.ts:235](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L235)
 
 ## Constructors
 
@@ -1114,7 +1115,7 @@ TypedEmitter&lt;Events\&gt;.constructor
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:160](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L160)
+[packages/host/src/lib/csi-controller.ts:162](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L162)
 
 ## Accessors
 
@@ -1128,7 +1129,7 @@ TypedEmitter&lt;Events\&gt;.constructor
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:140](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L140)
+[packages/host/src/lib/csi-controller.ts:142](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L142)
 
 • `set` **endOfSequence**(`prm`): `void`
 
@@ -1144,7 +1145,7 @@ TypedEmitter&lt;Events\&gt;.constructor
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:148](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L148)
+[packages/host/src/lib/csi-controller.ts:150](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L150)
 
 ___
 
@@ -1158,7 +1159,21 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:130](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L130)
+[packages/host/src/lib/csi-controller.ts:132](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L132)
+
+___
+
+### isRunning
+
+• `get` **isRunning**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+#### Defined in
+
+[packages/host/src/lib/csi-controller.ts:349](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L349)
 
 ___
 
@@ -1172,4 +1187,4 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:71](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L71)
+[packages/host/src/lib/csi-controller.ts:73](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L73)

--- a/docs/host/classes/Host.md
+++ b/docs/host/classes/Host.md
@@ -336,7 +336,7 @@ Stops running servers.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:866](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L866)
+[packages/host/src/lib/host.ts:869](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L869)
 
 ___
 
@@ -370,7 +370,7 @@ List of Instances.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:776](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L776)
+[packages/host/src/lib/host.ts:779](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L779)
 
 ___
 
@@ -394,7 +394,7 @@ Sequence info object.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:788](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L788)
+[packages/host/src/lib/host.ts:791](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L791)
 
 ___
 
@@ -418,7 +418,7 @@ List of Instances.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:825](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L825)
+[packages/host/src/lib/host.ts:828](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L828)
 
 ___
 
@@ -436,7 +436,7 @@ List of Sequences.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:810](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L810)
+[packages/host/src/lib/host.ts:813](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L813)
 
 ___
 
@@ -450,7 +450,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:836](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L836)
+[packages/host/src/lib/host.ts:839](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L839)
 
 ___
 
@@ -471,7 +471,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:490](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L490)
+[packages/host/src/lib/host.ts:493](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L493)
 
 ___
 
@@ -524,7 +524,7 @@ Promise resolving to operation result.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:535](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L535)
+[packages/host/src/lib/host.ts:538](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L538)
 
 ___
 
@@ -552,7 +552,7 @@ Promise resolving to operation result object.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:583](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L583)
+[packages/host/src/lib/host.ts:586](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L586)
 
 ___
 
@@ -566,7 +566,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:471](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L471)
+[packages/host/src/lib/host.ts:474](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L474)
 
 ___
 
@@ -583,7 +583,7 @@ Used to recover Sequences information after restart.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:508](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L508)
+[packages/host/src/lib/host.ts:511](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L511)
 
 ___
 
@@ -670,7 +670,7 @@ Creates new CSIController [CSIController](CSIController.md) object and handles i
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:637](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L637)
+[packages/host/src/lib/host.ts:640](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L640)
 
 ___
 
@@ -687,7 +687,7 @@ using its CSIController [CSIController](CSIController.md)
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:849](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L849)
+[packages/host/src/lib/host.ts:852](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L852)
 
 ___
 

--- a/docs/model/modules.md
+++ b/docs/model/modules.md
@@ -114,7 +114,7 @@ ___
 | Name | Type |
 | :------ | :------ |
 | `msgCode` | `X` |
-| `msgData` | `LoadCheckStat` \| `ErrorMessageData` \| `AcknowledgeMessageData` \| `DescribeSequenceMessageData` \| `StatusMessageData` \| `EventMessageData` \| `PingMessageData` \| `PangMessageData` \| `HandshakeAcknowledgeMessageData` \| `KeepAliveMessageData` \| `EmptyMessageData` \| `MonitoringRateMessageData` \| `MonitoringMessageData` \| `StopSequenceMessageData` \| `SequenceCompleteMessageData` \| `STHIDMessageData` \| `InstanceMessage` \| `InstanceBulkMessage` \| `SequenceMessage` \| `SequenceBulkMessage` \| `SequenceStoppedMessageData` \| `NetworkInfo`[] |
+| `msgData` | `LoadCheckStat` \| `ErrorMessageData` \| `AcknowledgeMessageData` \| `DescribeSequenceMessageData` \| `StatusMessageData` \| `EventMessageData` \| `PingMessageData` \| `PangMessageData` \| `HandshakeAcknowledgeMessageData` \| `KeepAliveMessageData` \| `KillMessageData` \| `MonitoringRateMessageData` \| `MonitoringMessageData` \| `StopSequenceMessageData` \| `SequenceCompleteMessageData` \| `STHIDMessageData` \| `InstanceMessage` \| `InstanceBulkMessage` \| `SequenceMessage` \| `SequenceBulkMessage` \| `SequenceStoppedMessageData` \| `NetworkInfo`[] |
 
 #### Returns
 

--- a/docs/sth-config/classes/ConfigService.md
+++ b/docs/sth-config/classes/ConfigService.md
@@ -29,7 +29,7 @@
 
 #### Defined in
 
-[sth-config/src/config-service.ts:77](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L77)
+[sth-config/src/config-service.ts:78](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L78)
 
 ## Methods
 
@@ -43,7 +43,7 @@
 
 #### Defined in
 
-[sth-config/src/config-service.ts:85](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L85)
+[sth-config/src/config-service.ts:86](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L86)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[sth-config/src/config-service.ts:97](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L97)
+[sth-config/src/config-service.ts:98](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L98)
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 #### Defined in
 
-[sth-config/src/config-service.ts:89](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L89)
+[sth-config/src/config-service.ts:90](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L90)
 
 ___
 
@@ -105,4 +105,4 @@ ___
 
 #### Defined in
 
-[sth-config/src/config-service.ts:93](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L93)
+[sth-config/src/config-service.ts:94](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L94)

--- a/docs/sth-config/modules.md
+++ b/docs/sth-config/modules.md
@@ -25,7 +25,7 @@
 
 #### Defined in
 
-[sth-config/src/config-service.ts:72](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L72)
+[sth-config/src/config-service.ts:73](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L73)
 
 ## Functions
 

--- a/docs/symbols/enums/RunnerExitCode.md
+++ b/docs/symbols/enums/RunnerExitCode.md
@@ -8,6 +8,7 @@
 
 - [INVALID\_ENV\_VARS](RunnerExitCode.md#invalid_env_vars)
 - [INVALID\_SEQUENCE\_PATH](RunnerExitCode.md#invalid_sequence_path)
+- [KILLED](RunnerExitCode.md#killed)
 - [SEQUENCE\_FAILED\_DURING\_EXECUTION](RunnerExitCode.md#sequence_failed_during_execution)
 - [SEQUENCE\_FAILED\_ON\_START](RunnerExitCode.md#sequence_failed_on_start)
 - [SEQUENCE\_UNPACK\_FAILED](RunnerExitCode.md#sequence_unpack_failed)
@@ -31,6 +32,16 @@ ___
 #### Defined in
 
 [runner-exit-code.ts:3](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/runner-exit-code.ts#L3)
+
+___
+
+### KILLED
+
+• **KILLED** = `137`
+
+#### Defined in
+
+[runner-exit-code.ts:7](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/runner-exit-code.ts#L7)
 
 ___
 

--- a/docs/types/interfaces/APIBase.md
+++ b/docs/types/interfaces/APIBase.md
@@ -43,7 +43,7 @@ A method that allows to consume incoming stream from the specified path on the A
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:126](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L126)
+[packages/types/src/api-expose.ts:127](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L127)
 
 ___
 
@@ -66,7 +66,7 @@ Allows to handle dual direction (duplex) streams.
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:138](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L138)
+[packages/types/src/api-expose.ts:135](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L135)
 
 ___
 
@@ -96,7 +96,7 @@ Simple GET request hook for static data in monitoring stream.
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:95](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L95)
+[packages/types/src/api-expose.ts:101](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L101)
 
 ▸ **get**(`path`, `msg`): `void`
 
@@ -115,13 +115,13 @@ Alternative GET request hook with dynamic resolution
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:104](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L104)
+[packages/types/src/api-expose.ts:109](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L109)
 
 ___
 
 ### op
 
-▸ **op**<`T`\>(`method`, `path`, `message`, `conn?`): `void`
+▸ **op**<`T`\>(`method`, `path`, `message`, `comm?`, `rawBody?`): `void`
 
 Simple POST/DELETE request hook.
 This method can be used in two ways - as a control message handler or as general data handler.
@@ -145,7 +145,8 @@ router.op("post", `${this.apiBase}/start`, (req) => this.handleStartRequest(req)
 | `method` | [`HttpMethod`](../modules.md#httpmethod) | - |
 | `path` | `string` \| `RegExp` | the request path as string or regex |
 | `message` | `T` \| [`OpResolver`](../modules.md#opresolver) | which operation to expose |
-| `conn?` | [`ICommunicationHandler`](ICommunicationHandler.md) | the communication handler to use |
+| `comm?` | [`ICommunicationHandler`](ICommunicationHandler.md) | - |
+| `rawBody?` | `boolean` | - |
 
 #### Returns
 
@@ -153,7 +154,7 @@ router.op("post", `${this.apiBase}/start`, (req) => this.handleStartRequest(req)
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:85](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L85)
+[packages/types/src/api-expose.ts:86](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L86)
 
 ___
 
@@ -177,7 +178,7 @@ A method that allows to pass a stream to the specified path on the API server
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:113](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L113)
+[packages/types/src/api-expose.ts:118](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L118)
 
 ___
 
@@ -200,4 +201,4 @@ Allows to register middlewares for specific paths, for all HTTP methods.
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:149](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L149)
+[packages/types/src/api-expose.ts:143](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L143)

--- a/docs/types/interfaces/APIError.md
+++ b/docs/types/interfaces/APIError.md
@@ -27,7 +27,7 @@
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:67](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L67)
+[packages/types/src/api-expose.ts:68](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L68)
 
 ___
 
@@ -39,7 +39,7 @@ Http status code to be outputted
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:59](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L59)
+[packages/types/src/api-expose.ts:60](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L60)
 
 ___
 
@@ -51,7 +51,7 @@ The message that will be sent in reason line
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:63](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L63)
+[packages/types/src/api-expose.ts:64](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L64)
 
 ___
 

--- a/docs/types/interfaces/APIExpose.md
+++ b/docs/types/interfaces/APIExpose.md
@@ -44,7 +44,7 @@
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:158](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L158)
+[packages/types/src/api-expose.ts:152](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L152)
 
 ___
 
@@ -72,7 +72,7 @@ A method that allows to consume incoming stream from the specified path on the A
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:126](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L126)
+[packages/types/src/api-expose.ts:127](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L127)
 
 ___
 
@@ -99,7 +99,7 @@ Allows to handle dual direction (duplex) streams.
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:138](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L138)
+[packages/types/src/api-expose.ts:135](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L135)
 
 ___
 
@@ -133,7 +133,7 @@ Simple GET request hook for static data in monitoring stream.
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:95](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L95)
+[packages/types/src/api-expose.ts:101](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L101)
 
 ▸ **get**(`path`, `msg`): `void`
 
@@ -156,13 +156,13 @@ Alternative GET request hook with dynamic resolution
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:104](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L104)
+[packages/types/src/api-expose.ts:109](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L109)
 
 ___
 
 ### op
 
-▸ **op**<`T`\>(`method`, `path`, `message`, `conn?`): `void`
+▸ **op**<`T`\>(`method`, `path`, `message`, `comm?`, `rawBody?`): `void`
 
 Simple POST/DELETE request hook.
 This method can be used in two ways - as a control message handler or as general data handler.
@@ -186,7 +186,8 @@ router.op("post", `${this.apiBase}/start`, (req) => this.handleStartRequest(req)
 | `method` | [`HttpMethod`](../modules.md#httpmethod) | - |
 | `path` | `string` \| `RegExp` | the request path as string or regex |
 | `message` | `T` \| [`OpResolver`](../modules.md#opresolver) | which operation to expose |
-| `conn?` | [`ICommunicationHandler`](ICommunicationHandler.md) | the communication handler to use |
+| `comm?` | [`ICommunicationHandler`](ICommunicationHandler.md) | - |
+| `rawBody?` | `boolean` | - |
 
 #### Returns
 
@@ -198,7 +199,7 @@ router.op("post", `${this.apiBase}/start`, (req) => this.handleStartRequest(req)
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:85](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L85)
+[packages/types/src/api-expose.ts:86](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L86)
 
 ___
 
@@ -226,7 +227,7 @@ A method that allows to pass a stream to the specified path on the API server
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:113](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L113)
+[packages/types/src/api-expose.ts:118](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L118)
 
 ___
 
@@ -253,7 +254,7 @@ Allows to register middlewares for specific paths, for all HTTP methods.
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:149](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L149)
+[packages/types/src/api-expose.ts:143](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L143)
 
 ## Properties
 
@@ -263,7 +264,7 @@ Allows to register middlewares for specific paths, for all HTTP methods.
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:157](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L157)
+[packages/types/src/api-expose.ts:151](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L151)
 
 ___
 
@@ -275,4 +276,4 @@ The raw HTTP server
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:156](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L156)
+[packages/types/src/api-expose.ts:150](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L150)

--- a/docs/types/interfaces/APIRoute.md
+++ b/docs/types/interfaces/APIRoute.md
@@ -49,7 +49,7 @@ A method that allows to consume incoming stream from the specified path on the A
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:126](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L126)
+[packages/types/src/api-expose.ts:127](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L127)
 
 ___
 
@@ -76,7 +76,7 @@ Allows to handle dual direction (duplex) streams.
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:138](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L138)
+[packages/types/src/api-expose.ts:135](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L135)
 
 ___
 
@@ -110,7 +110,7 @@ Simple GET request hook for static data in monitoring stream.
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:95](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L95)
+[packages/types/src/api-expose.ts:101](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L101)
 
 ▸ **get**(`path`, `msg`): `void`
 
@@ -133,13 +133,13 @@ Alternative GET request hook with dynamic resolution
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:104](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L104)
+[packages/types/src/api-expose.ts:109](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L109)
 
 ___
 
 ### op
 
-▸ **op**<`T`\>(`method`, `path`, `message`, `conn?`): `void`
+▸ **op**<`T`\>(`method`, `path`, `message`, `comm?`, `rawBody?`): `void`
 
 Simple POST/DELETE request hook.
 This method can be used in two ways - as a control message handler or as general data handler.
@@ -163,7 +163,8 @@ router.op("post", `${this.apiBase}/start`, (req) => this.handleStartRequest(req)
 | `method` | [`HttpMethod`](../modules.md#httpmethod) | - |
 | `path` | `string` \| `RegExp` | the request path as string or regex |
 | `message` | `T` \| [`OpResolver`](../modules.md#opresolver) | which operation to expose |
-| `conn?` | [`ICommunicationHandler`](ICommunicationHandler.md) | the communication handler to use |
+| `comm?` | [`ICommunicationHandler`](ICommunicationHandler.md) | - |
+| `rawBody?` | `boolean` | - |
 
 #### Returns
 
@@ -175,7 +176,7 @@ router.op("post", `${this.apiBase}/start`, (req) => this.handleStartRequest(req)
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:85](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L85)
+[packages/types/src/api-expose.ts:86](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L86)
 
 ___
 
@@ -203,7 +204,7 @@ A method that allows to pass a stream to the specified path on the API server
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:113](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L113)
+[packages/types/src/api-expose.ts:118](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L118)
 
 ___
 
@@ -230,7 +231,7 @@ Allows to register middlewares for specific paths, for all HTTP methods.
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:149](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L149)
+[packages/types/src/api-expose.ts:143](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L143)
 
 ## Properties
 
@@ -240,4 +241,4 @@ Allows to register middlewares for specific paths, for all HTTP methods.
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:162](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L162)
+[packages/types/src/api-expose.ts:156](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L156)

--- a/docs/types/modules.md
+++ b/docs/types/modules.md
@@ -120,6 +120,7 @@
 - [NetworkInfo](modules.md#networkinfo)
 - [NetworkInfoMessage](modules.md#networkinfomessage)
 - [NextCallback](modules.md#nextcallback)
+- [OpOptions](modules.md#opoptions)
 - [OpRecord](modules.md#oprecord)
 - [OpResolver](modules.md#opresolver)
 - [OpResponse](modules.md#opresponse)
@@ -533,7 +534,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:20](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L20)
+[packages/types/src/api-expose.ts:21](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L21)
 
 ___
 
@@ -1248,21 +1249,15 @@ ___
 
 ### KillSequenceMessage
 
-Ƭ **KillSequenceMessage**: `Object`
+Ƭ **KillSequenceMessage**: { `msgCode`: `RunnerMessageCode.KILL`  } & `KillMessageData`
 
 Message instructing Runner to terminate Sequence using the kill signal.
 It causes an ungraceful termination of Sequence.
 This message type is sent from CSIController.
 
-#### Type declaration
-
-| Name | Type |
-| :------ | :------ |
-| `msgCode` | `RunnerMessageCode.KILL` |
-
 #### Defined in
 
-[packages/types/src/messages/kill-sequence.ts:8](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/messages/kill-sequence.ts#L8)
+[packages/types/src/messages/kill-sequence.ts:15](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/messages/kill-sequence.ts#L15)
 
 ___
 
@@ -1476,7 +1471,7 @@ ___
 
 ### MessageDataType
 
-Ƭ **MessageDataType**<`T`\>: `T` extends `RunnerMessageCode.ACKNOWLEDGE` ? [`AcknowledgeMessageData`](modules.md#acknowledgemessagedata) : `T` extends `RunnerMessageCode.ALIVE` ? [`KeepAliveMessageData`](modules.md#keepalivemessagedata) : `T` extends `RunnerMessageCode.DESCRIBE_SEQUENCE` ? [`DescribeSequenceMessageData`](modules.md#describesequencemessagedata) : `T` extends `RunnerMessageCode.STATUS` ? [`StatusMessageData`](modules.md#statusmessagedata) : `T` extends `RunnerMessageCode.ERROR` ? [`ErrorMessageData`](modules.md#errormessagedata) : `T` extends `RunnerMessageCode.KILL` ? [`EmptyMessageData`](modules.md#emptymessagedata) : `T` extends `RunnerMessageCode.MONITORING` ? [`MonitoringMessageData`](modules.md#monitoringmessagedata) : `T` extends `RunnerMessageCode.MONITORING_RATE` ? [`MonitoringRateMessageData`](modules.md#monitoringratemessagedata) : `T` extends `RunnerMessageCode.STOP` ? [`StopSequenceMessageData`](modules.md#stopsequencemessagedata) : `T` extends `RunnerMessageCode.PING` ? [`PingMessageData`](modules.md#pingmessagedata) : `T` extends `RunnerMessageCode.PONG` ? [`HandshakeAcknowledgeMessageData`](modules.md#handshakeacknowledgemessagedata) : `T` extends `RunnerMessageCode.PANG` ? [`PangMessageData`](modules.md#pangmessagedata) : `T` extends `RunnerMessageCode.SEQUENCE_COMPLETED` ? `SequenceCompleteMessageData` : `T` extends `RunnerMessageCode.SEQUENCE_STOPPED` ? [`SequenceStoppedMessageData`](modules.md#sequencestoppedmessagedata) : `T` extends `RunnerMessageCode.EVENT` ? [`EventMessageData`](modules.md#eventmessagedata) : `T` extends `CPMMessageCode.STH_ID` ? [`STHIDMessageData`](modules.md#sthidmessagedata) : `T` extends `CPMMessageCode.LOAD` ? [`LoadCheckStat`](modules.md#loadcheckstat) : `T` extends `CPMMessageCode.NETWORK_INFO` ? [`NetworkInfo`](modules.md#networkinfo)[] : `T` extends `CPMMessageCode.INSTANCES` ? [`InstanceBulkMessage`](modules.md#instancebulkmessage) : `T` extends `CPMMessageCode.INSTANCE` ? [`InstanceMessage`](modules.md#instancemessage) : `T` extends `CPMMessageCode.SEQUENCES` ? [`SequenceBulkMessage`](modules.md#sequencebulkmessage) : `T` extends `CPMMessageCode.SEQUENCE` ? [`SequenceMessage`](modules.md#sequencemessage) : `never`
+Ƭ **MessageDataType**<`T`\>: `T` extends `RunnerMessageCode.ACKNOWLEDGE` ? [`AcknowledgeMessageData`](modules.md#acknowledgemessagedata) : `T` extends `RunnerMessageCode.ALIVE` ? [`KeepAliveMessageData`](modules.md#keepalivemessagedata) : `T` extends `RunnerMessageCode.DESCRIBE_SEQUENCE` ? [`DescribeSequenceMessageData`](modules.md#describesequencemessagedata) : `T` extends `RunnerMessageCode.STATUS` ? [`StatusMessageData`](modules.md#statusmessagedata) : `T` extends `RunnerMessageCode.ERROR` ? [`ErrorMessageData`](modules.md#errormessagedata) : `T` extends `RunnerMessageCode.KILL` ? `KillMessageData` : `T` extends `RunnerMessageCode.MONITORING` ? [`MonitoringMessageData`](modules.md#monitoringmessagedata) : `T` extends `RunnerMessageCode.MONITORING_RATE` ? [`MonitoringRateMessageData`](modules.md#monitoringratemessagedata) : `T` extends `RunnerMessageCode.STOP` ? [`StopSequenceMessageData`](modules.md#stopsequencemessagedata) : `T` extends `RunnerMessageCode.PING` ? [`PingMessageData`](modules.md#pingmessagedata) : `T` extends `RunnerMessageCode.PONG` ? [`HandshakeAcknowledgeMessageData`](modules.md#handshakeacknowledgemessagedata) : `T` extends `RunnerMessageCode.PANG` ? [`PangMessageData`](modules.md#pangmessagedata) : `T` extends `RunnerMessageCode.SEQUENCE_COMPLETED` ? `SequenceCompleteMessageData` : `T` extends `RunnerMessageCode.SEQUENCE_STOPPED` ? [`SequenceStoppedMessageData`](modules.md#sequencestoppedmessagedata) : `T` extends `RunnerMessageCode.EVENT` ? [`EventMessageData`](modules.md#eventmessagedata) : `T` extends `CPMMessageCode.STH_ID` ? [`STHIDMessageData`](modules.md#sthidmessagedata) : `T` extends `CPMMessageCode.LOAD` ? [`LoadCheckStat`](modules.md#loadcheckstat) : `T` extends `CPMMessageCode.NETWORK_INFO` ? [`NetworkInfo`](modules.md#networkinfo)[] : `T` extends `CPMMessageCode.INSTANCES` ? [`InstanceBulkMessage`](modules.md#instancebulkmessage) : `T` extends `CPMMessageCode.INSTANCE` ? [`InstanceMessage`](modules.md#instancemessage) : `T` extends `CPMMessageCode.SEQUENCES` ? [`SequenceBulkMessage`](modules.md#sequencebulkmessage) : `T` extends `CPMMessageCode.SEQUENCE` ? [`SequenceMessage`](modules.md#sequencemessage) : `never`
 
 #### Type parameters
 
@@ -1528,7 +1523,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:19](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L19)
+[packages/types/src/api-expose.ts:20](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L20)
 
 ___
 
@@ -1752,7 +1747,23 @@ ___
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:18](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L18)
+[packages/types/src/api-expose.ts:19](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L19)
+
+___
+
+### OpOptions
+
+Ƭ **OpOptions**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `rawBody?` | `boolean` |
+
+#### Defined in
+
+[packages/types/src/api-expose.ts:17](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L17)
 
 ___
 
@@ -1935,7 +1946,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/sth-configuration.ts:205](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L205)
+[packages/types/src/sth-configuration.ts:210](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L210)
 
 ___
 
@@ -2099,6 +2110,7 @@ ___
 | `hostname` | `string` |
 | `id?` | `string` |
 | `identifyExisting` | `boolean` |
+| `instanceLifetimeExtensionDelay` | `number` |
 | `instancesServerPort` | `string` |
 | `k8sAuthConfigPath` | `string` |
 | `k8sNamespace` | `string` |
@@ -2150,6 +2162,7 @@ ___
 | `host` | [`HostConfig`](modules.md#hostconfig) | Host configuration. |
 | `identifyExisting` | `boolean` | Should we identify existing sequences. |
 | `instanceAdapterExitDelay` | `number` | Time to wait after Runner container exit. In this additional time Instance API is still available. |
+| `instanceLifetimeExtensionDelay` | `number` | Time to wait before CSIController emits `end` event. |
 | `instanceRequirements` | { `cpuLoad`: `number` ; `freeMem`: `number` ; `freeSpace`: `number`  } | Minimum requirements to start new Instance. |
 | `instanceRequirements.cpuLoad` | `number` | Required free CPU. In percentage. |
 | `instanceRequirements.freeMem` | `number` | Free memory required to start Instance. In megabytes. |
@@ -2505,7 +2518,7 @@ Configuration options for streaming endpoints
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:25](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L25)
+[packages/types/src/api-expose.ts:26](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L26)
 
 ___
 
@@ -2525,7 +2538,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/api-expose.ts:13](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L13)
+[packages/types/src/api-expose.ts:14](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/api-expose.ts#L14)
 
 ___
 

--- a/docs/types/modules/STHRestAPI.md
+++ b/docs/types/modules/STHRestAPI.md
@@ -198,7 +198,7 @@ ___
 
 ### SendKillInstanceResponse
 
-Ƭ **SendKillInstanceResponse**: [`ControlMessageResponse`](STHRestAPI.md#controlmessageresponse)
+Ƭ **SendKillInstanceResponse**: [`Instance`](../modules.md#instance)
 
 #### Defined in
 
@@ -224,7 +224,7 @@ ___
 
 ### SendStopInstanceResponse
 
-Ƭ **SendStopInstanceResponse**: [`ControlMessageResponse`](STHRestAPI.md#controlmessageresponse)
+Ƭ **SendStopInstanceResponse**: [`Instance`](../modules.md#instance)
 
 #### Defined in
 


### PR DESCRIPTION
## @scramjet/transform Hub - v0.24.3

- Update missing types for kill/stop responses
- Restore instances details in /instances endpoint
- Fix si seq prune command


