### PR TITLE
Support x-name header on sequence post|put

### DIFF
--- a/packages/adapters/src/docker-sequence-adapter.ts
+++ b/packages/adapters/src/docker-sequence-adapter.ts
@@ -131,10 +131,15 @@ class DockerSequenceAdapter implements ISequenceAdapter {
      *
      * @param {Readable} stream Stream containing sequence to be identified.
      * @param {string} id Id for the new docker volume where sequence will be stored.
+     * @param {boolean} override Removes previous sequence
      * @returns {Promise<SequenceConfig>} Promise resolving to sequence config.
      */
-    async identify(stream: Readable, id: string): Promise<SequenceConfig> {
+    async identify(stream: Readable, id: string, override = false): Promise<SequenceConfig> {
         const volStart = new Date();
+
+        if (override) {
+            await this.dockerHelper.removeVolume(id);
+        }
 
         const volumeId = await this.createVolume(id);
 

--- a/packages/adapters/src/kubernetes-sequence-adapter.ts
+++ b/packages/adapters/src/kubernetes-sequence-adapter.ts
@@ -103,12 +103,17 @@ class KubernetesSequenceAdapter implements ISequenceAdapter {
      *
      * @param {Readable} stream Stream with packed sequence.
      * @param {string} id Sequence Id.
+     * @param {boolean} override Removes previous sequence
      * @returns {Promise<SequenceConfig>} Promise resolving to identified sequence configuration.
      */
-    async identify(stream: Readable, id: string): Promise<SequenceConfig> {
+    async identify(stream: Readable, id: string, override = false): Promise<SequenceConfig> {
         // 1. Unpack package.json to stdout and map to config
         // 2. Create compressed package on the disk
         const sequenceDir = path.join(this.adapterConfig.sequencesRoot, id);
+
+        if (override) {
+            await fs.rm(sequenceDir, { recursive: true, force: true });
+        }
 
         await fs.mkdir(sequenceDir);
 

--- a/packages/adapters/src/process-sequence-adapter.ts
+++ b/packages/adapters/src/process-sequence-adapter.ts
@@ -91,10 +91,15 @@ class ProcessSequenceAdapter implements ISequenceAdapter {
      *
      * @param {Readable} stream Stream with packed sequence.
      * @param {string} id Sequence Id.
+     * @param {boolean} override Removes previous sequence
      * @returns {Promise<SequenceConfig>} Promise resolving to identified sequence configuration.
      */
-    async identify(stream: Readable, id: string): Promise<SequenceConfig> {
+    async identify(stream: Readable, id: string, override = false): Promise<SequenceConfig> {
         const sequenceDir = path.join(this.config.sequencesRoot, id);
+
+        if (override) {
+            await fs.rm(sequenceDir, { recursive: true, force: true });
+        }
 
         await fs.mkdir(sequenceDir);
 

--- a/packages/api-client/src/host-client.ts
+++ b/packages/api-client/src/host-client.ts
@@ -50,14 +50,16 @@ export class HostClient implements ClientProvider {
      *
      * @param sequencePackage Stream with packed Sequence.
      * @param {RequestInit} requestInit RequestInit object to be passed to fetch.
+     * @param {boolean} update Send request with post or put method
      * @returns {SequenceClient} Sequence client.
      */
     async sendSequence(
         sequencePackage: Parameters<HttpClient["sendStream"]>[1],
-        requestInit?: RequestInit
+        requestInit?: RequestInit,
+        update?: boolean
     ): Promise<SequenceClient> {
         const response = await this.client.sendStream<any>("sequence", sequencePackage, requestInit, {
-            parseResponse: "json",
+            parseResponse: "json", put: update
         });
 
         return SequenceClient.from(response.id, this);

--- a/packages/api-client/src/sequence-client.ts
+++ b/packages/api-client/src/sequence-client.ts
@@ -1,5 +1,6 @@
 import { ClientProvider, HttpClient } from "@scramjet/client-utils";
 import { STHRestAPI } from "@scramjet/types";
+import { Readable } from "stream";
 
 import { InstanceClient } from "./instance-client";
 
@@ -94,10 +95,11 @@ export class SequenceClient {
         return this.clientUtils.get<STHRestAPI.GetSequenceResponse>(this.sequenceURL);
     }
 
-    /**
-     * Not implemented.
-     */
-    async overwrite() {
-        throw Error("Not yet implemented");
+    async overwrite(stream: Readable) {
+        const response = await this.clientUtils.sendStream<any>("sequence", stream, { method: "PUT" }, {
+            parseResponse: "json"
+        });
+
+        return SequenceClient.from(response.id, this.host);
     }
 }

--- a/packages/api-server/src/handlers/op.ts
+++ b/packages/api-server/src/handlers/op.ts
@@ -16,7 +16,7 @@ import { StringDecoder } from "string_decoder";
 import { getStatusCode, ReasonPhrases, StatusCodes } from "http-status-codes";
 import { ObjLogger } from "@scramjet/obj-logger";
 
-const logger = new ObjLogger("API");
+export const logger = new ObjLogger("API op");
 
 /**
  * Creates and returns a method to set up a POST/DELETE handlers for the given path.
@@ -190,12 +190,17 @@ export function createOperationHandler(router: SequentialCeroRouter): APIRoute["
             }
         };
 
+        logger.debug("Registering", method);
+
         switch (method) {
             case "post":
                 router.post(path, handler);
                 break;
             case "delete":
                 router.delete(path, handler);
+                break;
+            case "put":
+                router.put(path, handler);
                 break;
             default:
                 throw new Error("ERR_UNSUPPORTED_METHOD");

--- a/packages/api-server/src/handlers/stream.ts
+++ b/packages/api-server/src/handlers/stream.ts
@@ -105,9 +105,9 @@ export function createStreamHandlers(router: SequentialCeroRouter) {
     const downstream = (
         path: string | RegExp,
         stream: StreamOutput,
-        { json = false, text = false, end: _end = false, encoding = "utf-8", checkContentType = true, checkEndHeader = true }: StreamConfig = {}
+        { json = false, text = false, end: _end = false, encoding = "utf-8", checkContentType = true, checkEndHeader = true, method = "post" }: StreamConfig = {}
     ): void => {
-        router.post(path, async (req, res, next) => {
+        router[method](path, async (req, res, next) => {
             try {
                 if (checkContentType) {
                     checkAccepts(req.headers["content-type"], text, json);

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -4,7 +4,7 @@ import { IncomingMessage, ServerResponse, Server as HttpServer, createServer as 
 import { Server as HttpsServer, createServer as createHttpsServer } from "https";
 import { DataStream } from "scramjet";
 import { createGetterHandler } from "./handlers/get";
-import { createOperationHandler } from "./handlers/op";
+import { createOperationHandler, logger as opLogger } from "./handlers/op";
 import { createStreamHandlers } from "./handlers/stream";
 import { cero, sequentialRouter } from "./lib/0http";
 import { CeroRouter, CeroRouterConfig } from "./lib/definitions";
@@ -19,7 +19,9 @@ export type ServerConfig = {
 
 export { cero, sequentialRouter };
 
-const logger = new ObjLogger("ApiServer");
+export const logger = new ObjLogger("ApiServer");
+
+opLogger.pipe(logger);
 
 function safeHandler<T extends unknown[]>(cb: (...args: T) => MaybePromise<void>) {
     return async (...args: T) => {
@@ -115,6 +117,7 @@ export function createServer(conf: ServerConfig = {}): APIExpose {
     return {
         server: srv,
         get,
+        opLogger,
         op,
         duplex,
         downstream,

--- a/packages/cli/src/lib/commands/sequence.ts
+++ b/packages/cli/src/lib/commands/sequence.ts
@@ -18,15 +18,19 @@ type SequenceStartsOptions = {
     name?: string;
 }
 
-const sendPackage = async (sequencePackage: string, options: SequenceStartsOptions = {}, format: displayFormat) => {
+const sendPackage = async (
+    sequencePackage: string, options: SequenceStartsOptions = {}, format: displayFormat, update = false
+) => {
     try {
         const sequencePath = getPackagePath(sequencePackage);
         const seq = await getHostClient().sendSequence(
-            await getReadStreamFromFile(sequencePath), {
+            await getReadStreamFromFile(sequencePath),
+            {
                 headers: {
                     "x-name": options.name || ""
                 }
-            }
+            },
+            update
         );
 
         sessionConfig.setLastSequenceId(seq.id);
@@ -139,6 +143,16 @@ export const sequence: CommandDefinition = (program) => {
         .description("Send the Sequence package to the Hub")
         .action(
             async (sequencePackage: string, { name }) => sendPackage(sequencePackage, { name }, profileConfig.format)
+        );
+
+    sequenceCmd
+        .command("update")
+        .argument("<package>", "The file to upload or '-' to use the last packed")
+        .option("--name <name>", "Sequence to be updated (by name)")
+        .description("Updates sequence with given name")
+        .action(
+            async (sequencePackage: string, { name }) =>
+                sendPackage(sequencePackage, { name }, profileConfig.format, true)
         );
 
     sequenceCmd

--- a/packages/client-utils/src/types/index.ts
+++ b/packages/client-utils/src/types/index.ts
@@ -8,6 +8,7 @@ export type SendStreamOptions = Partial<{
     type: string;
     end: boolean;
     parseResponse?: "json" | "text" | "stream";
+    put: boolean
 }>;
 
 /**

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -706,6 +706,11 @@ export class CSIController extends TypedEmitter<Events> {
             appConfig: this.appConfig,
             sequenceArgs: this.sequenceArgs,
             sequence: this.sequence.id,
+            sequenceInfo: {
+                id: this.sequence.id,
+                config: this.sequence.config,
+                name: this.sequence.name
+            },
             ports: this.info.ports,
             created: this.info.created,
             started: this.info.started,

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -419,7 +419,7 @@ export class Host implements IComponent {
 
         this.logger.trace("Deleting Sequence...", id);
 
-        const sequenceInfo = this.sequencesStore.get(id);
+        const sequenceInfo = this.sequencesStore.get(id) || this.getSequenceByName(id);
 
         if (!sequenceInfo) {
             return {

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -885,6 +885,7 @@ export class Host implements IComponent {
         return Array.from(this.sequencesStore.values())
             .map(sequence => ({
                 id: sequence.id,
+                name: sequence.name,
                 config: sequence.config,
                 instances: Array.from(sequence.instances.values())
             }));

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -661,7 +661,8 @@ export class Host implements IComponent {
 
         const id = req.params?.id;
         const payload = req.body || {} as STHRestAPI.StartSequencePayload;
-        const sequence = this.sequencesStore.get(id);
+        const sequence = this.sequencesStore.get(id) ||
+            Array.from(this.sequencesStore.values()).find((seq: SequenceInfo) => seq.name === id);
 
         if (!sequence) {
             return { opStatus: ReasonPhrases.NOT_FOUND };

--- a/packages/types/src/api-expose.ts
+++ b/packages/types/src/api-expose.ts
@@ -3,6 +3,7 @@ import { DataStream } from "scramjet";
 import { Duplex, Readable, Writable } from "stream";
 import { ICommunicationHandler } from "./communication-handler";
 import { ControlMessageCode, MonitoringMessageCode } from "./message-streams";
+import { IObjectLogger } from "./object-logger";
 import { MaybePromise } from "./utils";
 
 export type ParsedMessage = IncomingMessage & { body?: any; params: { [key: string]: any } | undefined };
@@ -149,6 +150,7 @@ export interface APIExpose extends APIBase {
      */
     server: Server;
     log: DataStream;
+    opLogger?: IObjectLogger;
     decorate(path: string | RegExp, ...decorators: Decorator[]): void;
 }
 

--- a/packages/types/src/api-expose.ts
+++ b/packages/types/src/api-expose.ts
@@ -52,6 +52,8 @@ export type StreamConfig = {
      *  @default true
      */
     checkEndHeader?: boolean;
+
+    method?: "post" | "put";
 };
 
 export interface APIError extends Error {

--- a/packages/types/src/op-response.ts
+++ b/packages/types/src/op-response.ts
@@ -1,5 +1,9 @@
 import { ReasonPhrases } from "http-status-codes";
 
 export type OpResponse<PayloadType extends Record<string, unknown>> =
-| (PayloadType & { opStatus: ReasonPhrases.OK | ReasonPhrases.ACCEPTED })
-| { opStatus: Exclude<ReasonPhrases, ReasonPhrases.OK | ReasonPhrases.ACCEPTED>, error?: unknown }
+    | (PayloadType & { opStatus: ReasonPhrases.OK | ReasonPhrases.ACCEPTED })
+    | {
+        opStatus: Exclude<
+            ReasonPhrases, ReasonPhrases.OK | ReasonPhrases.ACCEPTED
+        >, error?: unknown
+    }

--- a/packages/types/src/rest-api-sth/get-instance.ts
+++ b/packages/types/src/rest-api-sth/get-instance.ts
@@ -1,3 +1,7 @@
 import { Instance } from "../instance-store";
+import { DeepPartial } from "../utils";
+import { GetSequenceResponse } from "./get-sequence";
 
-export type GetInstanceResponse = Instance;
+export type GetInstanceResponse = Instance & {
+    sequenceInfo: DeepPartial<GetSequenceResponse>
+};

--- a/packages/types/src/rest-api-sth/get-sequence.ts
+++ b/packages/types/src/rest-api-sth/get-sequence.ts
@@ -2,6 +2,7 @@ import { SequenceConfig } from "../runner-config";
 
 export type GetSequenceResponse = {
     id: string;
+    name?: string;
     config: SequenceConfig,
     instances: readonly string[]
 }

--- a/packages/types/src/sequence-adapter.ts
+++ b/packages/types/src/sequence-adapter.ts
@@ -4,9 +4,10 @@ import { InstanceId } from "./instance";
 import { IObjectLogger } from "./object-logger";
 
 export type SequenceInfo = {
-    id: string;
     config: SequenceConfig;
+    id: string;
     instances: Set<InstanceId>;
+    name?: string;
 }
 
 export interface ISequenceAdapter {

--- a/packages/types/src/sequence-adapter.ts
+++ b/packages/types/src/sequence-adapter.ts
@@ -26,7 +26,7 @@ export interface ISequenceAdapter {
     /**
      * Identifies new Sequence
      */
-    identify(stream: Readable, id: string): Promise<SequenceConfig>;
+    identify(stream: Readable, id: string, override?: boolean): Promise<SequenceConfig>;
 
     remove(conifg: SequenceConfig): Promise<void>
 


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
- support `x-name` header for sequence when uploading new sequence
- overriding sequence with `PUT /sequence/:id`

**Why?**  <!-- What is this needed for? You can link to an issue. -->
updating sequences

```
$ si seq send packages/hello-alice-out.tar.gz --name names-generator
SequenceClient {
  _id: 'b6133713-ffc6-4807-9369-f5bb3ba02edd',
  host: HostClient {
    apiBase: 'http://127.0.0.1:8000/api/v1',
    client: ClientUtils {
      apiBase: 'http://127.0.0.1:8000/api/v1',
      fetch: [Function (anonymous)],
      normalizeUrlFn: [Function: normalizeUrl]
    }
  },
  sequenceURL: 'sequence/b6133713-ffc6-4807-9369-f5bb3ba02edd'
}

$ si seq update packages/avengers-names-output.tar.gz --name names-generator
SequenceClient {
  _id: 'b6133713-ffc6-4807-9369-f5bb3ba02edd',
  host: HostClient {
    apiBase: 'http://127.0.0.1:8000/api/v1',
    client: ClientUtils {
      apiBase: 'http://127.0.0.1:8000/api/v1',
      fetch: [Function (anonymous)],
      normalizeUrlFn: [Function: normalizeUrl]
    }
  },
  sequenceURL: 'sequence/b6133713-ffc6-4807-9369-f5bb3ba02edd'
}

```

**Review checks:**

These aspects need to be checked by the reviewer:

- [x] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [x] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

