### PR TITLE
[CLI] Small fixes and CLI tests refactor

### DIFF
--- a/bdd/data/sequences/deploy-app/dist/index.js
+++ b/bdd/data/sequences/deploy-app/dist/index.js
@@ -1,0 +1,12 @@
+"use strict";
+exports.__esModule = true;
+var stream_1 = require("stream");
+var exp = function (_stream, arg1, arg2, arg3, arg4) {
+    var out = new stream_1.PassThrough();
+    out.write(arg1 + "\n");
+    out.write(arg2.toString() + "\n");
+    out.write(arg3.abc + "\n");
+    out.write(arg4[0] + "\n");
+    return out;
+};
+exports["default"] = exp;

--- a/bdd/data/sequences/deploy-app/dist/package-lock.json
+++ b/bdd/data/sequences/deploy-app/dist/package-lock.json
@@ -1,0 +1,75 @@
+{
+  "name": "@scramjet/deploy-app",
+  "version": "0.23.2",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@scramjet/deploy-app",
+      "version": "0.23.2",
+      "license": "ISC",
+      "devDependencies": {
+        "@scramjet/types": "^0.23.2",
+        "@types/node": "15.12.5"
+      }
+    },
+    "node_modules/@scramjet/symbols": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/@scramjet/symbols/-/symbols-0.23.2.tgz",
+      "integrity": "sha512-K7rmDPZDw+zDJ8sLRUaGyR+yYQQJis676HdveXt9jfYv9TpT4zP5zczFjHf74ZLbE4DTBEWDs2YRxlQsFQzVfg==",
+      "dev": true
+    },
+    "node_modules/@scramjet/types": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/@scramjet/types/-/types-0.23.2.tgz",
+      "integrity": "sha512-t0VW7u9DEd9bs8tvgz0jPvIDGNTiJ3ehUMmdS1BWZt+wvX9HVMserhlAtfLAAPkzsW68v8nRz0+/BOUuSGx1pg==",
+      "dev": true,
+      "dependencies": {
+        "@scramjet/symbols": "^0.23.2",
+        "http-status-codes": "^2.2.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "15.12.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
+      "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
+      "dev": true
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==",
+      "dev": true
+    }
+  },
+  "dependencies": {
+    "@scramjet/symbols": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/@scramjet/symbols/-/symbols-0.23.2.tgz",
+      "integrity": "sha512-K7rmDPZDw+zDJ8sLRUaGyR+yYQQJis676HdveXt9jfYv9TpT4zP5zczFjHf74ZLbE4DTBEWDs2YRxlQsFQzVfg==",
+      "dev": true
+    },
+    "@scramjet/types": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/@scramjet/types/-/types-0.23.2.tgz",
+      "integrity": "sha512-t0VW7u9DEd9bs8tvgz0jPvIDGNTiJ3ehUMmdS1BWZt+wvX9HVMserhlAtfLAAPkzsW68v8nRz0+/BOUuSGx1pg==",
+      "dev": true,
+      "requires": {
+        "@scramjet/symbols": "^0.23.2",
+        "http-status-codes": "^2.2.0"
+      }
+    },
+    "@types/node": {
+      "version": "15.12.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
+      "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
+      "dev": true
+    },
+    "http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==",
+      "dev": true
+    }
+  }
+}

--- a/bdd/data/sequences/deploy-app/dist/package.json
+++ b/bdd/data/sequences/deploy-app/dist/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@scramjet/deploy-app",
+  "version": "0.23.2",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "postbuild": "cp -r package.json dist/ && (cd dist && npm i --only=production)"
+  },
+  "author": "Scramjet <open-source@scramjet.org>",
+  "license": "ISC",
+  "devDependencies": {
+    "@scramjet/types": "^0.23.2",
+    "@types/node": "15.12.5"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scramjetorg/transform-hub.git"
+  }
+}

--- a/bdd/data/sequences/deploy-app/index.ts
+++ b/bdd/data/sequences/deploy-app/index.ts
@@ -1,0 +1,17 @@
+import { ReadableApp } from "@scramjet/types";
+import { PassThrough } from "stream";
+
+type Arguments = [string, number, { abc: string }, [string]]
+
+const exp: ReadableApp<string, Arguments> = function(_stream, arg1, arg2, arg3, arg4) {
+    const out = new PassThrough();
+
+    out.write(arg1 + "\n");
+    out.write(arg2.toString() + "\n");
+    out.write(arg3.abc + "\n");
+    out.write(arg4[0] + "\n");
+
+    return out;
+};
+
+export default exp;

--- a/bdd/data/sequences/deploy-app/package-lock.json
+++ b/bdd/data/sequences/deploy-app/package-lock.json
@@ -1,0 +1,75 @@
+{
+  "name": "@scramjet/deploy-app",
+  "version": "0.23.2",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@scramjet/deploy-app",
+      "version": "0.23.2",
+      "license": "ISC",
+      "devDependencies": {
+        "@scramjet/types": "^0.23.2",
+        "@types/node": "15.12.5"
+      }
+    },
+    "node_modules/@scramjet/symbols": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/@scramjet/symbols/-/symbols-0.23.2.tgz",
+      "integrity": "sha512-K7rmDPZDw+zDJ8sLRUaGyR+yYQQJis676HdveXt9jfYv9TpT4zP5zczFjHf74ZLbE4DTBEWDs2YRxlQsFQzVfg==",
+      "dev": true
+    },
+    "node_modules/@scramjet/types": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/@scramjet/types/-/types-0.23.2.tgz",
+      "integrity": "sha512-t0VW7u9DEd9bs8tvgz0jPvIDGNTiJ3ehUMmdS1BWZt+wvX9HVMserhlAtfLAAPkzsW68v8nRz0+/BOUuSGx1pg==",
+      "dev": true,
+      "dependencies": {
+        "@scramjet/symbols": "^0.23.2",
+        "http-status-codes": "^2.2.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "15.12.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
+      "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
+      "dev": true
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==",
+      "dev": true
+    }
+  },
+  "dependencies": {
+    "@scramjet/symbols": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/@scramjet/symbols/-/symbols-0.23.2.tgz",
+      "integrity": "sha512-K7rmDPZDw+zDJ8sLRUaGyR+yYQQJis676HdveXt9jfYv9TpT4zP5zczFjHf74ZLbE4DTBEWDs2YRxlQsFQzVfg==",
+      "dev": true
+    },
+    "@scramjet/types": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/@scramjet/types/-/types-0.23.2.tgz",
+      "integrity": "sha512-t0VW7u9DEd9bs8tvgz0jPvIDGNTiJ3ehUMmdS1BWZt+wvX9HVMserhlAtfLAAPkzsW68v8nRz0+/BOUuSGx1pg==",
+      "dev": true,
+      "requires": {
+        "@scramjet/symbols": "^0.23.2",
+        "http-status-codes": "^2.2.0"
+      }
+    },
+    "@types/node": {
+      "version": "15.12.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
+      "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
+      "dev": true
+    },
+    "http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==",
+      "dev": true
+    }
+  }
+}

--- a/bdd/data/sequences/deploy-app/package.json
+++ b/bdd/data/sequences/deploy-app/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@scramjet/deploy-app",
+  "version": "0.23.2",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "postbuild": "cp -r package.json dist/ && (cd dist && npm i --only=production)"
+  },
+  "author": "Scramjet <open-source@scramjet.org>",
+  "license": "ISC",
+  "devDependencies": {
+    "@scramjet/types": "^0.23.2",
+    "@types/node": "15.12.5"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scramjetorg/transform-hub.git"
+  }
+}

--- a/bdd/data/sequences/deploy-app/tsconfig.json
+++ b/bdd/data/sequences/deploy-app/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": [
+    "./index.ts"
+  ]
+}

--- a/bdd/features/e2e/E2E-001-samples.feature
+++ b/bdd/features/e2e/E2E-001-samples.feature
@@ -3,7 +3,7 @@ Feature: Sample e2e tests
     @ci-instance-node
     Scenario: E2E-001 TC-002 Test stdio available after the sequence is completed
         Given host is running
-        When I execute CLI with "seq pack data/sequences/simple-stdio -o data/simple-stdio-2.tar.gz" arguments
+        When I execute CLI with "seq pack data/sequences/simple-stdio -o data/simple-stdio-2.tar.gz"
         And sequence "data/simple-stdio-2.tar.gz" loaded
         And instance started with arguments "1"
         And wait for "500" ms

--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -3,258 +3,168 @@ Feature: CLI tests
 This feature checks CLI functionalities
 
     @ci-api @cli
-    Scenario: E2E-010 TC-001 CLI displays help, version, hub load
-        Given host is running
-        Then I set json format
-        Then I set apiUrl in config
-        When I execute CLI with "--help" arguments
-        Then I get a help information
-        When I execute CLI with "--version" arguments
-        Then I get a version
-        When I execute CLI with "hub load" arguments
-        Then I get Hub load information
-        And host is still running
+    Scenario: E2E-010 TC-001 Test 'si --help' and 'si --version' display
+        Given I set config for local Hub
+        When I execute CLI with "--help"
+        When I execute CLI with "--version"
 
     @ci-api @cli
-    Scenario: E2E-010 TC-002 Pack Sequence
-        Given host is running
-        Then I set json format
-        Then I set apiUrl in config
-        When I execute CLI with "seq pack ../packages/reference-apps/transform-function  -o ../packages/reference-apps/transform-function.tar.gz" arguments
+    Scenario: E2E-010 TC-002 Test 'si hub' options
+        When I execute CLI with "hub --help"
+        When I execute CLI with "hub load"
+        When I execute CLI with "hub version"
+
+    @ci-api @cli
+    Scenario: E2E-010 TC-003 Test Sequence 'pack' option
+        When I execute CLI with "seq pack ../packages/reference-apps/transform-function  -o ../packages/reference-apps/transform-function.tar.gz"
         Then I get location "../packages/reference-apps/transform-function.tar.gz" of compressed directory
-        And host is still running
 
     @ci-api @cli
-    Scenario: E2E-010 TC-003 Send, list and delete Sequence
-        Given host is running
-        Then I set json format
-        Then I set apiUrl in config
-        When I execute CLI with "config print" arguments
-        When I execute CLI with "seq send ../packages/reference-apps/hello-alice-out.tar.gz" arguments
-        Then I get Sequence id
-        When I execute CLI with "seq ls" arguments
-        Then I get array of information about Sequences
-        Then I delete Sequence
-        And host is still running
+    Scenario: E2E-010 TC-004 Test Sequence options
+        When I execute CLI with "seq --help"
+        When I execute CLI with "seq send ../packages/reference-apps/args-to-output.tar.gz"
+        When I execute CLI with "seq send ../packages/reference-apps/checksum-sequence.tar.gz"
+        When I execute CLI with "seq send ../packages/reference-apps/hello-alice-out.tar.gz"
+        When I execute CLI with "seq get -"
+        When I execute CLI with "seq list"
+        When I execute CLI with "seq delete -"
+        When I execute CLI with "seq list"
+        When I execute CLI with "seq prune"
+        When I execute CLI with "seq list"
 
     @ci-api @cli
-    Scenario: E2E-010 TC-004 Get Instance info, health, kill Instance
-        Given host is running
-        Then I set json format
-        Then I set apiUrl in config
-        When I execute CLI with "seq send ../packages/reference-apps/hello-alice-out.tar.gz" arguments
-        Then I get Sequence id
-        Then I start Sequence
-        And I get Instance id
-        When I execute CLI with "inst info -" arguments
-        Then I get Instance health
-        Then I kill Instance
-        And host is still running
+    Scenario: E2E-010 TC-005 Test Sequence 'prune --force' option
+        When I execute CLI with "seq send ../packages/reference-apps/checksum-sequence.tar.gz"
+        When I execute CLI with "seq send ../packages/reference-apps/csv-transform.tar.gz"
+        When I execute CLI with "seq list"
+        When I execute CLI with "seq start -"
+        When I execute CLI with "inst list"
+        When I execute CLI with "seq prune --force"
+        Then I confirm "Instance" list is empty
+        Then I confirm "Sequence" list is empty
+
+    @ci-api @cli
+    Scenario: E2E-010 TC-006 Test Instance options
+        When I execute CLI with "inst --help"
+        When I execute CLI with "seq send ../packages/reference-apps/csv-transform.tar.gz"
+        When I execute CLI with "seq start -"
+        When I execute CLI with "inst info -"
+        When I execute CLI with "inst health -"
+        When I execute CLI with "inst list"
+        When I execute CLI with "inst kill -"
+        And I wait for Instance to end
+        Then I confirm "Instance" list is empty
+
+    @ci-api @cli
+    Scenario: E2E-010 TC-007 Test Instance 'log' option
+        When I execute CLI with "seq send ../packages/reference-apps/inert-function.tar.gz"
+        When I execute CLI with "seq start -"
+        When I execute CLI with "inst log -" without waiting for the end
+        Then I confirm instance logs received
+        When I execute CLI with "inst kill -"
 
     @ci-api @cli @not-github
-    Scenario: E2E-010 TC-005 Get 404 on health endpoint for finished Instance
-        Given host is running
-        Then I set json format
-        Then I set apiUrl in config
-        When I execute CLI with "seq send ../packages/reference-apps/inert-function.tar.gz" arguments
-        Then I get Sequence id
-        Then I start Sequence
-        Then I get Instance health
-        Then I wait for Instance to have ended
-        And host is still running
+    Scenario: E2E-010 TC-008 Get 404 on health endpoint for finished Instance
+        When I execute CLI with "seq send ../packages/reference-apps/inert-function.tar.gz"
+        When I execute CLI with "seq start -"
+        When I execute CLI with "inst health -"
+        And I wait for Instance to end
+        Then I confirm "Instance" list is empty
+
+    Scenario: E2E-010 TC-009 Test Instance 'input' option
+        When I execute CLI with "seq deploy ../packages/reference-apps/checksum-sequence.tar.gz"
+        When I execute CLI with "inst input - data/test-data/checksum.json"
+        When I execute CLI with "inst kill -"
 
     @ci-api @cli
-    Scenario: E2E-010 TC-006 Get log from Instance
-        Given host is running
-        Then I set json format
-        Then I set apiUrl in config
-        When I execute CLI with "seq send ../packages/reference-apps/inert-function.tar.gz" arguments
-        Then I get Sequence id
-        Then I start Sequence
-        And I get Instance id
-        When I execute CLI with "inst log -" arguments without waiting for the end
-        Then confirm instance logs received
-        And host is still running
+    Scenario: E2E-010 TC-010 Test Instance 'input --end' option and confirm output received
+        When I execute CLI with "seq deploy ../packages/reference-apps/checksum-sequence.tar.gz"
+        When I execute CLI with "inst input - data/test-data/checksum.json --end"
+        When I execute CLI with "inst output -"
+        Then I confirm data named "checksum" received
 
     @ci-api @cli
-    Scenario: E2E-010 TC-007 Send input data to Instance
-        Given host is running
-        Then I set json format
-        Then I set apiUrl in config
-        When I execute CLI with "seq send ../packages/reference-apps/checksum-sequence.tar.gz" arguments
-        Then I get Sequence id
-        Then I start Sequence
-        And I get Instance id
-        Then I send input data from file "data/test-data/checksum.json"
-        Then I kill Instance
-        And host is still running
+    Scenario: E2E-010 TC-011 Test Instances 'stop' option
+        When I execute CLI with "seq send ../packages/reference-apps/checksum-sequence.tar.gz"
+        When I execute CLI with "seq start -"
+        When I execute CLI with "inst ls"
+        When I execute CLI with "inst stop - 3000"
+        And I wait for Instance to end
+        Then I confirm "Instance" list is empty
 
     @ci-api @cli
-    Scenario: E2E-010 TC-008 Send input data to Instance and close input stream
-        Given host is running
-        Then I set json format
-        Then I set apiUrl in config
-        When I execute CLI with "seq send ../packages/reference-apps/checksum-sequence.tar.gz" arguments
-        Then I get Sequence id
-        Then I start Sequence
-        And I get Instance id
-        Then I send input data from file "data/test-data/checksum.json" with options "--end"
-        Then I get Instance output
-        Then confirm data named "checksum" received
-        And host is still running
-
-    @ci-api @cli
-    Scenario: E2E-010 TC-009 List Instances and stop Instance
-        Given host is running
-        Then I set json format
-        Then I set apiUrl in config
-        When I execute CLI with "seq send ../packages/reference-apps/hello-alice-out.tar.gz" arguments
-        Then I get Sequence id
-        Then I start Sequence
-        And I get Instance id
-        Then I get list of Instances
-        Then I stop Instance "3000" "false"
-        And host is still running
-
-    @ci-api @cli
-    Scenario: E2E-010 TC-010 Send event
-        Given host is running
-        Then I set json format
-        Then I set apiUrl in config
-        When I execute CLI with "seq send ../packages/reference-apps/event-sequence-v2.tar.gz" arguments
-        Then I get Sequence id
-        Then I start Sequence
-        Then I get Instance id
-        Then I send an event named "test-event" with event message "test message" to Instance
+    Scenario: E2E-010 TC-012 Test Instance 'event' option
+        When I execute CLI with "seq deploy ../packages/reference-apps/event-sequence-v2.tar.gz"
+        When I execute CLI with "inst event emit - test-event test message"
+        When I execute CLI with "inst event on - test-event-response"
         Then I get event "test-event-response" with event message "{\"eventName\":\"test-event-response\",\"message\":\"message from sequence\"}" from Instance
-        And host is still running
 
     @ci-api @cli
-    Scenario: E2E-010 TC-011 Start Sequence with multiple JSON arguments
-        Given host is running
-        Then I set json format
-        Then I set apiUrl in config
-        When I execute CLI with "seq send ../packages/reference-apps/args-to-output.tar.gz" arguments
-        Then I get Sequence id
-        Then I start Sequence with options "--args [\"Hello\",123,{\"abc\":456},[\"789\"]]"
-        Then I get Instance health
-        Then I get Instance id
-        And I get Instance output without waiting for the end
-        Then confirm data named "args-on-output" will be received
-        And host is still running
+    Scenario: E2E-010 TC-013 Test Sequence 'start' with multiple JSON arguments
+        When I execute CLI with "seq send ../packages/reference-apps/args-to-output.tar.gz"
+        When I execute CLI with "seq start - --args [\"Hello\",123,{\"abc\":456},[\"789\"]]"
+        When I execute CLI with "inst output -" without waiting for the end
+        Then I confirm data named "args-on-output" will be received
+        When I execute CLI with "inst kill -"
 
-    # TODO: This test fails hanging on deployy. Need to investigate.
     @ci-api @cli
-    Scenario: E2E-010 TC-012 Deploy Sequence with multiple JSON arguments
-        Given host is running
-        Then I set json format
-        Then I set apiUrl in config
-        When I execute CLI with "seq deploy data/sequences/args-to-output --args [\"Hello\",123,{\"abc\":456},[\"789\"]]" arguments
-        Then I get Instance id after deployment
-        And I get Instance output without waiting for the end
-        Then confirm data named "args-on-output" will be received
-        And host is still running
+    Scenario: E2E-010 TC-014 Deploy Sequence with multiple JSON arguments
+        When I execute CLI with "seq deploy data/sequences/deploy-app/dist --args [\"Hello\",123,{\"abc\":456},[\"789\"]]"
+        When I execute CLI with "inst output -" without waiting for the end
+        Then I confirm data named "args-on-output" will be received
+        When I execute CLI with "inst kill -"
 
     # This tests writes and uses shared config file so it may fail if run in parallel
     @ci-api @cli @no-parallel
-    Scenario: E2E-010 TC-013 Check minus replacements with a Sequence
-        Given host is running
-        Then I set json format
-        Then I set apiUrl in config
-        When I execute CLI with "seq pack data/sequences/simple-stdio -o data/simple-stdio.tar.gz" arguments
-        And I execute CLI with "seq send -" arguments
-        And I execute CLI with "seq start -" arguments
-        And I execute CLI with "inst info -" arguments
-        And I execute CLI with "inst kill -" arguments
-        And wait for instance healthy is "false"
-        # Give instance some time to close correctly
-        And wait for "1000" ms
-        And I execute CLI with "seq rm -" arguments
-        And host is still running
+    Scenario: E2E-010 TC-015 Check minus replacements with a Sequence
+        When I execute CLI with "seq pack data/sequences/simple-stdio -o data/simple-stdio.tar.gz"
+        And I execute CLI with "seq send -"
+        And I execute CLI with "seq start -"
+        And I execute CLI with "inst info -"
+        And I execute CLI with "inst kill -"
+        And I wait for Instance to end
+        And I execute CLI with "seq rm -"
+        Then I confirm "Instance" list is empty
+        Then I confirm "Sequence" list is empty
 
     @ci-api @cli
-    Scenario: E2E-010 TC-014 API to API
-        Given host is running
-        Then I set json format
-        Then I set apiUrl in config
-        When I execute CLI with "topic send cities features/e2e/cities.json" arguments
-        Then I execute CLI with "topic get cities" arguments without waiting for the end
-        Then confirm data named "nyc-city-nl" will be received
-        And host is still running
+    Scenario: E2E-010 TC-016 API to API
+        When I execute CLI with "topic send cities features/e2e/cities.json"
+        Then I execute CLI with "topic get cities" without waiting for the end
+        Then I confirm data named "nyc-city-nl" will be received
 
     @ci-api @cli
-    Scenario: E2E-010 TC-015 Instance to API
-        Given host is running
-        Then I set json format
-        Then I set apiUrl in config
-        When I execute CLI with "seq send ../packages/reference-apps/endless-names-output.tar.gz" arguments
-        Then I get Sequence id
-        When I start Sequence with options "--output-topic names5"
-        Then I get Instance health
-        Then I execute CLI with "topic get names5" arguments without waiting for the end
-        Then confirm data named "endless-names-10" will be received
-        And host is still running
+    Scenario: E2E-010 TC-017 Instance to API
+        When I execute CLI with "seq send ../packages/reference-apps/endless-names-output.tar.gz"
+        When I execute CLI with "seq start - --output-topic names13"
+        Then I execute CLI with "topic get names13" without waiting for the end
+        Then I confirm data named "endless-names-10" will be received
+        Then I execute CLI with "inst kill -"
 
     @ci-api @cli
-    Scenario: E2E-010 TC-016 API to Instance
-        Given host is running
-        Then I set json format
-        Then I set apiUrl in config
-        When I execute CLI with "topic send names6 features/e2e/data.json" arguments
-        When I execute CLI with "seq send ../packages/reference-apps/hello-input-out.tar.gz" arguments
-        Then I get Sequence id
-        Then I start Sequence with options "--input-topic names6"
-        Then I get Instance health
-        Then I get Instance id
+    Scenario: E2E-010 TC-018 API to Instance
+        When I execute CLI with "topic send names14 features/e2e/data.json"
+        When I execute CLI with "seq send ../packages/reference-apps/hello-input-out.tar.gz"
+        When I execute CLI with "seq start - --input-topic names14 "
         And wait for "10000" ms
-        And I get Instance output without waiting for the end
-        Then confirm data named "hello-avengers" will be received
-        And host is still running
+        And I execute CLI with "inst output -" without waiting for the end
+        Then I confirm data named "hello-avengers" will be received
+        Then I execute CLI with "inst kill -"
 
     # TODO: need to test this via separate two sequences
     @ci-api @cli @not-github
-    Scenario: E2E-010 TC-017 Instance to Instance
-        Given host is running
-        Then I set json format
-        Then I set apiUrl in config
-        When I execute CLI with "seq prune -f" arguments
-        When I execute CLI with "seq send ../packages/reference-apps/endless-names-output.tar.gz" arguments
-        When I execute CLI with "seq send ../packages/reference-apps/hello-input-out.tar.gz" arguments
-        And I get list of Sequences
-        And there are some sequences
-        Then I get id from both Sequences
-        Then I start the first Sequence
+    Scenario: E2E-010 TC-019 Instance to Instance
+        When I execute CLI with "seq send ../packages/reference-apps/endless-names-output.tar.gz"
+        When I execute CLI with "seq start - --output-topic names15"
         And wait for "6000" ms
-        Then I start the second Sequence
+        When I execute CLI with "seq send ../packages/reference-apps/hello-input-out.tar.gz"
+        When I execute CLI with "seq start - --input-topic names15"
         And wait for "4000" ms
-        And I get the second Instance output without waiting for the end
-        Then confirm data named "hello-input-out-10" will be received
-        And host is still running
+        And I execute CLI with "inst output -" without waiting for the end
+        Then I confirm data named "hello-input-out-10" will be received
+        Then I execute CLI with "inst kill -"
 
     @ci-api @cli
-    Scenario: E2E-010 TC-018 Rename topic output
-        Given host is running
-        Then I set json format
-        Then I set apiUrl in config
-        When I execute CLI with "seq send ../packages/reference-apps/endless-names-output.tar.gz" arguments
-        Then I get Sequence id
-        Then I start Sequence with options "--output-topic names2"
-        Then I get Instance health
-        Then I execute CLI with "topic get names2" arguments without waiting for the end
-        Then confirm data named "endless-names-10" will be received
-        And host is still running
-
-    @ci-api @cli
-    Scenario: E2E-010 TC-019 Rename topic input
-        Given host is running
-        Then I set json format
-        Then I set apiUrl in config
-        When I execute CLI with "topic send names4 features/e2e/data.json" arguments
-        When I execute CLI with "seq send ../packages/reference-apps/hello-input-out.tar.gz" arguments
-        Then I get Sequence id
-        Then I start Sequence with options "--input-topic names4"
-        Then I get Instance health
-        Then I get Instance id
-        And I get Instance output without waiting for the end
-        Then confirm data named "hello-avengers" will be received
-        And host is still running
+    Scenario: E2E-010 TC-020 Get Hub logs
+        When I execute SI command "hub logs" without waiting for the end
+        Then I confirm Hub logs received

--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -70,10 +70,14 @@ This feature checks CLI functionalities
         When I execute CLI with "seq start -"
         When I execute CLI with "inst health -"
         And I wait for Instance to end
+        When I execute CLI with "seq prune --force"
+        Then I confirm "Sequence" list is empty
 
     Scenario: E2E-010 TC-009 Test Instance 'input' option
         When I execute CLI with "seq deploy ../packages/reference-apps/checksum-sequence.tar.gz"
         When I execute CLI with "inst input - data/test-data/checksum.json"
+        When I execute CLI with "seq prune --force"
+        Then I confirm "Sequence" list is empty
 
     @ci-api @cli
     Scenario: E2E-010 TC-010 Test Instance 'input --end' option and confirm output received
@@ -106,7 +110,6 @@ This feature checks CLI functionalities
 
     @ci-api @cli
     Scenario: E2E-010 TC-013 Test Sequence 'start' with multiple JSON arguments
-        Given I set config for local Hub
         When I execute CLI with "seq send ../packages/reference-apps/args-to-output.tar.gz"
         When I execute CLI with "seq start - --args [\"Hello\",123,{\"abc\":456},[\"789\"]]"
         When I execute CLI with "inst output -" without waiting for the end

--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -32,8 +32,21 @@ This feature checks CLI functionalities
         When I execute CLI with "seq prune"
         When I execute CLI with "seq list"
 
+    # This tests writes and uses shared config file so it may fail if run in parallel
+    @ci-api @cli @no-parallel
+    Scenario: E2E-010 TC-005 Check minus replacements with a Sequence
+        When I execute CLI with "seq pack data/sequences/simple-stdio -o data/simple-stdio.tar.gz"
+        And I execute CLI with "seq send -"
+        And I execute CLI with "seq start -"
+        And I execute CLI with "inst info -"
+        And I execute CLI with "inst kill -"
+        And I wait for Instance to end
+        And I execute CLI with "seq rm -"
+        Then I confirm "Instance" list is empty
+        Then I confirm "Sequence" list is empty
+
     @ci-api @cli
-    Scenario: E2E-010 TC-005 Test Sequence 'prune --force' option
+    Scenario: E2E-010 TC-006 Test Sequence 'prune --force' option
         When I execute CLI with "seq send ../packages/reference-apps/checksum-sequence.tar.gz"
         When I execute CLI with "seq send ../packages/reference-apps/csv-transform.tar.gz"
         When I execute CLI with "seq list"
@@ -44,7 +57,7 @@ This feature checks CLI functionalities
         Then I confirm "Sequence" list is empty
 
     @ci-api @cli
-    Scenario: E2E-010 TC-006 Test Instance options
+    Scenario: E2E-010 TC-007 Test Instance options
         When I execute CLI with "inst --help"
         When I execute CLI with "seq send ../packages/reference-apps/csv-transform.tar.gz"
         When I execute CLI with "seq start -"
@@ -56,40 +69,7 @@ This feature checks CLI functionalities
         Then I confirm "Instance" list is empty
 
     @ci-api @cli
-    Scenario: E2E-010 TC-007 Test Instance 'log' option
-        When I execute CLI with "seq send ../packages/reference-apps/inert-function.tar.gz"
-        When I execute CLI with "seq start -"
-        When I execute CLI with "inst log -" without waiting for the end
-        Then I confirm instance logs received
-        When I execute CLI with "seq prune --force"
-        Then I confirm "Sequence" list is empty
-
-    @ci-api @cli @not-github
-    Scenario: E2E-010 TC-008 Get 404 on health endpoint for finished Instance
-        When I execute CLI with "seq send ../packages/reference-apps/inert-function.tar.gz"
-        When I execute CLI with "seq start -"
-        When I execute CLI with "inst health -"
-        And I wait for Instance to end
-        When I execute CLI with "seq prune --force"
-        Then I confirm "Sequence" list is empty
-
-    Scenario: E2E-010 TC-009 Test Instance 'input' option
-        When I execute CLI with "seq deploy ../packages/reference-apps/checksum-sequence.tar.gz"
-        When I execute CLI with "inst input - data/test-data/checksum.json"
-        When I execute CLI with "seq prune --force"
-        Then I confirm "Sequence" list is empty
-
-    @ci-api @cli
-    Scenario: E2E-010 TC-010 Test Instance 'input --end' option and confirm output received
-        When I execute CLI with "seq deploy ../packages/reference-apps/checksum-sequence.tar.gz"
-        When I execute CLI with "inst input - data/test-data/checksum.json --end"
-        When I execute CLI with "inst output -"
-        Then I confirm data named "checksum" received
-        When I execute CLI with "seq prune --force"
-        Then I confirm "Sequence" list is empty
-
-    @ci-api @cli
-    Scenario: E2E-010 TC-011 Test Instances 'stop' option
+    Scenario: E2E-010 TC-008 Test Instances 'stop' option
         When I execute CLI with "seq send ../packages/reference-apps/checksum-sequence.tar.gz"
         When I execute CLI with "seq start -"
         When I execute CLI with "inst ls"
@@ -100,43 +80,52 @@ This feature checks CLI functionalities
         Then I confirm "Sequence" list is empty
 
     @ci-api @cli
-    Scenario: E2E-010 TC-012 Test Instance 'event' option
+    Scenario: E2E-010 TC-009 Get 404 on health endpoint for finished Instance
+        When I execute CLI with "seq send ../packages/reference-apps/inert-function.tar.gz"
+        When I execute CLI with "seq start -"
+        When I execute CLI with "inst health -"
+        And I wait for Instance to end
+        When I execute CLI with "seq prune --force"
+        Then I confirm "Sequence" list is empty
+
+    @ci-api @cli
+    Scenario: E2E-010 TC-010 Test Instance 'log' option
+        When I execute CLI with "seq send ../packages/reference-apps/inert-function.tar.gz"
+        When I execute CLI with "seq start -"
+        When I execute CLI with "inst log -" without waiting for the end
+        Then I confirm instance logs received
+
+    @ci-api @cli
+    Scenario: E2E-010 TC-011 Test Instance 'input' option
+        When I execute CLI with "seq deploy ../packages/reference-apps/checksum-sequence.tar.gz"
+        When I execute CLI with "inst input - data/test-data/checksum.json"
+
+    @ci-api @cli
+    Scenario: E2E-010 TC-012 Test Instance 'input --end' option and confirm output received
+        When I execute CLI with "seq deploy ../packages/reference-apps/checksum-sequence.tar.gz"
+        When I execute CLI with "inst input - data/test-data/checksum.json --end"
+        When I execute CLI with "inst output -"
+        Then I confirm data named "checksum" received
+
+    @ci-api @cli
+    Scenario: E2E-010 TC-013 Test Instance 'event' option
         When I execute CLI with "seq deploy ../packages/reference-apps/event-sequence-v2.tar.gz"
         When I execute CLI with "inst event emit - test-event test message"
         When I execute CLI with "inst event on - test-event-response"
         Then I get event "test-event-response" with event message "{\"eventName\":\"test-event-response\",\"message\":\"message from sequence\"}" from Instance
-        When I execute CLI with "seq prune --force"
-        Then I confirm "Sequence" list is empty
 
     @ci-api @cli
-    Scenario: E2E-010 TC-013 Test Sequence 'start' with multiple JSON arguments
+    Scenario: E2E-010 TC-014 Test Sequence 'start' with multiple JSON arguments
         When I execute CLI with "seq send ../packages/reference-apps/args-to-output.tar.gz"
         When I execute CLI with "seq start - --args [\"Hello\",123,{\"abc\":456},[\"789\"]]"
         When I execute CLI with "inst output -" without waiting for the end
         Then I confirm data named "args-on-output" will be received
-        When I execute CLI with "seq prune --force"
-        Then I confirm "Sequence" list is empty
 
     @ci-api @cli
-    Scenario: E2E-010 TC-014 Deploy Sequence with multiple JSON arguments
+    Scenario: E2E-010 TC-015 Deploy Sequence with multiple JSON arguments
         When I execute CLI with "seq deploy data/sequences/deploy-app/dist --args [\"Hello\",123,{\"abc\":456},[\"789\"]]"
         When I execute CLI with "inst output -" without waiting for the end
         Then I confirm data named "args-on-output" will be received
-        When I execute CLI with "seq prune --force"
-        Then I confirm "Sequence" list is empty
-
-    # This tests writes and uses shared config file so it may fail if run in parallel
-    @ci-api @cli @no-parallel
-    Scenario: E2E-010 TC-015 Check minus replacements with a Sequence
-        When I execute CLI with "seq pack data/sequences/simple-stdio -o data/simple-stdio.tar.gz"
-        And I execute CLI with "seq send -"
-        And I execute CLI with "seq start -"
-        And I execute CLI with "inst info -"
-        And I execute CLI with "inst kill -"
-        And I wait for Instance to end
-        And I execute CLI with "seq rm -"
-        Then I confirm "Instance" list is empty
-        Then I confirm "Sequence" list is empty
 
     @ci-api @cli
     Scenario: E2E-010 TC-016 API to API
@@ -150,7 +139,6 @@ This feature checks CLI functionalities
         When I execute CLI with "seq start - --output-topic names13"
         Then I execute CLI with "topic get names13" without waiting for the end
         Then I confirm data named "endless-names-10" will be received
-        Then I execute CLI with "inst kill -"
 
     @ci-api @cli
     Scenario: E2E-010 TC-018 API to Instance
@@ -160,10 +148,9 @@ This feature checks CLI functionalities
         And wait for "10000" ms
         And I execute CLI with "inst output -" without waiting for the end
         Then I confirm data named "hello-avengers" will be received
-        Then I execute CLI with "inst kill -"
 
     # TODO: need to test this via separate two sequences
-    @ci-api @cli @not-github
+    @ci-api @cli
     Scenario: E2E-010 TC-019 Instance to Instance
         When I execute CLI with "seq send ../packages/reference-apps/endless-names-output.tar.gz"
         When I execute CLI with "seq start - --output-topic names15"
@@ -173,7 +160,6 @@ This feature checks CLI functionalities
         And wait for "4000" ms
         And I execute CLI with "inst output -" without waiting for the end
         Then I confirm data named "hello-input-out-10" will be received
-        Then I execute CLI with "inst kill -"
 
     @ci-api @cli
     Scenario: E2E-010 TC-020 Get Hub logs

--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -61,7 +61,8 @@ This feature checks CLI functionalities
         When I execute CLI with "seq start -"
         When I execute CLI with "inst log -" without waiting for the end
         Then I confirm instance logs received
-        When I execute CLI with "inst kill -"
+        When I execute CLI with "seq prune --force"
+        Then I confirm "Sequence" list is empty
 
     @ci-api @cli @not-github
     Scenario: E2E-010 TC-008 Get 404 on health endpoint for finished Instance
@@ -69,12 +70,10 @@ This feature checks CLI functionalities
         When I execute CLI with "seq start -"
         When I execute CLI with "inst health -"
         And I wait for Instance to end
-        Then I confirm "Instance" list is empty
 
     Scenario: E2E-010 TC-009 Test Instance 'input' option
         When I execute CLI with "seq deploy ../packages/reference-apps/checksum-sequence.tar.gz"
         When I execute CLI with "inst input - data/test-data/checksum.json"
-        When I execute CLI with "inst kill -"
 
     @ci-api @cli
     Scenario: E2E-010 TC-010 Test Instance 'input --end' option and confirm output received
@@ -82,6 +81,8 @@ This feature checks CLI functionalities
         When I execute CLI with "inst input - data/test-data/checksum.json --end"
         When I execute CLI with "inst output -"
         Then I confirm data named "checksum" received
+        When I execute CLI with "seq prune --force"
+        Then I confirm "Sequence" list is empty
 
     @ci-api @cli
     Scenario: E2E-010 TC-011 Test Instances 'stop' option
@@ -91,6 +92,8 @@ This feature checks CLI functionalities
         When I execute CLI with "inst stop - 3000"
         And I wait for Instance to end
         Then I confirm "Instance" list is empty
+        When I execute CLI with "seq prune --force"
+        Then I confirm "Sequence" list is empty
 
     @ci-api @cli
     Scenario: E2E-010 TC-012 Test Instance 'event' option
@@ -98,21 +101,26 @@ This feature checks CLI functionalities
         When I execute CLI with "inst event emit - test-event test message"
         When I execute CLI with "inst event on - test-event-response"
         Then I get event "test-event-response" with event message "{\"eventName\":\"test-event-response\",\"message\":\"message from sequence\"}" from Instance
+        When I execute CLI with "seq prune --force"
+        Then I confirm "Sequence" list is empty
 
     @ci-api @cli
     Scenario: E2E-010 TC-013 Test Sequence 'start' with multiple JSON arguments
+        Given I set config for local Hub
         When I execute CLI with "seq send ../packages/reference-apps/args-to-output.tar.gz"
         When I execute CLI with "seq start - --args [\"Hello\",123,{\"abc\":456},[\"789\"]]"
         When I execute CLI with "inst output -" without waiting for the end
         Then I confirm data named "args-on-output" will be received
-        When I execute CLI with "inst kill -"
+        When I execute CLI with "seq prune --force"
+        Then I confirm "Sequence" list is empty
 
     @ci-api @cli
     Scenario: E2E-010 TC-014 Deploy Sequence with multiple JSON arguments
         When I execute CLI with "seq deploy data/sequences/deploy-app/dist --args [\"Hello\",123,{\"abc\":456},[\"789\"]]"
         When I execute CLI with "inst output -" without waiting for the end
         Then I confirm data named "args-on-output" will be received
-        When I execute CLI with "inst kill -"
+        When I execute CLI with "seq prune --force"
+        Then I confirm "Sequence" list is empty
 
     # This tests writes and uses shared config file so it may fail if run in parallel
     @ci-api @cli @no-parallel
@@ -166,5 +174,5 @@ This feature checks CLI functionalities
 
     @ci-api @cli
     Scenario: E2E-010 TC-020 Get Hub logs
-        When I execute SI command "hub logs" without waiting for the end
+        When I execute CLI with "hub logs" without waiting for the end
         Then I confirm Hub logs received

--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -122,7 +122,7 @@ This feature checks CLI functionalities
         Then I confirm data named "args-on-output" will be received
 
     @ci-api @cli
-    Scenario: E2E-010 TC-015 Deploy Sequence with multiple JSON arguments
+    Scenario: E2E-010 TC-015 Deploy uncompressed Sequence with multiple JSON arguments
         When I execute CLI with "seq deploy data/sequences/deploy-app/dist --args [\"Hello\",123,{\"abc\":456},[\"789\"]]"
         When I execute CLI with "inst output -" without waiting for the end
         Then I confirm data named "args-on-output" will be received

--- a/bdd/features/e2e/E2E-014-python.feature
+++ b/bdd/features/e2e/E2E-014-python.feature
@@ -51,7 +51,6 @@ Feature: Test our shiny new Python runner
         Then I set config for local Hub
         When I execute CLI with "seq send ../packages/reference-apps/python-topic-producer.tar.gz"
         When I execute CLI with "seq start - --output-topic names3"
-        When I execute CLI with ""
         Then I send input data "topic test input" with options "--end"
         When I execute CLI with "seq send ../packages/reference-apps/python-topic-consumer.tar.gz"
         When I execute CLI with "seq start - --input-topic names3"

--- a/bdd/features/e2e/E2E-014-python.feature
+++ b/bdd/features/e2e/E2E-014-python.feature
@@ -48,17 +48,16 @@ Feature: Test our shiny new Python runner
     @ci-instance-python
     Scenario: E2E-014 TC-014 Rename topic output and input
         Given host is running
-        Then I set json format
-        Then I set apiUrl in config
-        When I execute CLI with "seq send ../packages/reference-apps/python-topic-producer.tar.gz" arguments
+        Then I set config for local Hub
+        When I execute CLI with "seq send ../packages/reference-apps/python-topic-producer.tar.gz"
         Then I get Sequence id
         Then I start Sequence with options "--output-topic names3"
         Then I send input data "topic test input" with options "--end"
-        When I execute CLI with "seq send ../packages/reference-apps/python-topic-consumer.tar.gz" arguments
+        When I execute CLI with "seq send ../packages/reference-apps/python-topic-consumer.tar.gz"
         Then I get Sequence id
         Then I start Sequence with options "--input-topic names3"
         And I get Instance output without waiting for the end
-        Then confirm data named "python-topics" will be received
+        Then I confirm data named "python-topics" will be received
         And host is still running
 
     @ci-instance-python

--- a/bdd/features/e2e/E2E-014-python.feature
+++ b/bdd/features/e2e/E2E-014-python.feature
@@ -50,13 +50,12 @@ Feature: Test our shiny new Python runner
         Given host is running
         Then I set config for local Hub
         When I execute CLI with "seq send ../packages/reference-apps/python-topic-producer.tar.gz"
-        Then I get Sequence id
-        Then I start Sequence with options "--output-topic names3"
+        When I execute CLI with "seq start - --output-topic names3"
+        When I execute CLI with ""
         Then I send input data "topic test input" with options "--end"
         When I execute CLI with "seq send ../packages/reference-apps/python-topic-consumer.tar.gz"
-        Then I get Sequence id
-        Then I start Sequence with options "--input-topic names3"
-        And I get Instance output without waiting for the end
+        When I execute CLI with "seq start - --input-topic names3"
+        And I execute CLI with "inst output -" without waiting for the end
         Then I confirm data named "python-topics" will be received
         And host is still running
 

--- a/bdd/step-definitions/e2e/cli.ts
+++ b/bdd/step-definitions/e2e/cli.ts
@@ -333,8 +333,6 @@ Then("there are some instances", async function() {
 
 Then("I see a sequence called {string}", function(string: string) {
     const { sequences } = (this as CustomWorld).cliResources;
-
-    // Write code here that turns the phrase above into concrete actions
     const sequenceFound = sequences?.find(({ id }: { id: string }) => {
         return id === string;
     });
@@ -400,6 +398,12 @@ Then("I confirm {string} list is empty", async function(this: CustomWorld, entit
 
         assert.equal(emptyList.trim(), "[]");
     }
+});
+
+Then("I confirm instance logs received", async function(this: CustomWorld) {
+    const { stdout } = this.cliResources!.commandInProgress!;
+
+    await waitUntilStreamContains(stdout, "");
 });
 
 Then("I confirm Hub logs received", async function(this: CustomWorld) {

--- a/bdd/step-definitions/e2e/cli.ts
+++ b/bdd/step-definitions/e2e/cli.ts
@@ -355,13 +355,6 @@ Then("I get list of Instances", async function() {
     assert.equal(instanceFound, true);
 });
 
-// When("I send an event named {string} with event message {string} to Instance", async function(eventName: string, eventMsg: string) {
-//     const res = (this as CustomWorld).cliResources;
-
-//     res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "event", "emit", res.instanceId || "", eventName, eventMsg]);
-//     assert.equal(res.stdio[2], 0);
-// });
-
 Then("I get event {string} with event message {string} from Instance", async function(eventName: string, value: string) {
     const res = (this as CustomWorld).cliResources;
 
@@ -409,9 +402,9 @@ Then("I confirm {string} list is empty", async function(this: CustomWorld, entit
     }
 });
 
-// Then("I confirm Hub is running", async function(this: CustomWorld) {
-//     const res = this.cliResources!;
-//     const hubLoadStatus = res.stdio![2];
+Then("I confirm Hub logs received", async function(this: CustomWorld) {
+    const { stdout } = this.cliResources!.commandInProgress!;
 
-//     assert.equal(hubLoadStatus, 0);
-// });
+    await waitUntilStreamContains(stdout, "");
+});
+

--- a/bdd/step-definitions/e2e/cli.ts
+++ b/bdd/step-definitions/e2e/cli.ts
@@ -5,7 +5,6 @@
 import { Given, Then, When } from "@cucumber/cucumber";
 import { strict as assert } from "assert";
 import fs from "fs";
-// import { STHRestAPI } from "@scramjet/types";
 import { getStreamsFromSpawn, defer, waitUntilStreamEquals, waitUntilStreamContains } from "../../lib/utils";
 import { expectedResponses } from "./expectedResponses";
 import { CustomWorld } from "../world";
@@ -58,147 +57,6 @@ Then("I get location {string} of compressed directory", function(filepath: strin
     assert.equal(fs.existsSync(filepath), true);
 });
 
-// Then("I get a help information", function() {
-//     const res = (this as CustomWorld).cliResources;
-//     const stdio: any[] = res.stdio || [];
-
-//     assert.equal(stdio[0]?.includes("Usage:"), true);
-// });
-
-// Then("I get a version", function() {
-//     const res = (this as CustomWorld).cliResources;
-//     const stdio: any = res.stdio || [];
-
-//     logger.log("Version:", stdio[0]);
-//     assert.equal(stdio[2], 0);
-// });
-
-// Then("I get Sequence id", function() {
-//     const res = (this as CustomWorld).cliResources;
-//     const stdio = res.stdio || [];
-
-//     const seq = JSON.parse((stdio[0] || "").replace("\n", ""));
-
-//     res.sequenceId = seq._id;
-//     assert.equal(typeof res.sequenceId !== "undefined", true);
-// });
-
-// Then("I get id from both Sequences", function() {
-//     const res = (this as CustomWorld).cliResources;
-//     const stdio = res.stdio || [];
-
-//     const seq1 = JSON.parse((stdio[0] || "").replace("\n", ""))[0];
-//     const seq2 = JSON.parse((stdio[0] || "").replace("\n", ""))[1];
-
-//     res.sequence1Id = seq1.id;
-//     res.sequence2Id = seq2.id;
-
-//     assert.equal(typeof res.sequence1Id && typeof res.sequence2Id !== "undefined", true);
-// });
-
-// Then("I start the first Sequence", async function() {
-//     const res = (this as CustomWorld).cliResources;
-//     const sequence1Id: string = res.sequence1Id || "";
-
-//     try {
-//         res.stdio1 = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "start", sequence1Id]);
-//         assert.equal(res.stdio1[2], 0);
-
-//         if (process.env.SCRAMJET_TEST_LOG) {
-//             logger.debug(res.stdio1[0]);
-//         }
-
-//         const instance1 = JSON.parse(res.stdio1[0].replace("\n", ""));
-
-//         res.instance1Id = instance1._id;
-
-//         assert.equal(typeof res.instance1Id !== "undefined", true);
-//     } catch (e: any) {
-//         logger.error(e.stack, res.stdio);
-//         assert.fail("Error occurred");
-//     }
-// });
-
-// Then("I start the second Sequence", async function() {
-//     const res = (this as CustomWorld).cliResources;
-//     const sequence2Id: string = res.sequence2Id || "";
-
-//     try {
-//         res.stdio2 = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "start", sequence2Id]);
-//         assert.equal(res.stdio2[2], 0);
-
-//         if (process.env.SCRAMJET_TEST_LOG) {
-//             logger.debug(res.stdio2[0]);
-//         }
-
-//         const instance2 = JSON.parse(res.stdio2[0].replace("\n", ""));
-
-//         res.instance2Id = instance2._id;
-
-//         assert.equal(typeof res.instance2Id !== "undefined", true);
-//     } catch (e: any) {
-//         logger.error(e.stack, res.stdio);
-//         assert.fail("Error occurred");
-//     }
-// });
-
-// Then("I get array of information about Sequences", function() {
-//     const res = (this as CustomWorld).cliResources;
-//     const stdio = res.stdio || [];
-//     const arr = JSON.parse((stdio[0] || "").replace("\n", ""));
-
-//     assert.equal(Array.isArray(arr), true);
-// });
-
-// Then("I start Sequence", async function() {
-//     const res = (this as CustomWorld).cliResources;
-//     const sequenceId: string = res.sequenceId || "";
-
-//     try {
-//         res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "start", sequenceId]);
-//         assert.equal(res.stdio[2], 0);
-
-//         if (process.env.SCRAMJET_TEST_LOG) {
-//             logger.debug(res.stdio[0]);
-//         }
-
-//         const instance = JSON.parse(res.stdio[0].replace("\n", ""));
-
-//         res.instanceId = instance._id;
-//     } catch (e: any) {
-//         logger.error(e.stack, res.stdio);
-//         assert.fail("Error occurred");
-//     }
-// });
-
-// Then("I start Sequence with options {string}", async function(optionsStr: string) {
-//     const res = (this as CustomWorld).cliResources;
-//     const sequenceId: string = res.sequenceId || "";
-//     const options = optionsStr.split(" ");
-
-//     try {
-//         res.stdio = await getStreamsFromSpawn("/usr/bin/env", ["NODE_ENV=development", ...si, "seq", "start", sequenceId, ...options]);
-//         assert.equal(res.stdio[2], 0);
-
-//         if (process.env.SCRAMJET_TEST_LOG) {
-//             logger.debug(res.stdio[0]);
-//         }
-
-//         const instance = JSON.parse(res.stdio[0].replace("\n", ""));
-
-//         res.instanceId = instance._id;
-//     } catch (e: any) {
-//         logger.error(e.stack, res.stdio);
-//         assert.fail("Error occurred");
-//     }
-// });
-
-// Then("I get Instance id", function() {
-//     const res = (this as CustomWorld).cliResources;
-
-//     assert.equal(typeof res.instanceId !== "undefined", true);
-// });
-
 Then("I get Instance id after deployment", function() {
     const res = (this as CustomWorld).cliResources;
     const stdio = res.stdio![0].split("\n");
@@ -207,33 +65,6 @@ Then("I get Instance id after deployment", function() {
     (this as CustomWorld).cliResources.instanceId = json._id;
     assert.equal(typeof json._id !== "undefined", true);
 });
-
-// Then("I kill Instance", async function() {
-//     const res = (this as CustomWorld).cliResources;
-
-//     res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "kill", res.instanceId || ""]);
-
-//     assert.equal(res.stdio[2], 0);
-// });
-
-// Then("I delete Sequence", { timeout: 10000 }, async function() {
-//     const res = (this as CustomWorld).cliResources;
-
-//     res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "delete", res.sequenceId || ""]);
-
-//     assert.equal(res.stdio[2], 0);
-// });
-
-// Then("I get Instance health", { timeout: 10000 }, async function() {
-//     const res = (this as CustomWorld).cliResources;
-
-//     res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "health", res.instanceId || ""]);
-
-//     assert.equal(res.stdio[2], 0);
-//     const msg = JSON.parse((res.stdio[0] || "").replace("\n", ""));
-
-//     assert.equal(typeof msg.healthy !== "undefined", true);
-// });
 
 Then("I wait for Instance to end", { timeout: 25e4 }, async function() {
     const res = (this as CustomWorld).cliResources;
@@ -252,44 +83,8 @@ Then("I wait for Instance to end", { timeout: 25e4 }, async function() {
     }
 });
 
-// Then("I get Instance output", { timeout: 30000 }, async function() {
-//     const res = (this as CustomWorld).cliResources;
-
-//     res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "output", res.instanceId || ""]);
-
-//     assert.equal(res.stdio[2], 0);
-// });
-
-// Then("I get Instance output without waiting for the end", { timeout: 10000 }, async function(this: CustomWorld) {
-//     const cmdProcess = await spawn("/usr/bin/env", [...si, "inst", "output", this.cliResources.instanceId || ""]);
-
-//     this.cliResources.commandInProgress = cmdProcess;
-// });
-
-// Then("I get the second Instance output without waiting for the end", { timeout: 30000 }, async function(this: CustomWorld) {
-//     const cmdProcess = await spawn("/usr/bin/env", [...si, "inst", "output", this.cliResources.instance2Id || ""]);
-
-//     this.cliResources.commandInProgress = cmdProcess;
-// });
-
-// Then("I send input data from file {string}", async function(pathToFile: string) {
-//     const res = (this as CustomWorld).cliResources;
-
-//     res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "input", res.instanceId || "", pathToFile]);
-//     assert.equal(res.stdio[2], 0);
-// });
-
-// Then("I send input data from file {string} with options {string}", async function(pathToFile: string, options: string) {
-//     const res = (this as CustomWorld).cliResources;
-
-//     res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "input", res.instanceId || "", pathToFile, ...options.split(" ")]);
-//     assert.equal(res.stdio[2], 0);
-// });
-
 Then("I send input data {string} with options {string}", async function(data: string, options: string) {
-    const res = (this as CustomWorld).cliResources;
-
-    const inputCmdProc: any = spawn("/usr/bin/env", [...si, "inst", "input", res.instanceId || "", ...options.split(' ')]);
+    const inputCmdProc: any = spawn("/usr/bin/env", [...si, "inst", "input", "-" || "", ...options.split(' ')]);
 
     inputCmdProc.stdin.write(data);
     inputCmdProc.stdin.end();
@@ -298,37 +93,6 @@ Then("I send input data {string} with options {string}", async function(data: st
 
     assert.equal(statusCode, 0);
 });
-
-// Then("I stop Instance {string} {string}", async function(timeout: string, canCallKeepAlive: string) {
-//     const res = (this as CustomWorld).cliResources;
-
-//     res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "stop", res.instanceId || "", timeout, canCallKeepAlive]);
-//     assert.equal(res.stdio[2], 0);
-// });
-
-// Then("I get list of Sequences", async function() {
-//     const res = (this as CustomWorld).cliResources;
-
-//     res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "ls"]);
-//     assert.equal(res.stdio[2], 0);
-//     res.sequences = JSON.parse(res.stdio[0].replace("\n", ""));
-
-//     assert.notEqual(res.sequences, undefined);
-//     assert.notEqual(res.sequences?.length, 0);
-// });
-
-// Then("I get list of Instances", async function() {
-//     const res = (this as CustomWorld).cliResources;
-
-//     res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "ls"]);
-
-//     assert.equal(res.stdio[2], 0);
-//     const instances = JSON.parse(res.stdio[0].replace("\n", "")) as STHRestAPI.GetInstancesResponse;
-
-//     const instanceFound = instances.some(({ id }) => id === res.instanceId);
-
-//     assert.equal(instanceFound, true);
-// });
 
 Then("I get event {string} with event message {string} from Instance", async function(eventName: string, value: string) {
     const res: any = (this as CustomWorld).cliResources;

--- a/bdd/step-definitions/e2e/cli.ts
+++ b/bdd/step-definitions/e2e/cli.ts
@@ -5,7 +5,7 @@
 import { Given, Then, When } from "@cucumber/cucumber";
 import { strict as assert } from "assert";
 import fs from "fs";
-import { STHRestAPI } from "@scramjet/types";
+// import { STHRestAPI } from "@scramjet/types";
 import { getStreamsFromSpawn, defer, waitUntilStreamEquals, waitUntilStreamContains } from "../../lib/utils";
 import { expectedResponses } from "./expectedResponses";
 import { CustomWorld } from "../world";
@@ -54,150 +54,150 @@ When("I execute CLI with {string} without waiting for the end", { timeout: 30000
     this.cliResources.commandInProgress = cmdProcess;
 });
 
-Then("I get a help information", function() {
-    const res = (this as CustomWorld).cliResources;
-    const stdio: any[] = res.stdio || [];
-
-    assert.equal(stdio[0]?.includes("Usage:"), true);
-});
-
-Then("I get a version", function() {
-    const res = (this as CustomWorld).cliResources;
-    const stdio: any = res.stdio || [];
-
-    logger.log("Version:", stdio[0]);
-    assert.equal(stdio[2], 0);
-});
-
 Then("I get location {string} of compressed directory", function(filepath: string) {
     assert.equal(fs.existsSync(filepath), true);
 });
 
-Then("I get Sequence id", function() {
-    const res = (this as CustomWorld).cliResources;
-    const stdio = res.stdio || [];
+// Then("I get a help information", function() {
+//     const res = (this as CustomWorld).cliResources;
+//     const stdio: any[] = res.stdio || [];
 
-    const seq = JSON.parse((stdio[0] || "").replace("\n", ""));
+//     assert.equal(stdio[0]?.includes("Usage:"), true);
+// });
 
-    res.sequenceId = seq._id;
-    assert.equal(typeof res.sequenceId !== "undefined", true);
-});
+// Then("I get a version", function() {
+//     const res = (this as CustomWorld).cliResources;
+//     const stdio: any = res.stdio || [];
 
-Then("I get id from both Sequences", function() {
-    const res = (this as CustomWorld).cliResources;
-    const stdio = res.stdio || [];
+//     logger.log("Version:", stdio[0]);
+//     assert.equal(stdio[2], 0);
+// });
 
-    const seq1 = JSON.parse((stdio[0] || "").replace("\n", ""))[0];
-    const seq2 = JSON.parse((stdio[0] || "").replace("\n", ""))[1];
+// Then("I get Sequence id", function() {
+//     const res = (this as CustomWorld).cliResources;
+//     const stdio = res.stdio || [];
 
-    res.sequence1Id = seq1.id;
-    res.sequence2Id = seq2.id;
+//     const seq = JSON.parse((stdio[0] || "").replace("\n", ""));
 
-    assert.equal(typeof res.sequence1Id && typeof res.sequence2Id !== "undefined", true);
-});
+//     res.sequenceId = seq._id;
+//     assert.equal(typeof res.sequenceId !== "undefined", true);
+// });
 
-Then("I start the first Sequence", async function() {
-    const res = (this as CustomWorld).cliResources;
-    const sequence1Id: string = res.sequence1Id || "";
+// Then("I get id from both Sequences", function() {
+//     const res = (this as CustomWorld).cliResources;
+//     const stdio = res.stdio || [];
 
-    try {
-        res.stdio1 = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "start", sequence1Id]);
-        assert.equal(res.stdio1[2], 0);
+//     const seq1 = JSON.parse((stdio[0] || "").replace("\n", ""))[0];
+//     const seq2 = JSON.parse((stdio[0] || "").replace("\n", ""))[1];
 
-        if (process.env.SCRAMJET_TEST_LOG) {
-            logger.debug(res.stdio1[0]);
-        }
+//     res.sequence1Id = seq1.id;
+//     res.sequence2Id = seq2.id;
 
-        const instance1 = JSON.parse(res.stdio1[0].replace("\n", ""));
+//     assert.equal(typeof res.sequence1Id && typeof res.sequence2Id !== "undefined", true);
+// });
 
-        res.instance1Id = instance1._id;
+// Then("I start the first Sequence", async function() {
+//     const res = (this as CustomWorld).cliResources;
+//     const sequence1Id: string = res.sequence1Id || "";
 
-        assert.equal(typeof res.instance1Id !== "undefined", true);
-    } catch (e: any) {
-        logger.error(e.stack, res.stdio);
-        assert.fail("Error occurred");
-    }
-});
+//     try {
+//         res.stdio1 = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "start", sequence1Id]);
+//         assert.equal(res.stdio1[2], 0);
 
-Then("I start the second Sequence", async function() {
-    const res = (this as CustomWorld).cliResources;
-    const sequence2Id: string = res.sequence2Id || "";
+//         if (process.env.SCRAMJET_TEST_LOG) {
+//             logger.debug(res.stdio1[0]);
+//         }
 
-    try {
-        res.stdio2 = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "start", sequence2Id]);
-        assert.equal(res.stdio2[2], 0);
+//         const instance1 = JSON.parse(res.stdio1[0].replace("\n", ""));
 
-        if (process.env.SCRAMJET_TEST_LOG) {
-            logger.debug(res.stdio2[0]);
-        }
+//         res.instance1Id = instance1._id;
 
-        const instance2 = JSON.parse(res.stdio2[0].replace("\n", ""));
+//         assert.equal(typeof res.instance1Id !== "undefined", true);
+//     } catch (e: any) {
+//         logger.error(e.stack, res.stdio);
+//         assert.fail("Error occurred");
+//     }
+// });
 
-        res.instance2Id = instance2._id;
+// Then("I start the second Sequence", async function() {
+//     const res = (this as CustomWorld).cliResources;
+//     const sequence2Id: string = res.sequence2Id || "";
 
-        assert.equal(typeof res.instance2Id !== "undefined", true);
-    } catch (e: any) {
-        logger.error(e.stack, res.stdio);
-        assert.fail("Error occurred");
-    }
-});
+//     try {
+//         res.stdio2 = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "start", sequence2Id]);
+//         assert.equal(res.stdio2[2], 0);
 
-Then("I get array of information about Sequences", function() {
-    const res = (this as CustomWorld).cliResources;
-    const stdio = res.stdio || [];
-    const arr = JSON.parse((stdio[0] || "").replace("\n", ""));
+//         if (process.env.SCRAMJET_TEST_LOG) {
+//             logger.debug(res.stdio2[0]);
+//         }
 
-    assert.equal(Array.isArray(arr), true);
-});
+//         const instance2 = JSON.parse(res.stdio2[0].replace("\n", ""));
 
-Then("I start Sequence", async function() {
-    const res = (this as CustomWorld).cliResources;
-    const sequenceId: string = res.sequenceId || "";
+//         res.instance2Id = instance2._id;
 
-    try {
-        res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "start", sequenceId]);
-        assert.equal(res.stdio[2], 0);
+//         assert.equal(typeof res.instance2Id !== "undefined", true);
+//     } catch (e: any) {
+//         logger.error(e.stack, res.stdio);
+//         assert.fail("Error occurred");
+//     }
+// });
 
-        if (process.env.SCRAMJET_TEST_LOG) {
-            logger.debug(res.stdio[0]);
-        }
+// Then("I get array of information about Sequences", function() {
+//     const res = (this as CustomWorld).cliResources;
+//     const stdio = res.stdio || [];
+//     const arr = JSON.parse((stdio[0] || "").replace("\n", ""));
 
-        const instance = JSON.parse(res.stdio[0].replace("\n", ""));
+//     assert.equal(Array.isArray(arr), true);
+// });
 
-        res.instanceId = instance._id;
-    } catch (e: any) {
-        logger.error(e.stack, res.stdio);
-        assert.fail("Error occurred");
-    }
-});
+// Then("I start Sequence", async function() {
+//     const res = (this as CustomWorld).cliResources;
+//     const sequenceId: string = res.sequenceId || "";
 
-Then("I start Sequence with options {string}", async function(optionsStr: string) {
-    const res = (this as CustomWorld).cliResources;
-    const sequenceId: string = res.sequenceId || "";
-    const options = optionsStr.split(" ");
+//     try {
+//         res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "start", sequenceId]);
+//         assert.equal(res.stdio[2], 0);
 
-    try {
-        res.stdio = await getStreamsFromSpawn("/usr/bin/env", ["NODE_ENV=development", ...si, "seq", "start", sequenceId, ...options]);
-        assert.equal(res.stdio[2], 0);
+//         if (process.env.SCRAMJET_TEST_LOG) {
+//             logger.debug(res.stdio[0]);
+//         }
 
-        if (process.env.SCRAMJET_TEST_LOG) {
-            logger.debug(res.stdio[0]);
-        }
+//         const instance = JSON.parse(res.stdio[0].replace("\n", ""));
 
-        const instance = JSON.parse(res.stdio[0].replace("\n", ""));
+//         res.instanceId = instance._id;
+//     } catch (e: any) {
+//         logger.error(e.stack, res.stdio);
+//         assert.fail("Error occurred");
+//     }
+// });
 
-        res.instanceId = instance._id;
-    } catch (e: any) {
-        logger.error(e.stack, res.stdio);
-        assert.fail("Error occurred");
-    }
-});
+// Then("I start Sequence with options {string}", async function(optionsStr: string) {
+//     const res = (this as CustomWorld).cliResources;
+//     const sequenceId: string = res.sequenceId || "";
+//     const options = optionsStr.split(" ");
 
-Then("I get Instance id", function() {
-    const res = (this as CustomWorld).cliResources;
+//     try {
+//         res.stdio = await getStreamsFromSpawn("/usr/bin/env", ["NODE_ENV=development", ...si, "seq", "start", sequenceId, ...options]);
+//         assert.equal(res.stdio[2], 0);
 
-    assert.equal(typeof res.instanceId !== "undefined", true);
-});
+//         if (process.env.SCRAMJET_TEST_LOG) {
+//             logger.debug(res.stdio[0]);
+//         }
+
+//         const instance = JSON.parse(res.stdio[0].replace("\n", ""));
+
+//         res.instanceId = instance._id;
+//     } catch (e: any) {
+//         logger.error(e.stack, res.stdio);
+//         assert.fail("Error occurred");
+//     }
+// });
+
+// Then("I get Instance id", function() {
+//     const res = (this as CustomWorld).cliResources;
+
+//     assert.equal(typeof res.instanceId !== "undefined", true);
+// });
 
 Then("I get Instance id after deployment", function() {
     const res = (this as CustomWorld).cliResources;
@@ -208,32 +208,32 @@ Then("I get Instance id after deployment", function() {
     assert.equal(typeof json._id !== "undefined", true);
 });
 
-Then("I kill Instance", async function() {
-    const res = (this as CustomWorld).cliResources;
+// Then("I kill Instance", async function() {
+//     const res = (this as CustomWorld).cliResources;
 
-    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "kill", res.instanceId || ""]);
+//     res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "kill", res.instanceId || ""]);
 
-    assert.equal(res.stdio[2], 0);
-});
+//     assert.equal(res.stdio[2], 0);
+// });
 
-Then("I delete Sequence", { timeout: 10000 }, async function() {
-    const res = (this as CustomWorld).cliResources;
+// Then("I delete Sequence", { timeout: 10000 }, async function() {
+//     const res = (this as CustomWorld).cliResources;
 
-    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "delete", res.sequenceId || ""]);
+//     res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "delete", res.sequenceId || ""]);
 
-    assert.equal(res.stdio[2], 0);
-});
+//     assert.equal(res.stdio[2], 0);
+// });
 
-Then("I get Instance health", { timeout: 10000 }, async function() {
-    const res = (this as CustomWorld).cliResources;
+// Then("I get Instance health", { timeout: 10000 }, async function() {
+//     const res = (this as CustomWorld).cliResources;
 
-    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "health", res.instanceId || ""]);
+//     res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "health", res.instanceId || ""]);
 
-    assert.equal(res.stdio[2], 0);
-    const msg = JSON.parse((res.stdio[0] || "").replace("\n", ""));
+//     assert.equal(res.stdio[2], 0);
+//     const msg = JSON.parse((res.stdio[0] || "").replace("\n", ""));
 
-    assert.equal(typeof msg.healthy !== "undefined", true);
-});
+//     assert.equal(typeof msg.healthy !== "undefined", true);
+// });
 
 Then("I wait for Instance to end", { timeout: 25e4 }, async function() {
     const res = (this as CustomWorld).cliResources;
@@ -252,44 +252,44 @@ Then("I wait for Instance to end", { timeout: 25e4 }, async function() {
     }
 });
 
-Then("I get Instance output", { timeout: 30000 }, async function() {
-    const res = (this as CustomWorld).cliResources;
+// Then("I get Instance output", { timeout: 30000 }, async function() {
+//     const res = (this as CustomWorld).cliResources;
 
-    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "output", res.instanceId || ""]);
+//     res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "output", res.instanceId || ""]);
 
-    assert.equal(res.stdio[2], 0);
-});
+//     assert.equal(res.stdio[2], 0);
+// });
 
-Then("I get Instance output without waiting for the end", { timeout: 10000 }, async function(this: CustomWorld) {
-    const cmdProcess = await spawn("/usr/bin/env", [...si, "inst", "output", this.cliResources.instanceId || ""]);
+// Then("I get Instance output without waiting for the end", { timeout: 10000 }, async function(this: CustomWorld) {
+//     const cmdProcess = await spawn("/usr/bin/env", [...si, "inst", "output", this.cliResources.instanceId || ""]);
 
-    this.cliResources.commandInProgress = cmdProcess;
-});
+//     this.cliResources.commandInProgress = cmdProcess;
+// });
 
-Then("I get the second Instance output without waiting for the end", { timeout: 30000 }, async function(this: CustomWorld) {
-    const cmdProcess = await spawn("/usr/bin/env", [...si, "inst", "output", this.cliResources.instance2Id || ""]);
+// Then("I get the second Instance output without waiting for the end", { timeout: 30000 }, async function(this: CustomWorld) {
+//     const cmdProcess = await spawn("/usr/bin/env", [...si, "inst", "output", this.cliResources.instance2Id || ""]);
 
-    this.cliResources.commandInProgress = cmdProcess;
-});
+//     this.cliResources.commandInProgress = cmdProcess;
+// });
 
-Then("I send input data from file {string}", async function(pathToFile: string) {
-    const res = (this as CustomWorld).cliResources;
+// Then("I send input data from file {string}", async function(pathToFile: string) {
+//     const res = (this as CustomWorld).cliResources;
 
-    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "input", res.instanceId || "", pathToFile]);
-    assert.equal(res.stdio[2], 0);
-});
+//     res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "input", res.instanceId || "", pathToFile]);
+//     assert.equal(res.stdio[2], 0);
+// });
 
-Then("I send input data from file {string} with options {string}", async function(pathToFile: string, options: string) {
-    const res = (this as CustomWorld).cliResources;
+// Then("I send input data from file {string} with options {string}", async function(pathToFile: string, options: string) {
+//     const res = (this as CustomWorld).cliResources;
 
-    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "input", res.instanceId || "", pathToFile, ...options.split(" ")]);
-    assert.equal(res.stdio[2], 0);
-});
+//     res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "input", res.instanceId || "", pathToFile, ...options.split(" ")]);
+//     assert.equal(res.stdio[2], 0);
+// });
 
 Then("I send input data {string} with options {string}", async function(data: string, options: string) {
     const res = (this as CustomWorld).cliResources;
 
-    const inputCmdProc = spawn("/usr/bin/env", [...si, "inst", "input", res.instanceId || "", ...options.split(' ')]);
+    const inputCmdProc: any = spawn("/usr/bin/env", [...si, "inst", "input", res.instanceId || "", ...options.split(' ')]);
 
     inputCmdProc.stdin.write(data);
     inputCmdProc.stdin.end();
@@ -299,62 +299,39 @@ Then("I send input data {string} with options {string}", async function(data: st
     assert.equal(statusCode, 0);
 });
 
-Then("I stop Instance {string} {string}", async function(timeout: string, canCallKeepAlive: string) {
-    const res = (this as CustomWorld).cliResources;
+// Then("I stop Instance {string} {string}", async function(timeout: string, canCallKeepAlive: string) {
+//     const res = (this as CustomWorld).cliResources;
 
-    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "stop", res.instanceId || "", timeout, canCallKeepAlive]);
-    assert.equal(res.stdio[2], 0);
-});
+//     res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "stop", res.instanceId || "", timeout, canCallKeepAlive]);
+//     assert.equal(res.stdio[2], 0);
+// });
 
-Then("I get list of Sequences", async function() {
-    const res = (this as CustomWorld).cliResources;
+// Then("I get list of Sequences", async function() {
+//     const res = (this as CustomWorld).cliResources;
 
-    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "ls"]);
-    assert.equal(res.stdio[2], 0);
-    res.sequences = JSON.parse(res.stdio[0].replace("\n", ""));
+//     res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "seq", "ls"]);
+//     assert.equal(res.stdio[2], 0);
+//     res.sequences = JSON.parse(res.stdio[0].replace("\n", ""));
 
-    assert.notEqual(res.sequences, undefined);
-    assert.notEqual(res.sequences?.length, 0);
-});
+//     assert.notEqual(res.sequences, undefined);
+//     assert.notEqual(res.sequences?.length, 0);
+// });
 
-Then("there are some sequences", async function() {
-    const { sequences } = (this as CustomWorld).cliResources;
+// Then("I get list of Instances", async function() {
+//     const res = (this as CustomWorld).cliResources;
 
-    assert.notEqual(sequences, undefined);
-    assert.notEqual(sequences?.length, 0);
-});
+//     res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "ls"]);
 
-Then("there are some instances", async function() {
-    const { instances } = (this as CustomWorld).cliResources;
+//     assert.equal(res.stdio[2], 0);
+//     const instances = JSON.parse(res.stdio[0].replace("\n", "")) as STHRestAPI.GetInstancesResponse;
 
-    assert.notEqual(instances, undefined);
-    assert.notEqual(instances?.length, 0);
-});
+//     const instanceFound = instances.some(({ id }) => id === res.instanceId);
 
-Then("I see a sequence called {string}", function(string: string) {
-    const { sequences } = (this as CustomWorld).cliResources;
-    const sequenceFound = sequences?.find(({ id }: { id: string }) => {
-        return id === string;
-    });
-
-    assert.notStrictEqual(typeof sequenceFound, "undefined", `Sequence ${string} not found`);
-});
-
-Then("I get list of Instances", async function() {
-    const res = (this as CustomWorld).cliResources;
-
-    res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "ls"]);
-
-    assert.equal(res.stdio[2], 0);
-    const instances = JSON.parse(res.stdio[0].replace("\n", "")) as STHRestAPI.GetInstancesResponse;
-
-    const instanceFound = instances.some(({ id }) => id === res.instanceId);
-
-    assert.equal(instanceFound, true);
-});
+//     assert.equal(instanceFound, true);
+// });
 
 Then("I get event {string} with event message {string} from Instance", async function(eventName: string, value: string) {
-    const res = (this as CustomWorld).cliResources;
+    const res: any = (this as CustomWorld).cliResources;
 
     res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, "inst", "event", "on", "-" || "", eventName]);
     assert.equal(res.stdio[2], 0);
@@ -375,12 +352,6 @@ Then("I confirm data named {string} will be received", async function(this: Cust
     const response = await waitUntilStreamEquals(stdout, expected);
 
     assert.equal(response, expected);
-});
-
-Then("confirm instance logs received", async function(this: CustomWorld) {
-    const { stdout } = this.cliResources!.commandInProgress!;
-
-    await waitUntilStreamContains(stdout, "");
 });
 
 Then("I confirm {string} list is empty", async function(this: CustomWorld, entity: string) {

--- a/bdd/step-definitions/hub/config.ts
+++ b/bdd/step-definitions/hub/config.ts
@@ -88,6 +88,29 @@ Then("I get list of instances", async function(this: CustomWorld) {
     this.cliResources.instances = await hostClient.listInstances();
 });
 
+Then("there are some instances", async function() {
+    const { instances } = (this as CustomWorld).cliResources;
+
+    assert.notEqual(instances, undefined);
+    assert.notEqual(instances?.length, 0);
+});
+
+Then("there are some sequences", async function() {
+    const { sequences } = (this as CustomWorld).cliResources;
+
+    assert.notEqual(sequences, undefined);
+    assert.notEqual(sequences?.length, 0);
+});
+
+Then("I see a sequence called {string}", function(string: string) {
+    const { sequences } = (this as CustomWorld).cliResources;
+    const sequenceFound = sequences?.find(({ id }: { id: string }) => {
+        return id === string;
+    });
+
+    assert.notStrictEqual(typeof sequenceFound, "undefined", `Sequence ${string} not found`);
+});
+
 Then("the output of an instance of {string} is as in {string} file", async function(this: CustomWorld, sequenceId, outputContentsFile) {
     const fileData = await readFile(outputContentsFile, "utf-8");
     const hostClient = getHostClient();

--- a/packages/api-server/src/handlers/get.ts
+++ b/packages/api-server/src/handlers/get.ts
@@ -49,7 +49,7 @@ export function createGetterHandler(router: SequentialCeroRouter): APIRoute["get
                 delete data.opStatus;
             }
 
-            const out = Object.keys(data).length ? JSON.stringify(data) : undefined;
+            const out = Array.isArray(data) || Object.keys(data).length ? JSON.stringify(data) : undefined;
 
             res.writeHead(statusCode, reason, {
                 "content-type": "application/json"

--- a/packages/cli/src/lib/commands/config.ts
+++ b/packages/cli/src/lib/commands/config.ts
@@ -131,7 +131,7 @@ export const config: CommandDefinition = (program) => {
 
     setCmd
         .command("env")
-        .addArgument(new commander.Argument("<production|develop>").choices(["production", "develop"]))
+        .addArgument(new commander.Argument("<production|development>").choices(["production", "development"]))
         .description("Specify the environment")
         .action(env => {
             if (!profileConfig.setEnv(env)) {


### PR DESCRIPTION
<!-- If writing isn't your strength, ask @jan-warchol for help ;) -->
<!-- (or join our Discord https://discord.com/invite/ngXmwvjSYF)  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
- Fix for Issue #583 
- Fix in `si config set env` (could not set `env` `development` in CLI config) because of change in this [line](https://github.com/scramjetorg/transform-hub/pull/585/files#diff-6325315784fa45e3477aa946161cb1f49e3e5918836d6bb9318f8d0afe26b7f0L134)
- bring back `si seq prune -f` CLI test
- bring back the test scenario with sequence deployment, where the Sequence package is not compressed
- unify wording in all CLI scenarios
- clean up redundant definitions

**Verification:**
<!-- Example (if applicable), how to verify (if not covered by tests). -->
- CI tests will verify all the changes 

