### PR TITLE
(fix) docker compose for sth

### DIFF
--- a/packages/sth/docker-compose.yaml
+++ b/packages/sth/docker-compose.yaml
@@ -1,12 +1,11 @@
 version: "3"
 services:
   scramjet-hub:
-    image: scramjetorg/sth:0.12.2
+    image: scramjetorg/sth:0.28.1
     volumes:
       - /tmp/:/tmp/
       - /var/run/docker.sock:/var/run/docker.sock
     ports:
       - 8000:8000
     restart: unless-stopped
-    init: true
     command: ["scramjet-transform-hub"]


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->

**What?**  <!-- Two-sentence summary, understandable for a junior. -->
fix docker compose for sth


**Why?**  <!-- What is this needed for? You can link to an issue. -->
Start STH from this compose on docker-compose v1.25.0 throws error

```
docker-compose -v
docker-compose version 1.25.0, build unknown
```
Error:
```
docker-compose up -d
ERROR: The Compose file './docker-compose.yaml' is invalid because:
Unsupported config option for services.scramjet-hub: 'init'
```
Root case:
https://github.com/docker/docker.github.io/issues/3149
`init` was removed in version 3 and returned in v3.7

by the way, I updated the image version

Thanks to @S4adam for finding this bug

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

