### PR TITLE
Fix: topic data lost

### DIFF
--- a/packages/api-server/src/handlers/stream.ts
+++ b/packages/api-server/src/handlers/stream.ts
@@ -79,7 +79,8 @@ export function createStreamHandlers(router: SequentialCeroRouter) {
 
             res
                 .on("error", disconnect)
-                .on("unpipe", disconnect);
+                .on("unpipe", disconnect)
+                .socket?.on("end", () => disconnect());
 
             return out.pipe(res);
         } catch (e: any) {

--- a/packages/api-server/src/handlers/stream.ts
+++ b/packages/api-server/src/handlers/stream.ts
@@ -80,7 +80,7 @@ export function createStreamHandlers(router: SequentialCeroRouter) {
             res
                 .on("error", disconnect)
                 .on("unpipe", disconnect)
-                .socket?.on("end", () => disconnect());
+                .socket?.on("end", disconnect);
 
             return out.pipe(res);
         } catch (e: any) {


### PR DESCRIPTION
Big thanks to @MichalCz for cracking this net/streaming riddle and @patuwwy for the late evening debug session :muscle: 

**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Fix for losing the first chunks of data sent via Topic API.
https://github.com/scramjetorg/transform-hub/issues/663

**Why?**  <!-- What is this needed for? You can link to an issue. -->
It was required for the lossless Topic API data transfer.

When the request to get data from topic was finished, the event of closing connection was not invoked in the api-server. Therefore, we did not unpipe topic data stream from the response and the data was kept being consumed by stream from the finished connection until the error was thrown. 

**Usage:**
1. Start the STH
2. In one terminal window: 
`si topic get <topicName>` press Enter
3. In another terminal window:
`si topic send <topicName>` 
press Enter.
Send a few chunks of data.
4. In the first terminal window (from point 2), disconnect from getting topic from api (ctrl+c).
5. In the second terminal window (from point 3) send more few chunks of data.
6. In the first terminal window execute again the command:
`si topic get <topicName>` press Enter
You should receive all chunks of data that were sent to the topic while not being connected to it.

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

