### PR TITLE
Unpipe input from topic when instance is terminated

### DIFF
--- a/bdd/step-definitions/e2e/cli.ts
+++ b/bdd/step-definitions/e2e/cli.ts
@@ -37,9 +37,11 @@ When("I execute CLI with {string}", { timeout: 30000 }, async function(this: Cus
     const res = this.cliResources;
 
     res.stdio = await getStreamsFromSpawn("/usr/bin/env", [...si, ...args.split(" ")]);
+
     if (process.env.SCRAMJET_TEST_LOG) {
         logger.debug(res.stdio);
     }
+
     assert.equal(res.stdio[2], 0);
 });
 

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -54,9 +54,10 @@ const runnerExitDelay = 15000;
 
 type Events = {
     pang: (payload: MessageDataType<RunnerMessageCode.PANG>) => void,
-    error: (error: any) => void,
-    stop: (code: number) => void
-    end: (code: number) => void
+    error: (error: any) => void;
+    stop: (code: number) => void;
+    end: (code: number) => void;
+    terminated: (code: number) => void;
 }
 
 enum TerminateReason {
@@ -239,6 +240,7 @@ export class CSIController extends TypedEmitter<Events> {
         this.status = !errored ? "completed" : "errored";
 
         this.info.ended = new Date();
+        this.emit("terminated", code);
 
         this.logger.trace("Finalizing...");
 

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -834,6 +834,16 @@ export class Host implements IComponent {
 
         csic.on("end", (code) => {
             this.logger.trace("CSIControlled ended", `Exit code: ${code}`);
+
+            if (csic.provides && csic.provides !== "") {
+                csic.getOutputStream()!.unpipe(this.serviceDiscovery.getData(
+                    {
+                        topic: csic.provides,
+                        contentType: ""
+                    }
+                ) as Writable);
+            }
+
             csic.logger.unpipe(this.logger);
 
             delete InstanceStore[csic.id];
@@ -846,16 +856,9 @@ export class Host implements IComponent {
             }, InstanceMessageCode.INSTANCE_ENDED);
 
             this.auditor.auditInstance(id, InstanceMessageCode.INSTANCE_ENDED);
+        });
 
-            if (csic.provides && csic.provides !== "") {
-                csic.getOutputStream()!.unpipe(this.serviceDiscovery.getData(
-                    {
-                        topic: csic.provides,
-                        contentType: ""
-                    }
-                ) as Writable);
-            }
-
+        csic.once("terminated", (_code) => {
             if (csic.requires && csic.requires !== "") {
                 (this.serviceDiscovery.getData(
                     {


### PR DESCRIPTION
**What?**  <!-- Two-sentence summary, understandable for a junior. -->
The problem with topics can be caused by extended instance lifetime. topic data remains piped to ended, but still existing instance.

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [x] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [x] Documentation is updated or no changes

