### PR TITLE
[STH] Instance stop and kill body params fix

### DIFF
--- a/packages/api-client/src/instance-client.ts
+++ b/packages/api-client/src/instance-client.ts
@@ -1,5 +1,5 @@
 import { RunnerMessageCode } from "@scramjet/symbols";
-import { EncodedControlMessage, STHRestAPI } from "@scramjet/types";
+import { EncodedControlMessage, STHRestAPI, StopSequenceMessageData, KillMessageData } from "@scramjet/types";
 import { ClientProvider, HttpClient, SendStreamOptions } from "@scramjet/client-utils";
 
 export type InstanceInputStream = "stdin" | "input";
@@ -54,13 +54,7 @@ export class InstanceClient {
     async stop(timeout: number, canCallKeepalive: boolean): Promise<STHRestAPI.SendStopInstanceResponse> {
         return this.clientUtils.post<STHRestAPI.SendStopInstanceResponse>(
             `${this.instanceURL}/_stop`,
-            [
-                RunnerMessageCode.STOP,
-                {
-                    timeout,
-                    canCallKeepalive,
-                },
-            ] as EncodedControlMessage,
+            { timeout, canCallKeepalive, } as StopSequenceMessageData,
             {},
             { json: true, parse: "json" }
         );
@@ -73,10 +67,10 @@ export class InstanceClient {
      * @param {boolean} opts.removeImmediately If true, Instance lifetime extension delay will be bypassed.
      * @returns {Promise<SendKillInstanceResponse>} Promise resolving to kill Instance result.
      */
-    async kill(opts = { removeImmediately: false }): Promise<STHRestAPI.SendKillInstanceResponse> {
+    async kill(opts: KillMessageData = {}): Promise<STHRestAPI.SendKillInstanceResponse> {
         return this.clientUtils.post<STHRestAPI.SendKillInstanceResponse>(
             `${this.instanceURL}/_kill`,
-            [RunnerMessageCode.KILL, { removeImmediately: opts.removeImmediately }] as EncodedControlMessage,
+            opts,
             {},
             { json: true, parse: "json" }
         );

--- a/packages/types/src/instance.ts
+++ b/packages/types/src/instance.ts
@@ -1,2 +1,10 @@
 export type InstanceId = string;
-export type InstanceStatus = "initializing" | "starting" | "running" | "stopping" | "killing" | "completed" | "errored";
+export const enum InstanceStatus {
+    INITIALIZING = "initializing",
+    STARTING = "starting",
+    RUNNING = "running",
+    STOPPING = "stopping",
+    KILLING = "killing",
+    COMPLETED ="completed",
+    ERRORED = "errored",
+}

--- a/packages/types/src/messages/index.ts
+++ b/packages/types/src/messages/index.ts
@@ -6,7 +6,7 @@ export { EventMessage, EventMessageData } from "./event";
 export { PangMessageData, PingMessageData, HandshakeMessage } from "./handshake";
 export { HandshakeAcknowledgeMessage, HandshakeAcknowledgeMessageData } from "./handshake-acknowledge";
 export { KeepAliveMessage, KeepAliveMessageData } from "./keep-alive";
-export { KillSequenceMessage } from "./kill-sequence";
+export { KillSequenceMessage, KillMessageData } from "./kill-sequence";
 export { EmptyMessageData, Message } from "./message";
 export { MonitoringRateMessage, MonitoringRateMessageData } from "./monitor-rate";
 export { MonitoringMessage, MonitoringMessageData, MonitoringMessageFromRunnerData } from "./monitoring";


### PR DESCRIPTION
Currently instance endpoints /_kill and /_stop requires to pass in body InstatnceStatus Code to succesfully pass request validation which makes it impossible to use by regular user.

This PR changes required body params to be optional, and changes reqest body format from:
`[InstanceStatus.SomeCode, {...requiredParams}] `
to 
`{...optionalParams}`


**Review checks:**

These aspects need to be checked by the reviewer:

- [x] Verify and confirm operation 
- [x] All STH tests pass
- [x] Documentation is updated or no changes

Verification:
1) /_stop
Invalid timeout format:
![image](https://user-images.githubusercontent.com/90617593/188607015-b2136524-2de2-476d-b0c9-7e8b1b837d32.png)

Invalid canCallKeepalive format:
![image](https://user-images.githubusercontent.com/90617593/188607447-f28fbca2-1e07-4943-bf19-2983da443d00.png)

Valid params provided:
![image](https://user-images.githubusercontent.com/90617593/188607695-90e82700-88e2-4bf6-b9c2-38f9dbabcca6.png)

No params provided (use of default params):
![image](https://user-images.githubusercontent.com/90617593/188608243-5ed023d1-db23-4902-9fac-4581daf7430d.png)

2) /_kill
Invalid params format:
![image](https://user-images.githubusercontent.com/90617593/188608901-31f85e1d-243e-4971-a883-e73ab5a21eff.png)

Valid params provided:
![image](https://user-images.githubusercontent.com/90617593/188609120-e919d3fd-0fde-4378-8d97-22d6ed409f64.png)

No params provided (use of default params):
![image](https://user-images.githubusercontent.com/90617593/188609515-5603c801-128a-4697-b13d-e9b1c5b4d7fb.png)
