### PR TITLE
Fix for #634

### DIFF
--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -1,6 +1,6 @@
 import { existsSync, writeFileSync, readFileSync } from "fs";
 import { normalizeUrl } from "@scramjet/utility";
-import { createSessionDirIfNotExists, defaultConfigName, defaultConfigProfileFile, profileExists, profileNameToPath, sessionConfigFile, siConfigFile } from "./paths";
+import { createConfigDirIfNotExists, createSessionDirIfNotExists, defaultConfigName, defaultConfigProfileFile, profileExists, profileNameToPath, sessionConfigFile, siConfigFile } from "./paths";
 import { configEnv, isConfigEnv, isConfigFormat, ProfileConfigEntity, SiConfigEntity, SessionConfigEntity } from "../types";
 import isUrl from "validator/lib/isURL";
 import isJWT from "validator/lib/isJWT";
@@ -44,6 +44,7 @@ abstract class FileConfig extends Config {
     }
     writeConfig(config: any): boolean {
         try {
+            createConfigDirIfNotExists();
             writeFileSync(this.filePath, JSON.stringify(config, null, 2), "utf-8");
             return true;
         } catch (e) {
@@ -307,7 +308,7 @@ export class ProfileConfig extends DefaultFileConfig {
     }
 }
 
-// Session configuration represents configuration used by internally 
+// Session configuration represents configuration used by internally
 // that is stored and used through current shell session time that runs Cli.
 class SessionConfig extends DefaultFileConfig {
     constructor() {

--- a/packages/cli/src/lib/paths.ts
+++ b/packages/cli/src/lib/paths.ts
@@ -34,6 +34,11 @@ const initDir = (dir: string) => {
     }
 };
 
+export const createConfigDirIfNotExists = () => {
+    if (!existsSync(siDir))
+        initDir(siDir);
+};
+
 export const createSessionDirIfNotExists = () => {
     if (!existsSync(sessionDir))
         initDir(sessionDir);


### PR DESCRIPTION
**What?**  <!-- Two-sentence summary, understandable for a junior. -->

Fixes config directory creation before save attempt as mentioned in #634

**Why?**  <!-- What is this needed for? You can link to an issue. -->

You need to fix bugs, don't you? :)

To test:

1. Build
2. Run

```
rm ~/.si -rf
node dist/cli/bin --help
```

3. Observe that the message does not show anymore and the config is saved.

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [x] All STH tests pass
- [x] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [x] Documentation is updated or no changes

