### PR TITLE
Allow to merge if target key not exists

### DIFF
--- a/packages/utility/src/merge.ts
+++ b/packages/utility/src/merge.ts
@@ -14,6 +14,7 @@ export const merge = <T extends Record<string, unknown>>(
 ) => Object.keys(source)
         .forEach((key: keyof T) => {
             if (typeof source[key] === "object" && !Array.isArray(source[key])) {
+                target[key] ||= {} as T[keyof T];
                 merge(target[key] as Record<string, unknown>, source[key]);
             } else if (source[key] !== undefined) {
                 target[key] = source[key] as T[keyof T];


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Fix in merge util allowing to assign to key not existing in target but existing in source.

**Why?**  <!-- What is this needed for? You can link to an issue. -->
cant `merge({}, { newKey: "value" });` it requires `newKey` to exist in target.
**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [x] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

