### PR TITLE
Add --no-colors flag

### DIFF
--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -151,7 +151,7 @@ export class Host implements IComponent {
             this,
             {},
             ObjLogger.levels.find((l: LogLevel) => l.toLowerCase() === sthConfig.logLevel) ||
-                ObjLogger.levels[ObjLogger.levels.length - 1]
+            ObjLogger.levels[ObjLogger.levels.length - 1]
         );
 
         const prettyLog = new DataStream().map(prettyPrint({ colors: this.config.logColors }));
@@ -706,7 +706,8 @@ export class Host implements IComponent {
                 );
 
                 this.serviceDiscovery.update({
-                    requires: data.requires, contentType: data.contentType!, topicName: data.requires });
+                    requires: data.requires, contentType: data.contentType!, topicName: data.requires
+                });
             }
 
             // Do not route output stream to original topic if --output-topic is specified
@@ -722,7 +723,8 @@ export class Host implements IComponent {
                 );
 
                 this.serviceDiscovery.update({
-                    provides: data.provides, contentType: data.contentType!, topicName: data.provides });
+                    provides: data.provides, contentType: data.contentType!, topicName: data.provides
+                });
             }
         });
 

--- a/packages/obj-logger/src/utils/pretty-print.ts
+++ b/packages/obj-logger/src/utils/pretty-print.ts
@@ -1,5 +1,6 @@
-import { COLORS } from "./colors";
 import { LogEntry, LogLevel } from "@scramjet/types";
+
+import { COLORS } from "./colors";
 import { inspect } from "util";
 
 const COLOR_MAP: { [ key: string]: string } = {
@@ -20,6 +21,6 @@ export const prettyPrint = (opts: { colors?: boolean }) => opts.colors
     ? (obj: LogEntry) => {
         return `${colorDate(obj.ts)} ${colorLevel(obj.level)} ${colorSource(obj.from)} ${obj.msg} ${colorData(obj.data)}\n`;
     } : (obj: LogEntry) => {
-        return `${obj.ts} ${obj.level} ${obj.from} ${obj.msg} ${(obj.data || []).length ? inspect(obj.data, { colors: false, depth: 2 }) : ""}\n`;
+        return `${new Date(obj.ts!).toISOString()} ${obj.level} ${obj.from} ${obj.msg} ${(obj.data || []).length ? inspect(obj.data, { colors: false, depth: 2 }) : ""}\n`;
     };
 

--- a/packages/sth-config/src/config-service.ts
+++ b/packages/sth-config/src/config-service.ts
@@ -1,4 +1,5 @@
 import { DeepPartial, PublicSTHConfiguration, STHConfiguration } from "@scramjet/types";
+
 import { merge } from "@scramjet/utility";
 import path from "path";
 import { homedir } from "os";

--- a/packages/sth/src/bin/hub.ts
+++ b/packages/sth/src/bin/hub.ts
@@ -13,6 +13,7 @@ const program = new Command();
 const options: STHCommandOptions = program
     .option("-c, --config <path>", "Specifies path to config")
     .option("-L, --log-level <level>", "Specify log level")
+    .option("--no-colors", "Disable colors in output", false)
     .option("-P, --port <port>", "API port")
     .option("-H, --hostname <IP>", "API IP")
     .option("-E, --identify-existing", "Index existing volumes as sequences")
@@ -46,7 +47,7 @@ const options: STHCommandOptions = program
     .option("--k8s-runner-resources-limits-cpu <cpu unit>", "Set limits for CPU  [1 CPU unit is equivalent to 1 physical CPU core, or 1 virtual core]")
     .option("--k8s-runner-resources-limits-memory <memory>", "Set limits for memory e.g [128974848, 129e6, 129M,  128974848000m, 123Mi]")
     .parse(process.argv)
-    .opts() as STHCommandOptions;
+    .opts();
 
 (async () => {
     const configService = new ConfigService();
@@ -90,6 +91,7 @@ const options: STHCommandOptions = program
         exitWithLastInstance: options.exitWithLastInstance,
         safeOperationLimit: options.safeOperationLimit,
         logLevel: options.logLevel,
+        logColors: options.colors,
         kubernetes: {
             namespace: options.k8sNamespace,
             authConfigPath: options.k8sAuthConfigPath,

--- a/packages/types/src/sth-command-options.ts
+++ b/packages/types/src/sth-command-options.ts
@@ -2,6 +2,7 @@ import { LogLevel } from "./object-logger";
 
 export type STHCommandOptions = {
     logLevel: LogLevel;
+    colors: boolean,
     port: number;
     hostname: string;
     identifyExisting: boolean;

--- a/packages/utility/src/merge.ts
+++ b/packages/utility/src/merge.ts
@@ -15,7 +15,7 @@ export const merge = <T extends Record<string, unknown>>(
         .forEach((key: keyof T) => {
             if (typeof source[key] === "object" && !Array.isArray(source[key])) {
                 merge(target[key] as Record<string, unknown>, source[key]);
-            } else if (source[key]) {
+            } else if (source[key] !== undefined) {
                 target[key] = source[key] as T[keyof T];
             } else if (strict) {
                 throw new Error(`Unkown option ${String(key)} in config`);


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
`--no-colors` to disable logs colouring

**Why?**  <!-- What is this needed for? You can link to an issue. -->
output without color codes

**Usage:**
<!-- Example (if applicable), how to verify (if not covered by tests). -->
```
yarn start --no-colors
```
**Review checks:**

These aspects need to be checked by the reviewer:

- [x] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [x] All STH tests pass
- [x] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

