### PR TITLE
instance/inout endpoint

### DIFF
--- a/docs/adapters/classes/KubernetesInstanceAdapter.md
+++ b/docs/adapters/classes/KubernetesInstanceAdapter.md
@@ -50,7 +50,7 @@ Adapter for running Instance by Runner executed in separate process.
 
 #### Defined in
 
-[kubernetes-instance-adapter.ts:34](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L34)
+[kubernetes-instance-adapter.ts:35](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L35)
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 #### Defined in
 
-[kubernetes-instance-adapter.ts:37](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L37)
+[kubernetes-instance-adapter.ts:38](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L38)
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 #### Defined in
 
-[kubernetes-instance-adapter.ts:33](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L33)
+[kubernetes-instance-adapter.ts:34](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L34)
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 #### Defined in
 
-[kubernetes-instance-adapter.ts:36](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L36)
+[kubernetes-instance-adapter.ts:37](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L37)
 
 ___
 
@@ -94,7 +94,7 @@ ILifeCycleAdapterMain.logger
 
 #### Defined in
 
-[kubernetes-instance-adapter.ts:30](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L30)
+[kubernetes-instance-adapter.ts:31](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L31)
 
 ___
 
@@ -104,7 +104,7 @@ ___
 
 #### Defined in
 
-[kubernetes-instance-adapter.ts:31](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L31)
+[kubernetes-instance-adapter.ts:32](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L32)
 
 ## Methods
 
@@ -122,7 +122,7 @@ ILifeCycleAdapterMain.cleanup
 
 #### Defined in
 
-[kubernetes-instance-adapter.ts:179](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L179)
+[kubernetes-instance-adapter.ts:184](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L184)
 
 ___
 
@@ -140,7 +140,7 @@ ILifeCycleAdapterMain.getCrashLog
 
 #### Defined in
 
-[kubernetes-instance-adapter.ts:204](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L204)
+[kubernetes-instance-adapter.ts:209](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L209)
 
 ___
 
@@ -158,7 +158,7 @@ ILifeCycleAdapterMain.init
 
 #### Defined in
 
-[kubernetes-instance-adapter.ts:63](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L63)
+[kubernetes-instance-adapter.ts:64](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L64)
 
 ___
 
@@ -182,7 +182,7 @@ ILifeCycleAdapterRun.monitorRate
 
 #### Defined in
 
-[kubernetes-instance-adapter.ts:184](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L184)
+[kubernetes-instance-adapter.ts:189](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L189)
 
 ___
 
@@ -206,7 +206,7 @@ ILifeCycleAdapterMain.remove
 
 #### Defined in
 
-[kubernetes-instance-adapter.ts:193](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L193)
+[kubernetes-instance-adapter.ts:198](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L198)
 
 ___
 
@@ -232,7 +232,7 @@ ILifeCycleAdapterRun.run
 
 #### Defined in
 
-[kubernetes-instance-adapter.ts:90](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L90)
+[kubernetes-instance-adapter.ts:91](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L91)
 
 ___
 
@@ -256,7 +256,7 @@ ILifeCycleAdapterRun.stats
 
 #### Defined in
 
-[kubernetes-instance-adapter.ts:70](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L70)
+[kubernetes-instance-adapter.ts:71](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L71)
 
 ___
 
@@ -276,7 +276,7 @@ ___
 
 #### Defined in
 
-[kubernetes-instance-adapter.ts:188](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L188)
+[kubernetes-instance-adapter.ts:193](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L193)
 
 ## Constructors
 
@@ -292,7 +292,7 @@ ___
 
 #### Defined in
 
-[kubernetes-instance-adapter.ts:42](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L42)
+[kubernetes-instance-adapter.ts:43](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L43)
 
 ## Accessors
 
@@ -306,7 +306,7 @@ ___
 
 #### Defined in
 
-[kubernetes-instance-adapter.ts:55](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L55)
+[kubernetes-instance-adapter.ts:56](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L56)
 
 ___
 
@@ -324,7 +324,7 @@ ILifeCycleAdapterRun.limits
 
 #### Defined in
 
-[kubernetes-instance-adapter.ts:39](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L39)
+[kubernetes-instance-adapter.ts:40](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L40)
 
 • `set` **limits**(`value`): `void`
 
@@ -344,7 +344,7 @@ ILifeCycleAdapterRun.limits
 
 #### Defined in
 
-[kubernetes-instance-adapter.ts:40](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L40)
+[kubernetes-instance-adapter.ts:41](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L41)
 
 ___
 
@@ -367,4 +367,4 @@ ___
 
 #### Defined in
 
-[kubernetes-instance-adapter.ts:77](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L77)
+[kubernetes-instance-adapter.ts:78](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-instance-adapter.ts#L78)

--- a/docs/api-client/README.md
+++ b/docs/api-client/README.md
@@ -606,6 +606,23 @@ ___
 
 <details>
 <summary>
+    <strong class="post">[ POST ]</strong>  <code>/api/v1/instance/:id/inout</code> <small>- Experimental. Send data to the input stream of the Instance to consume it. Get stream data from instance.</small>
+</summary>
+
+<br> <strong>Parameters</strong>
+
+<small>No parameters</small>
+
+<strong>Responses</strong>
+
+| Name                     | Code  | Description                                                  |
+| :----------------------- | :---- | :----------------------------------------------------------- |
+| Successful operation     | `200` | -                                                            |
+
+</details>
+
+<details>
+<summary>
     <strong class="post">[ POST ]</strong>  <code>/api/v1/instance/:id/stdin​</code> <small>- process.stdin</small>
 </summary>
 

--- a/docs/host/classes/CSIController.md
+++ b/docs/host/classes/CSIController.md
@@ -439,7 +439,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:372](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L372)
+[packages/host/src/lib/csi-controller.ts:376](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L376)
 
 ___
 
@@ -453,7 +453,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:531](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L531)
+[packages/host/src/lib/csi-controller.ts:535](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L535)
 
 ___
 
@@ -516,7 +516,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:380](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L380)
+[packages/host/src/lib/csi-controller.ts:384](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L384)
 
 ___
 
@@ -530,7 +530,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:723](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L723)
+[packages/host/src/lib/csi-controller.ts:742](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L742)
 
 ___
 
@@ -544,7 +544,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:747](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L747)
+[packages/host/src/lib/csi-controller.ts:766](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L766)
 
 ___
 
@@ -558,7 +558,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:751](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L751)
+[packages/host/src/lib/csi-controller.ts:770](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L770)
 
 ___
 
@@ -590,7 +590,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:743](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L743)
+[packages/host/src/lib/csi-controller.ts:762](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L762)
 
 ___
 
@@ -610,7 +610,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:494](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L494)
+[packages/host/src/lib/csi-controller.ts:498](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L498)
 
 ___
 
@@ -630,7 +630,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:519](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L519)
+[packages/host/src/lib/csi-controller.ts:523](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L523)
 
 ___
 
@@ -650,7 +650,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:802](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L802)
+[packages/host/src/lib/csi-controller.ts:821](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L821)
 
 ___
 
@@ -670,7 +670,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:756](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L756)
+[packages/host/src/lib/csi-controller.ts:775](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L775)
 
 ___
 
@@ -690,7 +690,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:775](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L775)
+[packages/host/src/lib/csi-controller.ts:794](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L794)
 
 ___
 
@@ -704,7 +704,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:320](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L320)
+[packages/host/src/lib/csi-controller.ts:318](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L318)
 
 ___
 
@@ -724,7 +724,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:411](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L411)
+[packages/host/src/lib/csi-controller.ts:415](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L415)
 
 ___
 
@@ -738,7 +738,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:403](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L403)
+[packages/host/src/lib/csi-controller.ts:407](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L407)
 
 ___
 
@@ -812,7 +812,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:221](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L221)
+[packages/host/src/lib/csi-controller.ts:222](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L222)
 
 ___
 
@@ -1079,7 +1079,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:810](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L810)
+[packages/host/src/lib/csi-controller.ts:829](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L829)
 
 ___
 
@@ -1131,7 +1131,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:260](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L260)
+[packages/host/src/lib/csi-controller.ts:258](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L258)
 
 ## Constructors
 
@@ -1213,7 +1213,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:378](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L378)
+[packages/host/src/lib/csi-controller.ts:382](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L382)
 
 ___
 

--- a/docs/symbols/enums/RunnerExitCode.md
+++ b/docs/symbols/enums/RunnerExitCode.md
@@ -10,6 +10,7 @@
 - [INVALID\_ENV\_VARS](RunnerExitCode.md#invalid_env_vars)
 - [INVALID\_SEQUENCE\_PATH](RunnerExitCode.md#invalid_sequence_path)
 - [KILLED](RunnerExitCode.md#killed)
+- [PODS\_LIMIT\_REACHED](RunnerExitCode.md#pods_limit_reached)
 - [SEQUENCE\_FAILED\_DURING\_EXECUTION](RunnerExitCode.md#sequence_failed_during_execution)
 - [SEQUENCE\_FAILED\_ON\_START](RunnerExitCode.md#sequence_failed_on_start)
 - [SEQUENCE\_UNPACK\_FAILED](RunnerExitCode.md#sequence_unpack_failed)
@@ -55,6 +56,16 @@ ___
 #### Defined in
 
 [runner-exit-code.ts:7](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/runner-exit-code.ts#L7)
+
+___
+
+### PODS\_LIMIT\_REACHED
+
+• **PODS\_LIMIT\_REACHED** = ``24``
+
+#### Defined in
+
+[runner-exit-code.ts:11](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/symbols/src/runner-exit-code.ts#L11)
 
 ___
 

--- a/docs/types/modules.md
+++ b/docs/types/modules.md
@@ -1197,6 +1197,7 @@ ___
 | :------ | :------ | :------ |
 | `authConfigPath?` | `string` | Authentication configuration path |
 | `namespace` | `string` | The Kubernetes namespace to use for running sequences |
+| `quotaName` | `string` | Quota object name to determine namespace limits. |
 | `runnerImages` | { `node`: `string` ; `python3`: `string`  } | Runner images to use |
 | `runnerImages.node` | `string` | - |
 | `runnerImages.python3` | `string` | - |
@@ -1976,7 +1977,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/sth-configuration.ts:238](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L238)
+[packages/types/src/sth-configuration.ts:244](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L244)
 
 ___
 
@@ -2149,6 +2150,7 @@ ___
 | `instancesServerPort` | `string` |
 | `k8sAuthConfigPath` | `string` |
 | `k8sNamespace` | `string` |
+| `k8sQuotaName` | `string` |
 | `k8sRunnerCleanupTimeout` | `string` |
 | `k8sRunnerImage` | `string` |
 | `k8sRunnerPyImage` | `string` |
@@ -2219,7 +2221,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/sth-configuration.ts:101](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L101)
+[packages/types/src/sth-configuration.ts:107](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L107)
 
 ___
 

--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -606,6 +606,23 @@ ___
 
 <details>
 <summary>
+    <strong class="post">[ POST ]</strong>  <code>/api/v1/instance/:id/inout</code> <small>- Experimental. Send data to the input stream of the Instance to consume it. Get stream data from instance.</small>
+</summary>
+
+<br> <strong>Parameters</strong>
+
+<small>No parameters</small>
+
+<strong>Responses</strong>
+
+| Name                     | Code  | Description                                                  |
+| :----------------------- | :---- | :----------------------------------------------------------- |
+| Successful operation     | `200` | -                                                            |
+
+</details>
+
+<details>
+<summary>
     <strong class="post">[ POST ]</strong>  <code>/api/v1/instance/:id/stdin​</code> <small>- process.stdin</small>
 </summary>
 

--- a/packages/api-client/src/readme.mtpl
+++ b/packages/api-client/src/readme.mtpl
@@ -584,6 +584,23 @@ ___
 
 <details>
 <summary>
+    <strong class="post">[ POST ]</strong>  <code>/api/v1/instance/:id/inout</code> <small>- Experimental. Send data to the input stream of the Instance to consume it. Get stream data from instance.</small>
+</summary>
+
+<br> <strong>Parameters</strong>
+
+<small>No parameters</small>
+
+<strong>Responses</strong>
+
+| Name                     | Code  | Description                                                  |
+| :----------------------- | :---- | :----------------------------------------------------------- |
+| Successful operation     | `200` | -                                                            |
+
+</details>
+
+<details>
+<summary>
     <strong class="post">[ POST ]</strong>  <code>/api/v1/instance/:id/stdin​</code> <small>- process.stdin</small>
 </summary>
 

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -543,6 +543,9 @@ export class CSIController extends TypedEmitter<Events> {
 
         this.router.get("/", () => this.getInfo());
 
+        /**
+         * @experimental
+         */
         this.router.duplex("/inout", (duplex, _headers) => {
             if (!inputHeadersSent) {
                 this.downStreams![CC.IN].write(`Content-Type: ${_headers["content-type"]}\r\n`);

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -38,7 +38,7 @@ import { development } from "@scramjet/sth-config";
 import { DataStream } from "scramjet";
 import { EventEmitter, once } from "events";
 import { ServerResponse } from "http";
-import { getRouter } from "@scramjet/api-server";
+import { DuplexStream, getRouter } from "@scramjet/api-server";
 
 import { getInstanceAdapter } from "@scramjet/adapters";
 import { cancellableDefer, CancellablePromise, defer, promiseTimeout, TypedEmitter } from "@scramjet/utility";
@@ -533,6 +533,8 @@ export class CSIController extends TypedEmitter<Events> {
     }
 
     createInstanceAPIRouter() {
+        let inputHeadersSent = false;
+
         if (!this.upStreams) {
             throw new AppError("UNATTACHED_STREAMS");
         }
@@ -540,6 +542,18 @@ export class CSIController extends TypedEmitter<Events> {
         this.router = getRouter();
 
         this.router.get("/", () => this.getInfo());
+
+        this.router.duplex("/inout", (duplex, _headers) => {
+            if (!inputHeadersSent) {
+                this.downStreams![CC.IN].write(`Content-Type: ${_headers["content-type"]}\r\n`);
+                this.downStreams![CC.IN].write("\r\n");
+
+                inputHeadersSent = true;
+            }
+
+            (duplex as unknown as DuplexStream).input.pipe(this.downStreams![CC.IN], { end: false });
+            this.upStreams![CC.OUT]?.pipe((duplex as unknown as DuplexStream).output, { end: false });
+        });
 
         this.router.upstream("/stdout", this.upStreams[CC.STDOUT]);
         this.router.upstream("/stderr", this.upStreams[CC.STDERR]);
@@ -569,8 +583,6 @@ export class CSIController extends TypedEmitter<Events> {
             this.router.upstream("/monitoring", this.upStreams[CC.MONITORING]);
         }
         this.router.upstream("/output", this.upStreams[CC.OUT]);
-
-        let inputHeadersSent = false;
 
         this.router.downstream("/input", (req) => {
             if (this.apiInputEnabled) {

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -1,6 +1,6 @@
-# `@scramjet/sth-config`
+# `@scramjet/telemetry`
 
-This package provides telemetry adapters.
+This package is part of Scramjet Transform Hub. The package provides modules for gathering analytics data.
 
 ## Docs
 


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
```
POST    INSTANCE_BASE/inout
```

Adds `POST` instance's `input` endpoint which provides instance's `output` in response

**Why?**  <!-- What is this needed for? You can link to an issue. -->
To trasform data with one request

**Usage:**
example. instance transforms ```inputpayload => "Echo: " + inputpayload```. 
`POST` sequence source to instance input and get response in single request.
```
curl http://localhost:8000/api/v1/instance/ef69602d-f494-429d-8fa6-77832d47c5cd/inout --no-buffer -H "Content-Type: text/plain" -d @dist/index.js
Echo: "use strict";Object.defineProperty(exports, "__esModule", { value: true });const stream_1 = require("stream");const mod = [    function (input) {        const out = new stream_1.PassThrough();        this.logger.trace("Instance started");        input            .map((data) => "Echo: " + data + "\n")            .pipe(out);        return out;    }];exports.default = mod;//# sourceMappingURL=index.js.map
```

<!--------------------- For non-trivial changes: ---------------------->

**How it works:**
Still needs a work. it is a POC.

**Review checks:**
These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [x] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

