### PR TITLE
Allow to configure CPMConnector

### DIFF
--- a/packages/host/src/lib/cpm-connector.ts
+++ b/packages/host/src/lib/cpm-connector.ts
@@ -38,27 +38,6 @@ type Events = {
  */
 export class CPMConnector extends TypedEmitter<Events> {
     /**
-     * Maximum attempts for first connection try.
-     *
-     * @type {number}
-     */
-    MAX_CONNECTION_ATTEMPTS = 100;
-
-    /**
-     * Maximum retries on connection lost.
-     *
-     * @type {number}
-     */
-    MAX_RECONNECTION_ATTEMPTS = 100;
-
-    /**
-     * Delay between connection attempts.
-     *
-     * @type {number}
-     */
-    RECONNECT_INTERVAL = 2000;
-
-    /**
      * Load check instance to be used to get load check data.
      *
      * @type {LoadCheck}
@@ -408,12 +387,9 @@ export class CPMConnector extends TypedEmitter<Events> {
 
         let shouldReconnect = true;
 
-        if (this.wasConnected) {
-            if (this.connectionAttempts > this.MAX_RECONNECTION_ATTEMPTS) {
-                shouldReconnect = false;
-            }
-        } else if (this.connectionAttempts > this.MAX_CONNECTION_ATTEMPTS) {
+        if (~this.config.maxReconnections && this.connectionAttempts > this.config.maxReconnections) {
             shouldReconnect = false;
+            this.logger.warn("Maximum reconnection attempts reached. Giving up.");
         }
 
         if (shouldReconnect) {
@@ -423,7 +399,7 @@ export class CPMConnector extends TypedEmitter<Events> {
                 this.logger.info("Connection lost, retrying", this.connectionAttempts);
 
                 await this.connect();
-            }, this.RECONNECT_INTERVAL);
+            }, this.config.reconnectionDelay);
         }
     }
 

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -195,7 +195,9 @@ export class Host implements IComponent {
                 {
                     id: this.config.host.id,
                     infoFilePath: this.config.host.infoFilePath,
-                    cpmSslCaPath: this.config.cpmSslCaPath
+                    cpmSslCaPath: this.config.cpmSslCaPath,
+                    maxReconnections: this.config.cpm.maxReconnections,
+                    reconnectionDelay: this.config.cpm.reconnectionDelay
                 },
                 this.api.server
             );

--- a/packages/sth-config/src/config-service.ts
+++ b/packages/sth-config/src/config-service.ts
@@ -10,6 +10,10 @@ const _defaultConfig: STHConfiguration = {
     logColors: true,
     cpmUrl: "",
     cpmId: "",
+    cpm: {
+        maxReconnections: 100,
+        reconnectionDelay: 2000,
+    },
     docker: {
         prerunner: {
             image: "",

--- a/packages/sth/src/bin/hub.ts
+++ b/packages/sth/src/bin/hub.ts
@@ -34,6 +34,8 @@ const options: STHCommandOptions = program
     .option("--prerunner-max-mem <mb>", "Maximum mem used by prerunner")
     .option("--cpm-ssl-ca-path <path>", "Certificate Authority for self-signed CPM SSL certificates")
     .option("--cpm-id <id>")
+    .option("--cpm-max-reconnections <number>", "Maximum reconnection attempts (-1 no limit)")
+    .option("--cpm-reconnection-delay <number>", "Time to wait before next reconnection attempt")
     .option("--k8s-namespace <namespace>", "Kubernetes namespace used in Sequence and Instance adapters.")
     .option("--k8s-auth-config-path <path>", "Kubernetes authorization config path. If not supplied the mounted service account will be used.")
     .option("--k8s-sth-pod-host <host>", "Runner needs to connect to STH. This is the host (IP or hostname) that it will try to connect to.")
@@ -46,7 +48,7 @@ const options: STHCommandOptions = program
     .option("--k8s-runner-resources-limits-cpu <cpu unit>", "Set limits for CPU  [1 CPU unit is equivalent to 1 physical CPU core, or 1 virtual core]")
     .option("--k8s-runner-resources-limits-memory <memory>", "Set limits for memory e.g [128974848, 129e6, 129M,  128974848000m, 123Mi]")
     .parse(process.argv)
-    .opts() as STHCommandOptions;
+    .opts();
 
 (async () => {
     const configService = new ConfigService();
@@ -62,6 +64,10 @@ const options: STHCommandOptions = program
         cpmUrl: options.cpmUrl,
         cpmId: options.cpmId,
         cpmSslCaPath: options.cpmSslCaPath,
+        cpm: {
+            reconnectionDelay: options.cpmReconnectionDelay,
+            maxReconnections: options.cpmMaxReconnections
+        },
         docker: {
             prerunner: {
                 image: options.prerunnerImage,

--- a/packages/types/src/cpm-connector.ts
+++ b/packages/types/src/cpm-connector.ts
@@ -4,4 +4,6 @@ export type CPMConnectorOptions = {
     id: STHConfiguration["host"]["id"];
     infoFilePath: STHConfiguration["host"]["infoFilePath"];
     cpmSslCaPath?: STHConfiguration["cpmSslCaPath"];
+    maxReconnections: STHConfiguration["cpm"]["maxReconnections"];
+    reconnectionDelay: STHConfiguration["cpm"]["reconnectionDelay"];
 }

--- a/packages/types/src/sth-command-options.ts
+++ b/packages/types/src/sth-command-options.ts
@@ -9,6 +9,8 @@ export type STHCommandOptions = {
     cpmUrl?: string;
     cpmId?: string;
     cpmSslCaPath?: string;
+    cpmMaxReconnections: number,
+    cpmReconnectionDelay: number,
     id?: string;
     runtimeAdapter: string;
     runnerImage: string;

--- a/packages/types/src/sth-configuration.ts
+++ b/packages/types/src/sth-configuration.ts
@@ -123,6 +123,11 @@ export type STHConfiguration = {
      */
     cpmId: string;
 
+    cpm: {
+        maxReconnections: number,
+        reconnectionDelay: number,
+    }
+
     /**
      * Docker related configuration.
      */


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Allow to configure CPMConnector max reconnections and reconnection delay with sth args

**Why?**  <!-- What is this needed for? You can link to an issue. -->
@daro1337 requested

**Usage:**
<!-- Example (if applicable), how to verify (if not covered by tests). -->
```
sth --cpm-max-reconnections 2 --cpm-reconnection-delay 10000
```
```
sth --cpm-max-reconnections -1                                # don't give up
```

<!--------------------- For non-trivial changes: ---------------------->

**How it works:**
<!-- Share some starting points for understanding the code. -->
-
-
-

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

