### PR TITLE
Allow Arrays in AppConfig

### DIFF
--- a/packages/types/src/app-config.ts
+++ b/packages/types/src/app-config.ts
@@ -1,5 +1,10 @@
+
+type SimpleType = null | string | number | boolean;
+
+type MaybeArray<T> = T | T[];
+
 /**
  * App configuration primitive.
  */
 
-export type AppConfig = { [key: string]: null | string | number | boolean | AppConfig; };
+export type AppConfig = { [key: string]: MaybeArray<SimpleType> | MaybeArray<AppConfig>; };


### PR DESCRIPTION
**What?**  <!-- Two-sentence summary, understandable for a junior. -->

Trivial change that allows using Arrays in AppConfig

**Why?**  <!-- What is this needed for? You can link to an issue. -->

As this is a bug, Arrays should be ok by all means.
