### PR TITLE
Rewrite STH-SCP connection

### DIFF
--- a/packages/api-client/src/host-client.ts
+++ b/packages/api-client/src/host-client.ts
@@ -115,6 +115,13 @@ export class HostClient implements ClientProvider {
     }
 
     /**
+     * Returns Host status.
+     */
+    async getStatus() {
+        return this.client.get<STHRestAPI.GetStatusResponse>("status");
+    }
+
+    /**
      * Returns Host public configuration.
      *
      * @returns {Promise<GetConfigResponse>} Promise resolving to Host configuration (public part).

--- a/packages/host/src/lib/cpm-connector.ts
+++ b/packages/host/src/lib/cpm-connector.ts
@@ -321,6 +321,12 @@ export class CPMConnector extends TypedEmitter<Events> {
         connection.socket
             .on("close", async () => { await this.handleConnectionClose(); });
 
+        /**
+         * @TODO: Distinguish existing `connect` request and started communication (Manager handled this host
+         * and made requests to it).
+         * @TODO: Provide detailed communication status.
+        */
+
         this.connected = true;
         this.connectionAttempts = 0;
 

--- a/packages/host/src/lib/cpm-connector.ts
+++ b/packages/host/src/lib/cpm-connector.ts
@@ -333,11 +333,21 @@ export class CPMConnector extends TypedEmitter<Events> {
         connection.req.on("error", async (error: any) => {
             this.logger.error("Request error", error);
 
-            await this.reconnect();
+            try {
+                await this.reconnect();
+            } catch (e) {
+                this.logger.error("Reconnect failed");
+            }
         });
 
         this.verserClient.on("error", async (error: any) => {
             this.logger.error("VerserClient error", error);
+
+            try {
+                await this.reconnect();
+            } catch (e) {
+                this.logger.error("Reconnect failed");
+            }
 
             await this.reconnect();
         });
@@ -383,11 +393,11 @@ export class CPMConnector extends TypedEmitter<Events> {
         if (shouldReconnect) {
             this.isReconnecting = true;
 
-            await new Promise<void>((res) => {
+            await new Promise<void>((resolve, reject) => {
                 setTimeout(async () => {
                     this.logger.info("Connection lost, retrying", this.connectionAttempts);
 
-                    await this.connect();
+                    await this.connect().then(resolve, reject);
                 }, this.config.reconnectionDelay);
             });
         }

--- a/packages/host/src/lib/cpm-connector.ts
+++ b/packages/host/src/lib/cpm-connector.ts
@@ -311,7 +311,7 @@ export class CPMConnector extends TypedEmitter<Events> {
         } catch (err) {
             this.logger.error("Can not connect to Manager", err);
 
-            this.reconnect();
+            await this.reconnect();
 
             return;
         }
@@ -324,16 +324,16 @@ export class CPMConnector extends TypedEmitter<Events> {
         this.connected = true;
         this.connectionAttempts = 0;
 
-        connection.req.on("error", (error: any) => {
+        connection.req.on("error", async (error: any) => {
             this.logger.error("Request error", error);
 
-            this.reconnect();
+            await this.reconnect();
         });
 
-        this.verserClient.on("error", (error: any) => {
+        this.verserClient.on("error", async (error: any) => {
             this.logger.error("VerserClient error", error);
 
-            this.reconnect();
+            await this.reconnect();
         });
     }
 
@@ -352,7 +352,7 @@ export class CPMConnector extends TypedEmitter<Events> {
             clearInterval(this.loadInterval);
         }
 
-        this.reconnect();
+        await this.reconnect();
     }
 
     /**
@@ -360,7 +360,7 @@ export class CPMConnector extends TypedEmitter<Events> {
      *
      * @returns {void}
      */
-    reconnect():void {
+    async reconnect(): Promise<void> {
         if (this.isReconnecting) {
             return;
         }
@@ -377,11 +377,13 @@ export class CPMConnector extends TypedEmitter<Events> {
         if (shouldReconnect) {
             this.isReconnecting = true;
 
-            setTimeout(async () => {
-                this.logger.info("Connection lost, retrying", this.connectionAttempts);
+            await new Promise<void>((res) => {
+                setTimeout(async () => {
+                    this.logger.info("Connection lost, retrying", this.connectionAttempts);
 
-                await this.connect();
-            }, this.config.reconnectionDelay);
+                    await this.connect();
+                }, this.config.reconnectionDelay);
+            });
         }
     }
 

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -205,7 +205,7 @@ export class Host implements IComponent {
 
             this.cpmConnector.logger.pipe(this.logger);
             this.cpmConnector.setLoadCheck(this.loadCheck);
-            this.cpmConnector.on("log_connect", (channel) => this.commonLogsPipe.getOut().pipe(channel));
+
             this.serviceDiscovery.setConnector(this.cpmConnector);
         }
     }
@@ -360,7 +360,7 @@ export class Host implements IComponent {
         this.api.use(this.topicsBase, (req, res, next) => this.topicsMiddleware(req, res, next));
 
         this.api.upstream(`${this.apiBase}/log`, () => this.commonLogsPipe.getOut());
-
+        this.api.duplex(`${this.apiBase}/manager-cc`, (stream, headers) => this.cpmConnector?.handleCommunicationRequest(stream, headers));
         this.api.use(`${this.instanceBase}/:id`, (req, res, next) => this.instanceMiddleware(req, res, next));
     }
 

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -240,9 +240,29 @@ export class Host implements IComponent {
         this.attachListeners();
         this.attachHostAPIs();
 
-        await this.connectToCPM();
         await this.performStartup();
         await this.startListening();
+
+        if (this.config.cpmUrl && this.config.cpmId) {
+            this.cpmConnector = new CPMConnector(
+                this.config.cpmUrl,
+                this.config.cpmId,
+                {
+                    id: this.config.host.id,
+                    infoFilePath: this.config.host.infoFilePath,
+                    cpmSslCaPath: this.config.cpmSslCaPath,
+                    maxReconnections: this.config.cpm.maxReconnections,
+                    reconnectionDelay: this.config.cpm.reconnectionDelay
+                },
+                this.api.server
+            );
+
+            this.cpmConnector.logger.pipe(this.logger);
+            this.cpmConnector.setLoadCheck(this.loadCheck);
+
+            this.serviceDiscovery.setConnector(this.cpmConnector);
+            await this.connectToCPM();
+        }
     }
 
     private async startListening() {
@@ -355,12 +375,12 @@ export class Host implements IComponent {
             ({ service: this.service, apiVersion: this.apiVersion, version, build: this.build }));
 
         this.api.get(`${this.apiBase}/config`, () => this.publicConfig);
-
+        this.api.get(`${this.apiBase}/status`, () => this.getStatus());
         this.api.get(`${this.apiBase}/topics`, () => this.serviceDiscovery.getTopics());
         this.api.use(this.topicsBase, (req, res, next) => this.topicsMiddleware(req, res, next));
 
         this.api.upstream(`${this.apiBase}/log`, () => this.commonLogsPipe.getOut());
-        this.api.duplex(`${this.apiBase}/manager-cc`, (stream, headers) => this.cpmConnector?.handleCommunicationRequest(stream, headers));
+        this.api.duplex(`${this.apiBase}/platform`, (stream, headers) => this.cpmConnector?.handleCommunicationRequest(stream, headers));
         this.api.use(`${this.instanceBase}/:id`, (req, res, next) => this.instanceMiddleware(req, res, next));
     }
 
@@ -926,6 +946,14 @@ export class Host implements IComponent {
                 contentType: topic.contentType
             })
         );
+    }
+
+    getStatus(): STHRestAPI.GetStatusResponse {
+        const { connected, cpmId } = this.cpmConnector || {};
+
+        return {
+            cpm: { connected, cpmId }
+        };
     }
 
     /**

--- a/packages/types/src/rest-api-sth/get-status.ts
+++ b/packages/types/src/rest-api-sth/get-status.ts
@@ -1,0 +1,6 @@
+export type GetStatusResponse = {
+    cpm: {
+        cpmId?: string;
+        connected?: boolean;
+    }
+};

--- a/packages/types/src/rest-api-sth/index.ts
+++ b/packages/types/src/rest-api-sth/index.ts
@@ -16,6 +16,7 @@ export * from "./get-health";
 export * from "./send-event";
 export * from "./get-event";
 export * from "./get-topics";
+export * from "./get-status";
 
 export type GetEventResponse = any;
 export type GetNextEventResponse = any;

--- a/packages/verser/src/lib/verser-client.ts
+++ b/packages/verser/src/lib/verser-client.ts
@@ -103,8 +103,6 @@ export class VerserClient extends TypedEmitter<Events> {
      *
      * If channel is registered, callback will be called with the duplex stream,
      * otherwise stream will be passed to the server.
-     *
-     * @param {VerserClientConnection} connection Connection object.
      */
     private mux() {
         new BPMux(this.socket)


### PR DESCRIPTION
**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Reimplement Host-Manager connection using Verser's makeRequest
added /status endpoint providing useful informations about cpm connection status and which can be extended.

**Why?**  <!-- What is this needed for? You can link to an issue. -->
stability and simplicity

**Review checks:**

These aspects need to be checked by the reviewer:

- [x] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [x] All STH tests pass
- [x] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

