### PR TITLE
sth add error msg on invalid instace id

### DIFF
--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -423,7 +423,8 @@ export class Host implements IComponent {
 
         if (!sequenceInfo) {
             return {
-                opStatus: ReasonPhrases.NOT_FOUND
+                opStatus: ReasonPhrases.NOT_FOUND,
+                error: `The sequence ${id} does not exist.`
             };
         }
 
@@ -792,7 +793,8 @@ export class Host implements IComponent {
 
         if (!sequence) {
             return {
-                opStatus: ReasonPhrases.NOT_FOUND
+                opStatus: ReasonPhrases.NOT_FOUND,
+                error: `The sequence ${id} does not exist.`
             };
         }
 

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -393,6 +393,7 @@ export class Host implements IComponent {
         }
 
         res.statusCode = 404;
+        res.write(JSON.stringify({ error: `The instance ${params.id} does not exist.` }));
         res.end();
 
         return next();


### PR DESCRIPTION
System should inform that instance does not exist while requesting instance details. Currently we response only with statusCode 404, this PR adds message in response body:
{  "error": "The instance <id> does not exist."}
