### PR TITLE
Allow to send event without payload

### DIFF
--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -108,9 +108,16 @@ This feature checks CLI functionalities without topics
         Then I confirm data named "checksum" received
 
     @ci-api @cli
-    Scenario: E2E-010 TC-013 Test Instance 'event' option
+    Scenario: E2E-010 TC-013 Test Instance 'event' option with payload
         When I execute CLI with "seq deploy ../packages/event-sequence-v2.tar.gz"
         When I execute CLI with "inst event emit - test-event test message"
+        When I execute CLI with "inst event on - test-event-response"
+        Then I get event "test-event-response" with event message "{\"eventName\":\"test-event-response\",\"message\":\"message from sequence\"}" from Instance
+
+    @ci-api @cli
+    Scenario: E2E-010 TC-013a Test Instance 'event' option without payload
+        When I execute CLI with "seq deploy ../packages/event-sequence-v2.tar.gz"
+        When I execute CLI with "inst event emit - test-event"
         When I execute CLI with "inst event on - test-event-response"
         Then I get event "test-event-response" with event message "{\"eventName\":\"test-event-response\",\"message\":\"message from sequence\"}" from Instance
 

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -584,6 +584,7 @@ export class CSIController extends TypedEmitter<Events> {
             const event = data[1];
 
             if (!event.eventName) return;
+
             localEmitter.lastEvents[event.eventName] = event;
             localEmitter.emit(event.eventName, event);
         });
@@ -630,6 +631,7 @@ export class CSIController extends TypedEmitter<Events> {
 
             return awaitEvent(req);
         });
+
         this.router.get("/once/:name", awaitEvent);
 
         // operations

--- a/packages/model/src/get-message.ts
+++ b/packages/model/src/get-message.ts
@@ -33,7 +33,7 @@ function isDescribeSequenceMessage(data: object): data is DescribeSequenceMessag
 }
 function isEventMessage(data: object): data is EventMessageData {
     return typeof (data as EventMessageData).eventName === "string" &&
-        typeof (data as EventMessageData).message === "string";
+        ((data as EventMessageData).message === undefined || typeof (data as EventMessageData).message === "string");
 }
 function isErrorMessage(data: object): data is ErrorMessageData {
     if (typeof (data as ErrorMessageData).message === "string") return false;

--- a/packages/runner/src/runner-app-context.ts
+++ b/packages/runner/src/runner-app-context.ts
@@ -139,7 +139,7 @@ implements AppContext<AppConfigType, State> {
         return this;
     }
 
-    emit(eventName: string, message: any) {
+    emit(eventName: string, message?: any) {
         this.runner.sendEvent({ eventName, message });
         // this.emitter.emit(eventName, message);
         return this;


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Allow to `inst event emit - myEvent` (without payload)

**Why?**  <!-- What is this needed for? You can link to an issue. -->
https://github.com/scramjetorg/transform-hub/issues/204

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

