### PR TITLE
[STH] Unify error responses

### DIFF
--- a/packages/api-client/src/sequence-client.ts
+++ b/packages/api-client/src/sequence-client.ts
@@ -52,18 +52,18 @@ export class SequenceClient {
      * @returns {Promise<InstanceClient>} Promise resolving to Instance Client.
      */
     async start(payload: STHRestAPI.StartSequencePayload): Promise<InstanceClient> {
-        const response = await this.clientUtils.post<STHRestAPI.StartSequenceResponse>(
-            `${this.sequenceURL}/start`,
-            payload,
-            {},
-            { json: true, parse: "json", throwOnErrorHttpCode: false }
-        );
+        try {
+            const response = await this.clientUtils.post<STHRestAPI.StartSequenceResponse>(
+                `${this.sequenceURL}/start`,
+                payload,
+                {},
+                { json: true, parse: "json", throwOnErrorHttpCode: true }
+            );
 
-        if (response.result === "error") {
-            return Promise.reject(response.error);
+            return InstanceClient.from(response.id, this.host);
+        } catch (error: any) {
+            return Promise.reject(JSON.parse(error.body)?.error || error);
         }
-
-        return InstanceClient.from(response.id, this.host);
     }
 
     /**

--- a/packages/api-server/src/handlers/get.ts
+++ b/packages/api-server/src/handlers/get.ts
@@ -46,6 +46,10 @@ export function createGetterHandler(router: SequentialCeroRouter): APIRoute["get
                 statusCode = getStatusCode(data.opStatus);
                 reason = data.opStatus;
 
+                if (statusCode >= 400) {
+                    data.error ||= data.opStatus;
+                }
+
                 delete data.opStatus;
             }
 

--- a/packages/api-server/src/handlers/op.ts
+++ b/packages/api-server/src/handlers/op.ts
@@ -113,6 +113,11 @@ export function createOperationHandler(router: SequentialCeroRouter): APIRoute["
             const statusCode = getStatusCode(result.opStatus);
             const reason = result.opStatus;
 
+            if (statusCode >= 400) {
+                result.error ||= result.opStatus;
+            }
+            delete result.opStatus;
+
             res.writeHead(statusCode, reason, { "content-type": "application/json" });
 
             if (Object.keys(result).length) {

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -326,8 +326,9 @@ export class CSIController extends TypedEmitter<Events> {
             case RunnerExitCode.INVALID_SEQUENCE_PATH: {
                 return Promise.reject({
                     message: `Sequence entrypoint path ${this.sequence.config.entrypointPath} is invalid. ` +
-                    "Check `main` field in Sequence package.json",
-                    exitcode: RunnerExitCode.INVALID_SEQUENCE_PATH });
+                        "Check `main` field in Sequence package.json",
+                    exitcode: RunnerExitCode.INVALID_SEQUENCE_PATH
+                });
             }
             case RunnerExitCode.SEQUENCE_FAILED_ON_START: {
                 return Promise.reject({
@@ -542,7 +543,6 @@ export class CSIController extends TypedEmitter<Events> {
         if (development()) {
             this.router.upstream("/monitoring", this.upStreams[CC.MONITORING]);
         }
-
         this.router.upstream("/output", this.upStreams[CC.OUT]);
 
         let inputHeadersSent = false;
@@ -555,7 +555,7 @@ export class CSIController extends TypedEmitter<Events> {
                 // @TODO: Check if subsequent requests have the same content-type.
                 if (!inputHeadersSent) {
                     if (contentType === undefined) {
-                        throw new Error("Content-Type must be defined");
+                        return { opStatus: ReasonPhrases.NOT_ACCEPTABLE, error: "Content-Type must be defined" };
                     }
 
                     stream.write(`Content-Type: ${contentType}\r\n`);
@@ -567,7 +567,7 @@ export class CSIController extends TypedEmitter<Events> {
                 return stream;
             }
 
-            return { opStatus: 406, error: "Input provided in other way." };
+            return { opStatus: ReasonPhrases.METHOD_NOT_ALLOWED, error: "Input provided in other way" };
         }, { checkContentType: false, end: true, encoding: "binary" });
 
         // monitoring data
@@ -578,7 +578,7 @@ export class CSIController extends TypedEmitter<Events> {
 
         const localEmitter = Object.assign(
             new EventEmitter(),
-                { lastEvents: {} } as { lastEvents: { [evname: string]: any } }
+            { lastEvents: {} } as { lastEvents: { [evname: string]: any } }
         );
 
         this.communicationHandler.addMonitoringHandler(RunnerMessageCode.EVENT, (data) => {
@@ -589,7 +589,6 @@ export class CSIController extends TypedEmitter<Events> {
             localEmitter.lastEvents[event.eventName] = event;
             localEmitter.emit(event.eventName, event);
         });
-
         this.router.upstream("/events/:name", async (req: ParsedMessage, res: ServerResponse) => {
             const name = req.params?.name;
 
@@ -632,7 +631,6 @@ export class CSIController extends TypedEmitter<Events> {
 
             return awaitEvent(req);
         });
-
         this.router.get("/once/:name", awaitEvent);
 
         // operations

--- a/packages/types/src/load-check-stat.ts
+++ b/packages/types/src/load-check-stat.ts
@@ -1,9 +1,11 @@
 export type DiskSpace = {
     fs: string,
+    type?: string,
     size: number,
     used: number,
     available: number,
     use: number
+    mount?: string
 }
 
 export type LoadCheckStat = {

--- a/packages/types/src/op-response.ts
+++ b/packages/types/src/op-response.ts
@@ -1,9 +1,11 @@
 import { ReasonPhrases } from "http-status-codes";
 
 export type OpResponse<PayloadType extends Record<string, unknown>> =
-    | (PayloadType & { opStatus: ReasonPhrases.OK | ReasonPhrases.ACCEPTED })
+    | (PayloadType & {
+        opStatus: ReasonPhrases.OK | ReasonPhrases.ACCEPTED,
+        message?: string
+    })
     | {
-        opStatus: Exclude<
-            ReasonPhrases, ReasonPhrases.OK | ReasonPhrases.ACCEPTED
-        >, error?: unknown
+        opStatus: Exclude<ReasonPhrases, ReasonPhrases.OK | ReasonPhrases.ACCEPTED>,
+        error?: string | Error | unknown
     }

--- a/packages/types/src/rest-api-manager/common.ts
+++ b/packages/types/src/rest-api-manager/common.ts
@@ -1,6 +1,12 @@
+export type ConnectedSTHInfoDetails = {
+    created?: Date;
+    lastConnected?: Date;
+    lastDisconnected?: Date;
+}
+
 export type ConnectedSTHInfo = {
     id: string,
-    info: { [key: string]: any },
+    info: ConnectedSTHInfoDetails,
     healthy: boolean,
     isConnectionActive: boolean
 };

--- a/packages/types/src/rest-api-sth/get-sequence-instances.ts
+++ b/packages/types/src/rest-api-sth/get-sequence-instances.ts
@@ -1,1 +1,7 @@
-export type GetSequenceInstancesResponse = readonly string[] | undefined;
+import { ReasonPhrases } from "http-status-codes";
+
+export type GetSequenceInstancesResponse = readonly string[]
+    | {
+        opStatus: Exclude<ReasonPhrases, ReasonPhrases.OK | ReasonPhrases.ACCEPTED>,
+        error?: string | Error | unknown
+    };

--- a/packages/types/src/rest-api-sth/start-sequence.ts
+++ b/packages/types/src/rest-api-sth/start-sequence.ts
@@ -1,7 +1,7 @@
 import { AppConfig } from "../app-config";
 import { InstanceLimits } from "../instance-limits";
 
-export type StartSequenceResponse = { result: "success", id: string } | { result: "error", error: unknown }
+export type StartSequenceResponse = { id: string }
 
 export type StartSequencePayload = {
     appConfig: AppConfig,

--- a/scripts/build-all.js
+++ b/scripts/build-all.js
@@ -31,6 +31,7 @@ const opts = minimist(process.argv.slice(2), {
     },
     default: {
         root: env.WORKSPACE_ROOT || cwd(),
+        verbose: !!env.SCRAMJET_VERBOSE,
         build: !env.NO_BUILD,
         dist: !env.NO_COPY_DIST,
         install: !env.NO_INSTALL,

--- a/scripts/run-script.js
+++ b/scripts/run-script.js
@@ -35,6 +35,7 @@ const opts = minimist(process.argv.slice(2), {
     },
     default: {
         root: env.WORKSPACE_ROOT || cwd(),
+        verbose: !!env.SCRAMJET_VERBOSE,
         build: !env.NO_BUILD,
         dist: !env.NO_COPY_DIST,
         install: !env.NO_INSTALL,


### PR DESCRIPTION
This PR unifies different api responses from STH:

All 4xx responses should return body:
{ error= string | Error }

Some post messages gets new descriptive message:
{message?: "message descirbing action (if needed)"}

**Why?**
Error codes- to help user find cause of errors faster.
Post messages- to help platform be more interactive.

**Review checks:**

These aspects need to be checked by the reviewer:

- [x] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [x] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [x] Documentation is updated or no changes

