### PR TITLE
Fix handling binary input

### DIFF
--- a/packages/api-server/src/handlers/stream.ts
+++ b/packages/api-server/src/handlers/stream.ts
@@ -133,6 +133,7 @@ export function createStreamHandlers(router: SequentialCeroRouter) {
                     await new Promise<void>((resolve, reject) => {
                         if (encoding) {
                             req.setEncoding(encoding);
+                            (data as Writable).setDefaultEncoding(encoding);
                         }
 
                         req

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -550,7 +550,7 @@ export class CSIController extends TypedEmitter<Events> {
             }
 
             return { opStatus: 406, error: "Input provided in other way." };
-        }, { checkContentType: false, end: true, encoding: "utf-8" });
+        }, { checkContentType: false, end: true, encoding: "binary" });
 
         // monitoring data
         this.router.get("/health", RunnerMessageCode.MONITORING, this.communicationHandler);


### PR DESCRIPTION
**What?**  <!-- Two-sentence summary, understandable for a junior. -->
change default input encoding to `binary`

**Why?**  <!-- What is this needed for? You can link to an issue. -->
when passing binary data to `/input` data was encoded to `utf-8` 

see #608 