### PR TITLE
Return CONFLICT on `stop` when instance is not running

### DIFF
--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -624,6 +624,11 @@ export class CSIController extends TypedEmitter<Events> {
     }
 
     private async handleStop(req: ParsedMessage): Promise<OpResponse<STHRestAPI.SendStopInstanceResponse>> {
+        if (["stopping", "killing", "completed", "errored"].includes(this.status)) {
+            this.logger.debug("instance stop conflict", this.getInfo());
+            return { opStatus: ReasonPhrases.CONFLICT, ...this.getInfo() };
+        }
+
         const message = req.body as EncodedMessage<RunnerMessageCode.STOP>;
 
         this.status = "stopping";


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Return CONFLICT on `stop` when instance is not running

**Why?**  <!-- What is this needed for? You can link to an issue. -->
to avoid issues like https://github.com/scramjetorg/transform-hub/issues/605

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

