### PR TITLE
[CLI] fix-reset all not clearing session

### DIFF
--- a/packages/cli/src/lib/commands/config.ts
+++ b/packages/cli/src/lib/commands/config.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-import { CommandDefinition, displayFormat } from "../../types";
+import { CommandDefinition } from "../../types";
 import { stringToBoolean } from "../../utils/stringToBoolean";
 import { ProfileConfig, profileConfig, profileManager, siConfig, sessionConfig } from "../config";
 import { displayMessage, displayObject } from "../output";
@@ -50,10 +50,11 @@ export const config: CommandDefinition = (program) => {
         .command("session")
         .alias("s")
         .description("Print out the current session configuration")
-        .action((format: displayFormat) => {
+        .action(() => {
+            const configuration = profileConfig.getConfig();
             const session = sessionConfig.getConfig();
 
-            displayObject(session, format);
+            displayObject(session, configuration.log.format);
         });
 
     const setCmd = configCmd

--- a/packages/cli/src/lib/commands/config.ts
+++ b/packages/cli/src/lib/commands/config.ts
@@ -189,7 +189,10 @@ export const config: CommandDefinition = (program) => {
     resetCmd
         .command("all")
         .description("Reset all configuration")
-        .action(() => resetValue(defaultConfig, v => profileConfig.setConfig(v)));
+        .action(() => {
+            profileConfig.restoreDefaultConfig();
+            sessionConfig.restoreDefaultConfig();
+        });
 
     const profileCmd = configCmd
         .command("profile")


### PR DESCRIPTION
CLI command `si c reset all` did't reset session configuration leaving old values. This PR fixes it.

- [x] Verify and confirm operation (please post a screenshot) 
- [x] All STH tests pass
- [x] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [x] Documentation is updated or no changes

![image](https://user-images.githubusercontent.com/90617593/188071632-9a44ef5d-a2ab-44f6-aec2-f6052740ef11.png)
