### PR TITLE
[CLI] Fix broken prod_env check

### DIFF
--- a/packages/cli/src/lib/commands/index.ts
+++ b/packages/cli/src/lib/commands/index.ts
@@ -1,4 +1,4 @@
-import { CommandDefinition, isProductionEnv } from "../../types";
+import { CommandDefinition } from "../../types";
 import { config } from "./config";
 import { hub } from "./hub";
 import { instance } from "./instance";
@@ -10,15 +10,12 @@ import { completion } from "./completion";
 import { util } from "./util";
 import { init } from "./init";
 import { isDevelopment } from "../../utils/envs";
-import { profileConfig } from "../config";
-
-const isProdEnv = isProductionEnv(profileConfig.getEnv());
 
 export const commands: CommandDefinition[] = [
     hub,
     config,
-    isProdEnv ? scope : () => {},
-    isProdEnv ? space : () => {},
+    scope,
+    space,
     sequence,
     instance,
     topic,

--- a/packages/cli/src/lib/commands/scope.ts
+++ b/packages/cli/src/lib/commands/scope.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { CommandDefinition } from "../../types";
+import { CommandDefinition, isProductionEnv } from "../../types";
 import { listScopes, deleteScope, getScope, scopeExists } from "../scope";
 import { displayError, displayObject } from "../output";
 import { profileConfig } from "../config";
@@ -11,6 +11,10 @@ import { isDevelopment } from "../../utils/envs";
  * @param {Command} program Commander object.
  */
 export const scope: CommandDefinition = (program) => {
+    const isProdEnv = isProductionEnv(profileConfig.getEnv());
+
+    if (!isProdEnv) return;
+
     const scopeCmd = program
         .command("scope")
         .addHelpCommand(false)
@@ -43,7 +47,7 @@ export const scope: CommandDefinition = (program) => {
             .option("--space <name> <apiUrl>", "Add space to specified scope")
             .description("TO BE IMPLEMENTED / Add a Hub or space to specified scope")
             .action(() => {
-            // FIXME: implement me
+                // FIXME: implement me
                 throw new Error("Implement me");
             });
 
@@ -53,7 +57,7 @@ export const scope: CommandDefinition = (program) => {
             .argument("<name>")
             .description("TO BE IMPLEMENTED / Save current chosen space and Hub under a scope name")
             .action(() => {
-            // FIXME: implement me
+                // FIXME: implement me
                 throw new Error("Implement me");
             });
 

--- a/packages/cli/src/lib/commands/space.ts
+++ b/packages/cli/src/lib/commands/space.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { CommandDefinition } from "../../types";
+import { CommandDefinition, isProductionEnv } from "../../types";
 import { isDevelopment } from "../../utils/envs";
 import { profileConfig, sessionConfig } from "../config";
 import { displayObject } from "../output";
@@ -11,6 +11,10 @@ import { getMiddlewareClient } from "../platform";
  * @param {Command} program Commander object.
  */
 export const space: CommandDefinition = (program) => {
+    const isProdEnv = isProductionEnv(profileConfig.getEnv());
+
+    if (!isProdEnv) return;
+
     const spaceCmd = program
         .command("space")
         .addHelpCommand(false)


### PR DESCRIPTION
This PR fixes problem of invisible `si space` `si scope` commands on different profiles than default (when proper env: production is set).