### PR TITLE
Fix si seq send does not return valid exit codes

### DIFF
--- a/packages/cli/src/lib/common.ts
+++ b/packages/cli/src/lib/common.ts
@@ -119,7 +119,8 @@ export const packAction = async (directory: string, { output }: { output: Writab
     // TODO: error handling?
     // TODO: check package contents?
     await access(packageLocation, F_OK | R_OK).catch(() => {
-        throw new Error(`${packageLocation} not found.`);
+        displayError(`${packageLocation} not found.`);
+        process.exit(1);
     });
 
     const ignoreLocation = resolve(cwd, ".siignore");
@@ -151,6 +152,7 @@ export const getReadStreamFromFile = async (file: string): Promise<Readable> => 
     return access(resolvedFilePath, F_OK)
         .then(() => createReadStream(resolvedFilePath))
         .catch(() => {
-            throw new Error(`File "${file}" not found.`);
+            displayError(`File "${file}" not found.`);
+            process.exit(1);
         });
 };


### PR DESCRIPTION
Steps to Reproduce:

```
yarn start:dev:cli seq send simple-counter-js.tar.gz; echo $?
yarn run v1.22.19
$ ts-node packages/cli/src/bin/index.ts seq send simple-counter-js.tar.gz
Error: File "simple-counter-js.tar.gz" not found.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
1
```

