### PR TITLE
[CLI] Add session id display

### DIFF
--- a/packages/cli/src/lib/commands/config.ts
+++ b/packages/cli/src/lib/commands/config.ts
@@ -2,7 +2,6 @@
 
 import { CommandDefinition, displayFormat } from "../../types";
 import { stringToBoolean } from "../../utils/stringToBoolean";
-import { sessionId } from "../../utils/sessionId";
 import { ProfileConfig, profileConfig, profileManager, siConfig, sessionConfig } from "../config";
 import { displayMessage, displayObject } from "../output";
 import commander from "commander";
@@ -53,9 +52,7 @@ export const config: CommandDefinition = (program) => {
         .description("Print out the current session configuration")
         .action((format: displayFormat) => {
             const session = sessionConfig.getConfig();
-            const id = sessionId();
 
-            displayMessage(`Session id: ${id}\n`);
             displayObject(session, format);
         });
 

--- a/packages/cli/src/lib/commands/config.ts
+++ b/packages/cli/src/lib/commands/config.ts
@@ -2,6 +2,7 @@
 
 import { CommandDefinition, displayFormat } from "../../types";
 import { stringToBoolean } from "../../utils/stringToBoolean";
+import { sessionId } from "../../utils/sessionId";
 import { ProfileConfig, profileConfig, profileManager, siConfig, sessionConfig } from "../config";
 import { displayMessage, displayObject } from "../output";
 import commander from "commander";
@@ -52,7 +53,9 @@ export const config: CommandDefinition = (program) => {
         .description("Print out the current session configuration")
         .action((format: displayFormat) => {
             const session = sessionConfig.getConfig();
+            const id = sessionId();
 
+            displayMessage(`Session id: ${id}\n`);
             displayObject(session, format);
         });
 

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -6,6 +6,7 @@ import isUrl from "validator/lib/isURL";
 import isJWT from "validator/lib/isJWT";
 import { envs } from "../utils/envs";
 import { displayError, displayMessage } from "./output";
+import { sessionId } from "../utils/sessionId";
 
 abstract class Config {
     abstract getConfig(): any | null;
@@ -307,7 +308,7 @@ export class ProfileConfig extends DefaultFileConfig {
     }
 }
 
-// Session configuration represents configuration used by internally 
+// Session configuration represents configuration used by internally
 // that is stored and used through current shell session time that runs Cli.
 class SessionConfig extends DefaultFileConfig {
     constructor() {
@@ -317,6 +318,7 @@ class SessionConfig extends DefaultFileConfig {
             lastSequenceId: "",
             lastSpaceId: "",
             lastHubId: "",
+            sessionId: sessionId()
         };
 
         super(sessionConfigFile, defaultSessionConfig);

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -40,4 +40,5 @@ export interface SessionConfigEntity {
     lastSequenceId: string;
     lastSpaceId: string,
     lastHubId: string,
+    sessionId: string
 }


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
add Session ID display in CLI command `si config session`.



**Why?**  <!-- What is this needed for? You can link to an issue. -->
To be able to visually distinguish the config settings of one session from another

**Usage:**
<!-- Example (if applicable), how to verify (if not covered by tests). -->

- `yarn start:dev:cli config session`

```bash
Session id: 4125483

{
  lastPackagePath: '',
  lastInstanceId: '907ed318-7260-47ce-9b83-6bd95da60429',
  lastSequenceId: '0f424150-5f01-420a-85d0-54ebf4701fc3',
  lastSpaceId: '',
  lastHubId: ''
}
```


<!--------------------- For non-trivial changes: ---------------------->

**How it works:**
<!-- Share some starting points for understanding the code. -->
-
-
-

**Review checks:**

These aspects need to be checked by the reviewer:

- [x] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [x] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

