### PR TITLE
CLI clean session config on profile change

### DIFF
--- a/packages/cli/src/lib/commands/config.ts
+++ b/packages/cli/src/lib/commands/config.ts
@@ -19,7 +19,7 @@ export const config: CommandDefinition = (program) => {
         middlewareApiUrl: defaulMiddlewareApiUrl,
         env: defaultEnv,
         token: defaultToken,
-        log:{
+        log: {
             debug: defaultDebug,
             format: defaultFormat
         }
@@ -216,6 +216,11 @@ export const config: CommandDefinition = (program) => {
         .description("Set configuration profile as default to use")
         .action((name) => {
             if (!profileExists(name)) throw Error(`Unknown profile: ${name}`);
+            const currentProfile = siConfig.getConfig().profile;
+
+            if (name === currentProfile)
+                return;
+            sessionConfig.restoreDefaultConfig();
             siConfig.setProfile(name);
         });
 

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -98,6 +98,9 @@ class DefaultFileConfig extends FileConfig {
     getDefaultConfig() {
         return this.defaultConfig;
     }
+    restoreDefaultConfig() {
+        return this.writeConfig(this.getDefaultConfig());
+    }
 
     validateConfigValue(key: string, value: any): boolean {
         type defaultConfigKey = keyof typeof this.defaultConfig;
@@ -291,7 +294,7 @@ export class ProfileConfig extends DefaultFileConfig {
                 if (value === this.defaultConfig.middlewareApiUrl) return true;
                 return isUrl(value);
             }
-            case "env" : return isConfigEnv(value);
+            case "env": return isConfigEnv(value);
             case "token": {
                 if (value === this.defaultConfig.token) return true;
                 return isJWT(value);
@@ -300,7 +303,7 @@ export class ProfileConfig extends DefaultFileConfig {
                 return true;
         }
     }
-    validateConfigLogValue(key: string, value: any):boolean {
+    validateConfigLogValue(key: string, value: any): boolean {
         type logConfigKey = keyof typeof this.defaultConfig.log;
         if (!(key in this.defaultConfig.log) || typeof value !== typeof this.defaultConfig.log[key as logConfigKey])
             return false;
@@ -380,7 +383,7 @@ export class ProfileManager {
     isPathSource() {
         return this.source === profileSource.envProfilePath || this.source === profileSource.flagProfilePath;
     }
-    getProfileName():string {
+    getProfileName(): string {
         if (this.isPathSource())
             return "user configuration file";
         return siConfig.getConfig().profile;
@@ -421,14 +424,14 @@ export class ProfileManager {
         return incomingSource >= this.source;
     }
 
-    protected setProfileFromName(profileName: string):boolean {
+    protected setProfileFromName(profileName: string): boolean {
         if (!profileExists(profileName)) throw Error(`Unable to find profile: ${profileName}`);
         this.profile.readOnly = false;
         this.profile.setFilePath(profileNameToPath(profileName));
         return true;
     }
 
-    protected setProfileFromFile = (path:string):boolean => {
+    protected setProfileFromFile = (path: string): boolean => {
         const fileConfig = JSON.parse(readFileSync(path, "utf-8"));
 
         if (!this.profile.validateConfig(fileConfig)) throw Error("Invalid config file");


### PR DESCRIPTION
This PR fixes issue:
https://github.com/scramjetorg/transform-hub/issues/611

On CLI on profile change adds cleaning of session config, so no lastInstanceId, lastSequenceId  etc. are used from work with previous profile.