### PR TITLE
Remove stream object from topics response

### DIFF
--- a/packages/host/src/lib/sd-adapter.ts
+++ b/packages/host/src/lib/sd-adapter.ts
@@ -162,7 +162,9 @@ export class ServiceDiscovery {
      */
     getTopics() {
         return Array.from(this.dataMap, ([key, value]) => ({
-            ...value, topic: key
+            contentType: value.contentType,
+            localProvider: value.localProvider,
+            topic: key
         }));
     }
 


### PR DESCRIPTION
**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Remove unnecessary data from `/topics` response

**Why?**  <!-- What is this needed for? You can link to an issue. -->
#607 

**Usage:**
<!-- Example (if applicable), how to verify (if not covered by tests). -->
```
si topic send mytopic myfile
```
```
si topic ls
```

Response will be similar to:
```
[ { contentType: 'text/plain', localProvider: 'api', topic: 'mytopic' } ]
```

without stream object mentioned in #607 
