### PR TITLE
Fix telemtry sizes and environment

### DIFF
--- a/docs/adapters/classes/DockerSequenceAdapter.md
+++ b/docs/adapters/classes/DockerSequenceAdapter.md
@@ -46,7 +46,7 @@ Adapter for preparing Sequence to be run in Docker container.
 
 #### Defined in
 
-[docker-sequence-adapter.ts:39](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L39)
+[docker-sequence-adapter.ts:40](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L40)
 
 ## Methods
 
@@ -70,7 +70,7 @@ Created volume.
 
 #### Defined in
 
-[docker-sequence-adapter.ts:209](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L209)
+[docker-sequence-adapter.ts:210](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L210)
 
 ___
 
@@ -92,7 +92,7 @@ Pulls image from registry.
 
 #### Defined in
 
-[docker-sequence-adapter.ts:67](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L67)
+[docker-sequence-adapter.ts:68](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L68)
 
 ___
 
@@ -125,7 +125,7 @@ ISequenceAdapter.identify
 
 #### Defined in
 
-[docker-sequence-adapter.ts:137](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L137)
+[docker-sequence-adapter.ts:138](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L138)
 
 ___
 
@@ -149,7 +149,7 @@ Sequence configuration or undefined if sequence cannot be identified.
 
 #### Defined in
 
-[docker-sequence-adapter.ts:96](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L96)
+[docker-sequence-adapter.ts:97](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L97)
 
 ___
 
@@ -169,7 +169,7 @@ ISequenceAdapter.init
 
 #### Defined in
 
-[docker-sequence-adapter.ts:50](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L50)
+[docker-sequence-adapter.ts:51](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L51)
 
 ___
 
@@ -191,7 +191,7 @@ ISequenceAdapter.list
 
 #### Defined in
 
-[docker-sequence-adapter.ts:76](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L76)
+[docker-sequence-adapter.ts:77](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L77)
 
 ___
 
@@ -217,7 +217,7 @@ Promise resolving to sequence configuration.
 
 #### Defined in
 
-[docker-sequence-adapter.ts:228](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L228)
+[docker-sequence-adapter.ts:229](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L229)
 
 ___
 
@@ -243,7 +243,7 @@ ISequenceAdapter.remove
 
 #### Defined in
 
-[docker-sequence-adapter.ts:284](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L284)
+[docker-sequence-adapter.ts:286](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L286)
 
 ## Properties
 
@@ -253,7 +253,7 @@ ISequenceAdapter.remove
 
 #### Defined in
 
-[docker-sequence-adapter.ts:29](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L29)
+[docker-sequence-adapter.ts:30](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L30)
 
 ___
 
@@ -269,7 +269,7 @@ ISequenceAdapter.logger
 
 #### Defined in
 
-[docker-sequence-adapter.ts:37](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L37)
+[docker-sequence-adapter.ts:38](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L38)
 
 ___
 
@@ -283,7 +283,7 @@ ISequenceAdapter.name
 
 #### Defined in
 
-[docker-sequence-adapter.ts:32](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L32)
+[docker-sequence-adapter.ts:33](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L33)
 
 ___
 
@@ -293,4 +293,4 @@ ___
 
 #### Defined in
 
-[docker-sequence-adapter.ts:30](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L30)
+[docker-sequence-adapter.ts:31](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/docker-sequence-adapter.ts#L31)

--- a/docs/adapters/classes/KubernetesSequenceAdapter.md
+++ b/docs/adapters/classes/KubernetesSequenceAdapter.md
@@ -35,7 +35,7 @@ Adapter for preparing Sequence to be run in process.
 
 #### Defined in
 
-[kubernetes-sequence-adapter.ts:57](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-sequence-adapter.ts#L57)
+[kubernetes-sequence-adapter.ts:59](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-sequence-adapter.ts#L59)
 
 ___
 
@@ -49,7 +49,7 @@ ISequenceAdapter.logger
 
 #### Defined in
 
-[kubernetes-sequence-adapter.ts:53](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-sequence-adapter.ts#L53)
+[kubernetes-sequence-adapter.ts:55](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-sequence-adapter.ts#L55)
 
 ___
 
@@ -63,7 +63,7 @@ ISequenceAdapter.name
 
 #### Defined in
 
-[kubernetes-sequence-adapter.ts:55](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-sequence-adapter.ts#L55)
+[kubernetes-sequence-adapter.ts:57](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-sequence-adapter.ts#L57)
 
 ## Constructors
 
@@ -79,7 +79,7 @@ ISequenceAdapter.name
 
 #### Defined in
 
-[kubernetes-sequence-adapter.ts:59](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-sequence-adapter.ts#L59)
+[kubernetes-sequence-adapter.ts:61](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-sequence-adapter.ts#L61)
 
 ## Methods
 
@@ -109,7 +109,7 @@ ISequenceAdapter.identify
 
 #### Defined in
 
-[kubernetes-sequence-adapter.ts:113](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-sequence-adapter.ts#L113)
+[kubernetes-sequence-adapter.ts:115](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-sequence-adapter.ts#L115)
 
 ___
 
@@ -131,7 +131,7 @@ ISequenceAdapter.init
 
 #### Defined in
 
-[kubernetes-sequence-adapter.ts:75](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-sequence-adapter.ts#L75)
+[kubernetes-sequence-adapter.ts:77](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-sequence-adapter.ts#L77)
 
 ___
 
@@ -153,7 +153,7 @@ ISequenceAdapter.list
 
 #### Defined in
 
-[kubernetes-sequence-adapter.ts:91](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-sequence-adapter.ts#L91)
+[kubernetes-sequence-adapter.ts:93](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-sequence-adapter.ts#L93)
 
 ___
 
@@ -181,4 +181,4 @@ ISequenceAdapter.remove
 
 #### Defined in
 
-[kubernetes-sequence-adapter.ts:143](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-sequence-adapter.ts#L143)
+[kubernetes-sequence-adapter.ts:145](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/adapters/src/kubernetes-sequence-adapter.ts#L145)

--- a/docs/api-client/README.md
+++ b/docs/api-client/README.md
@@ -1,4 +1,4 @@
-@scramjet/api-client / [Exports](modules.md)
+@scramjet/client-utils / [Exports](modules.md)
 
 <h1 align="center"><strong>Scramjet Transform Hub API Client</strong></h1>
 
@@ -51,11 +51,11 @@ There's no limit what you can use it for. You want a stock checker? A chat bot? 
 
 ## Quick guide
 
-- [Host operations](https://github.com/scramjetorg/transform-hub/tree/HEAD/packages/api-client/#host-operations)
-- [Sequence operations](https://github.com/scramjetorg/transform-hub/tree/HEAD/packages/api-client/#sequence-operations)
-- [Instance basic operations](https://github.com/scramjetorg/transform-hub/tree/HEAD/packages/api-client/#instance-basic-operations)
-- [Instance advanced operation](https://github.com/scramjetorg/transform-hub/tree/HEAD/packages/api-client/#instance-advanced-operation)
-- [Service Discovery: Topics](https://github.com/scramjetorg/transform-hub/tree/HEAD/packages/api-client/#service-discovery-topics)
+- [Host operations](https://github.com/scramjetorg/transform-hub/tree/HEAD/packages/client-utils/#host-operations)
+- [Sequence operations](https://github.com/scramjetorg/transform-hub/tree/HEAD/packages/client-utils/#sequence-operations)
+- [Instance basic operations](https://github.com/scramjetorg/transform-hub/tree/HEAD/packages/client-utils/#instance-basic-operations)
+- [Instance advanced operation](https://github.com/scramjetorg/transform-hub/tree/HEAD/packages/client-utils/#instance-advanced-operation)
+- [Service Discovery: Topics](https://github.com/scramjetorg/transform-hub/tree/HEAD/packages/client-utils/#service-discovery-topics)
 
 ___
 
@@ -63,16 +63,16 @@ ___
 
 <details>
 <summary>
-    <strong class="get">[ GET ]</strong>  <code>/api/v1/version</code> <small>- show the Host version</small>
+    <strong>[ GET ]</strong>  <code>/api/v1/version</code> <small>- show the Host version</small>
 </summary>
 
-<br> <strong>Parameters</strong>
+<br> <strong>**Parameters**</strong>
 
-<small>No parameters</small>
+No parameters
 
 <strong>Responses</strong>
 
-<small>Successful operation code: `200`</small>
+<small>Successful operation code: **200**</small>
 
 ```json
 { "version" : "0.12.2" }
@@ -82,16 +82,16 @@ ___
 
 <details>
 <summary>
-    <strong class="get">[ GET ]</strong>  <code>/api/v1/sequences</code> <small>- show all Sequences saved on the Host</small>
+    <strong>[ GET ]</strong>  <code>/api/v1/sequences</code> <small>- show all Sequences saved on the Host</small>
 </summary>
 
-<br> <strong>Parameters</strong>
+<br> <strong>**Parameters**</strong>
 
-<small>No parameters</small>
+No parameters
 
 <strong>Responses</strong>
 
-<small>Successful operation code: `200`</small>
+<small>Successful operation code: **200**</small>
 
 ```json
 [
@@ -148,16 +148,16 @@ ___
 
 <details>
 <summary>
-    <strong class="get">[ GET ]</strong>  <code>/api/v1/instances</code> <small>- show all Instances running on the Host</small>
+    <strong>[ GET ]</strong>  <code>/api/v1/instances</code> <small>- show all Instances running on the Host</small>
 </summary>
 
-<br> <strong>Parameters</strong>
+<br> <strong>**Parameters**</strong>
 
-<small>No parameters</small>
+No parameters
 
 <strong>Responses</strong>
 
-<small>Successful operation code: `200`</small>
+<small>Successful operation code: **200**</small>
 
 ```json
 [
@@ -176,16 +176,16 @@ ___
 
 <details>
 <summary>
-    <strong class="get">[ GET ]</strong>  <code>/api/v1/load-check</code> <small>- monitor CPU, memory and disk usage metrics on the Host machine</small>
+    <strong>[ GET ]</strong>  <code>/api/v1/load-check</code> <small>- monitor CPU, memory and disk usage metrics on the Host machine</small>
 </summary>
 
-<br> <strong>Parameters</strong>
+<br> <strong>**Parameters**</strong>
 
-<small>No parameters</small>
+No parameters
 
 <strong>Responses</strong>
 
-<small>Successful operation code: `200`</small>
+<small>Successful operation code: **200**</small>
 
 ```json
 {
@@ -221,18 +221,18 @@ ___
 
 <details>
 <summary>
-    <strong class="get">[ GET ]</strong>  <code>/api/v1/log</code> <small>- monitor CPU, memory and disk usage metrics on the Host machine</small>
+    <strong>[ GET ]</strong>  <code>/api/v1/log</code> <small>- monitor CPU, memory and disk usage metrics on the Host machine</small>
 </summary>
 
-<br> <strong>Parameters</strong>
+<br> <strong>**Parameters**</strong>
 
-<small>No parameters</small>
+No parameters
 
 <strong>Responses</strong>
 
-<small>Content-type: `application/octet-stream`</small>
+<small>Content-type: application/octet-stream</small>
 
-<small>Successful operation code: `200`</small>
+<small>Successful operation code: **200**</small>
 
 ```bash
 2021-11-19T16:04:47.094Z log (object:Host) Host main called.
@@ -271,19 +271,19 @@ ___
 
 <details>
 <summary>
-    <strong class="post">[ POST ]</strong> <code>/api/v1/sequence</code> <small>- add new sequence</small>
+    <strong>[ POST ]</strong> <code>/api/v1/sequence</code> <small>- add new sequence</small>
 </summary>
 
-<br><strong>Parameters</strong>
+<br><strong>**Parameters**</strong>
 
-| Name        | Type     | Description                         | Required |
-| ----------- | -------- | ----------------------------------- | -------- |
-| `file`      | `binary` | compressed package in tar.gz format | yes      |
-| `appConfig` | `json`   | additional package.json config file | no       |
+| Name      | Description                         | Type   | Required |
+| --------- | ----------------------------------- | ------ | -------- |
+| file      | compressed package in tar.gz format | binary | yes      |
+| appConfig | additional package.json config file | json   | no       |
 
 <strong>Responses</strong>
 
-<small>Accepted operation code: `202`</small>
+<small>Status: 202 Accepted</small>
 
 ```json
 {
@@ -295,16 +295,16 @@ ___
 
 <details>
 <summary>
-    <strong class="get">[ GET ]</strong>  <code>/api/v1/sequences</code> <small>- show list of sequences</small>
+    <strong>[ GET ]</strong>  <code>/api/v1/sequences</code> <small>- show list of sequences</small>
 </summary>
 
-<br> <strong>Parameters</strong>
+<br> <strong>**Parameters**</strong>
 
-<small>No parameters</small>
+No parameters
 
 <strong>Responses</strong>
 
-<small>Successful operation code: `200`</small>
+<small>Successful operation code: **200**</small>
 
 ```json
 [
@@ -333,19 +333,19 @@ ___
 
 <details>
 <summary>
-    <strong class="post">[ POST ]</strong> <code>/api/v1/sequence/:id/start</code> <small>- start chosen sequence</small>
+    <strong>[ POST ]</strong> <code>/api/v1/sequence/:id/start</code> <small>- start chosen sequence</small>
 </summary>
 
-<br> <strong>Parameters</strong>
+<br> <strong>**Parameters**</strong>
 
-| Name        | Type   | Description                                           | Required |
-| ----------- | ------ | ----------------------------------------------------- | -------- |
-| `appConfig` | `json` | additional package.json config file                   | no       |
-| `args`      | `json` | additional arguments that instance should starts with | no       |
+| Name      | Description                                           | Type | Required |
+| --------- | ----------------------------------------------------- | ---- | -------- |
+| appConfig | additional package.json config file                   | json | no       |
+| args      | additional arguments that instance should starts with | json | no       |
 
 <strong>Responses</strong>
 
-<small>Successful operation code: `200`</small>
+<small>Successful operation code: **200**</small>
 
 ```json
 {
@@ -357,16 +357,16 @@ ___
 
 <details>
 <summary>
-    <strong class="delete">[ DELETE ]</strong> <code>/api/v1/sequence/:id</code> <small>- delete a sequence by id</small>
+    <strong>[ DELETE ]</strong> <code>/api/v1/sequence/:id</code> <small>- delete a sequence by id</small>
 </summary>
 
-<br> <strong>Parameters</strong>
+<br> <strong>**Parameters**</strong>
 
-<small>No parameters</small>
+No parameters
 
 <strong>Responses</strong>
 
-<small>Successful operation code: `200`</small>
+<small>*Status*: 200 Success</small>
 
 ```json
 {
@@ -374,7 +374,7 @@ ___
 }
 ```
 
-<small>Conflict operation code: `409` - the instance is still running</small>
+<small>*Status*: 409 Conflict - the instance is still running</small>
 
 ```json
 {
@@ -390,16 +390,16 @@ ___
 
 <details>
 <summary>
-    <strong class="get">[ GET ]</strong> <code>/api/v1/instances</code> <small>- list all instances</small>
+    <strong>[ GET ]</strong> <code>/api/v1/instances</code> <small>- list all instances</small>
 </summary>
 
-<br> <strong>Parameters</strong>
+<br> <strong>**Parameters**</strong>
 
-<small>No parameters</small>
+No parameters
 
 <strong>Responses</strong>
 
-<small>Successful operation code: `200`</small>
+<small>Successful operation code: **200**</small>
 
 ```json
 [
@@ -422,19 +422,16 @@ ___
 
 <details>
 <summary>
-    <strong class="get">[ GET ]</strong> <code>/api/v1/instance/:id</code> <small>- show data of chosen instance</small>
+    <strong>[ GET ]</strong> <code>/api/v1/instance/:id</code> <small>- show data of chosen instance</small>
 </summary>
 
-<br> <strong>Parameters</strong>
+<br> <strong>**Parameters**</strong>
 
-<small>No parameters</small>
+No parameters
 
 <strong>Responses</strong>
 
-| Name                 | Code  | Description                                 |
-| :------------------- | :---- | :------------------------------------------ |
-| Successful operation | `200` | Returns JSON data                           |
-| Not Found operation  | `404` | For example if instance was already stopped |
+<small>*Status*: 200 Accepted</small>
 
 ```json
 {
@@ -444,23 +441,25 @@ ___
 }
 ```
 
+<small>*Status*: 404 Not Found</small>  <small>- when the Instance is not found, for example: the Instance was already stopped.</small>
+
 </details>
 
 <details>
 <summary>
-    <strong class="post">[ POST ]</strong> <code>/api/v1/instance/:id/_stop</code> <small>- end instance gracefully and prolong operations or not for task completion​</small>
+    <strong>[ POST ]</strong> <code>/api/v1/instance/:id/_stop</code> <small>- end instance gracefully and prolong operations or not for task completion​</small>
 </summary>
 
-<br> <strong>Parameters</strong>
+<br> <strong>**Parameters**</strong>
 
-| Name               | Type      | Description                                                                     | Required |
-| ------------------ | --------- | ------------------------------------------------------------------------------- | -------- |
-| `timeout`          | `number`  | The number of milliseconds before the Instance will be killed. Default: 7000ms. | no       |
-| `canCallKeepalive` | `boolean` | If set to true, the instance will prolong the running. Default: false.          | no       |
+| Name             | Description                                                                     | Type    | Required |
+| ---------------- | ------------------------------------------------------------------------------- | ------- | -------- |
+| timeout          | The number of milliseconds before the Instance will be killed. Default: 7000ms. | number  | no       |
+| canCallKeepalive | If set to true, the instance will prolong the running. Default: false.          | boolean | no       |
 
 <strong>Responses</strong>
 
-<small>Successful operation code: `200`</small>
+<small>Successful operation code: **200**</small>
 
 ```json
 {
@@ -474,16 +473,16 @@ ___
 
 <details>
 <summary>
-    <strong class="post">[ POST ]</strong>  <code>api/v1/instance/:id/_kill</code> <small>- end instance gracefully waiting for unfinished tasks</small>
+    <strong>[ POST ]</strong>  <code>api/v1/instance/:id/_kill</code> <small>- end instance gracefully waiting for unfinished tasks</small>
 </summary>
 
-<br> <strong>Parameters</strong>
+<br> <strong>**Parameters**</strong>
 
-<small>No parameters</small>
+No parameters
 
 <strong>Responses</strong>
 
-<small>Accepted operation code: `202`</small>
+<small>*Status*: 202 Accepted</small>
 
 ```text
 No body returned
@@ -493,16 +492,16 @@ No body returned
 
 <details>
 <summary>
-    <strong class="get">[ GET ]</strong>  <code>/api/v1/instance/:id/health</code> <small>- check status about instance health</small>
+    <strong>[ GET ]</strong>  <code>/api/v1/instance/:id/health</code> <small>- check status about instance health</small>
 </summary>
 
-<br> <strong>Parameters</strong>
+<br> <strong>**Parameters**</strong>
 
-<small>No parameters</small>
+No parameters
 
 <strong>Responses</strong>
 
-<small>Successful operation code: `200`</small>
+<small>Successful operation code: **200**</small>
 
 ```json
 {
@@ -523,12 +522,16 @@ ___
 
 ### Instance advanced operation
 
+STH allows you to interact (communicate) with an instance by sending events with or without any information defined in the object​. As well as providing and receiving stream with all kinds of data files.
+
+Event contains <eventName>, <handler> with optional <message> of any type: string, num, json obj, array, etc..
+
 <details>
 <summary>
-    <strong class="post">[ POST ]</strong>  <code>/api/v1/instance/:id/_event</code> <small>- send event to the Instance</small>
+    <strong>[ POST ]</strong>  <code>/api/v1/instance/:id/_event</code> <small>- send event to the Instance</small>
 </summary>
 
-<br> <strong>Parameters</strong>
+<br> <strong>**Parameters**</strong>
 
 | Name        | Type     | Description                  | Required |
 | :---------- | :------- | ---------------------------- | -------- |
@@ -537,132 +540,131 @@ ___
 
 <strong>Responses</strong>
 
-<small>Content-type: `application/octet-stream`</small>
+<small>Content-type: application/octet-stream</small>
 
 </details>
 
 <details>
 <summary>
-    <strong class="get">[ GET ]</strong>  <code>/api/v1/instance/:id/event</code> <small>- get the data stream with the events from the Instance</small>
+    <strong>[ GET ]</strong>  <code>/api/v1/instance/:id/event</code> <small>- get the data stream with the events from the Instance</small>
 </summary>
 
-<br> <strong>Parameters</strong>
+<br> <strong>**Parameters**</strong>
 
-<small>No parameters</small>
+No parameters
 
 <strong>Responses</strong>
 
-<small>Content-type: `application/octet-stream`</small>
+<small>Content-type: application/octet-stream</small>
 
 </details>
 
 <details>
 <summary>
-    <strong class="get">[ GET ]</strong>  <code>/api/v1/instance/:id/once</code> <small>- get the last event sent by the Instance</small>
+    <strong>[ GET ]</strong>  <code>/api/v1/instance/:id/once</code> <small>- get the last event sent by the Instance</small>
 </summary>
+<!-- ToDo: think about the name -->
+<br> <strong>**Parameters**</strong>
 
-<br> <strong>Parameters</strong>
-
-<small>No parameters</small>
+No parameters
 
 <strong>Responses</strong>
 
-<small>Content-type: `application/octet-stream`</small>
+<small>Content-type: application/octet-stream</small>
 
 </details>
 
 <details>
 <summary>
-    <strong class="post">[ POST ]</strong>  <code>/api/v1/instance/:id/input</code> <small>- send data to the input stream of the Instance to consume it</small>
+    <strong>[ POST ]</strong>  <code>/api/v1/instance/:id/input</code> <small>- send data to the Instance. The data is sent to the input stream of the Instance where it can be consumed.</small>
 </summary>
 
-<br> <strong>Parameters</strong>
+<br> <strong>**Parameters**</strong>
 
-<small>No parameters</small>
+No parameters
 
 <strong>Responses</strong>
 
-| Name                     | Code  | Description                                                  |
-| :----------------------- | :---- | :----------------------------------------------------------- |
-| Successful operation     | `200` | -                                                            |
-| Not Acceptable operation | `406` | Instance expects the input to be provided from the Topic API |
+<small>Successful operation code: **200**</small>
+
+<small>Operation code: **406 Not Acceptable**</small> <small>- with an error message "Input provided in other way." This status code is returned when the Instance expects the input to be provided from the Topic API.</small>
 
 </details>
 
 <details>
 <summary>
-    <strong class="get">[ GET ]</strong>  <code>/api/v1/instance/:id/output</code> <small>- get stream data from an instance and consume it through the endpoint</small>
+    <strong>[ GET ]</strong>  <code>/api/v1/instance/:id/output</code> <small>- get the output stream from the Instance. Everything the Instance writes to its output stream can be consumed through this endpoint.</small>
 </summary>
 
-<br> <strong>Parameters</strong>
+<br> <strong>**Parameters**</strong>
 
-<small>No parameters</small>
+No parameters
 
 <strong>Responses</strong>
 
-<small>Content-type: `application/octet-stream`</small>
+<small>Content-type: application/octet-stream</small>
 
 </details>
 
 <details>
 <summary>
-    <strong class="post">[ POST ]</strong>  <code>/api/v1/instance/:id/stdin​</code> <small>- process.stdin</small>
+    <strong>[ POST ]</strong>  <code>/api/v1/instance/:id/stdin​</code> <small>- process.stdin</small>
 </summary>
 
-<br> <strong>Parameters</strong>
+<br> <strong>**Parameters**</strong>
 
-<small>No parameters</small>
+No parameters
 
 <strong>Responses</strong>
 
-<small>Successful operation code: `200`</small>
+<small>Successful operation code: **200**</small>
 
 </details>
 
 <details>
 <summary>
-    <strong class="get">[ GET ]</strong>  <code>/api/v1/instance/:id/stdout</code> <small>- process.stdout</small>
+    <strong>[ GET ]</strong>  <code>/api/v1/instance/:id/stdout</code> <small>- process.stdout</small>
 </summary>
 
-<br> <strong>Parameters</strong>
+<br> <strong>**Parameters**</strong>
 
-<small>No parameters</small>
+No parameters
 
 <strong>Responses</strong>
 
-<small>Content-type: `application/octet-stream`</small>
+<small>Content-type: application/octet-stream</small>
 
 </details>
 
 <details>
 <summary>
-    <strong class="get">[ GET ]</strong>  <code>/api/v1/instance/:id/stderr</code> <small>- process.stderr</small>
+    <strong>[ GET ]</strong>  <code>/api/v1/instance/:id/stderr</code> <small>- process.stderr</small>
 </summary>
 
-<br> <strong>Parameters</strong>
+<br> <strong>**Parameters**</strong>
 
-<small>No parameters</small>
+No parameters
 
 <strong>Responses</strong>
 
-<small>Content-type: `application/octet-stream`</small>
+<small>Content-type: application/octet-stream</small>
 
 </details>
 
 <details>
 <summary>
-    <strong class="get">[ GET ]</strong>  <code>/api/v1/instance/:id/log</code> <small>- stream all instance logs</small>
+    <strong>[ GET ]</strong>  <code>/api/v1/instance/:id/log</code> <small>- stream all instance logs</small>
 </summary>
 
-<br> <strong>Parameters</strong>
+<br> <strong>**Parameters**</strong>
 
-<small>No parameters</small>
+No parameters
 
 <strong>Responses</strong>
 
-<small>Content-type: `application/octet-stream`</small>
+<small>Content-type: application/octet-stream</small>
 
-<small>Successful operation code: `200`</small>
+<small>Successful operation code: **200**</small>
 
 ```bash
 2021-11-19T16:12:22.948Z log (Sequence) 42
@@ -681,49 +683,45 @@ ___
 
 ### Service Discovery: Topics
 
-If a given topic does not exist, Transform-Hub creates it and stores the sent data in the newly created topic. The data is stored in the topic until the data is not consumed (either by the Topic API or by the Instances subscribing to this topic). When the data are sent to the topic they are written to the returned stream.
-
 <details>
 <summary>
-    <strong class="post">[ POST ]</strong>  <code>/api/v1/topics/:name​</code> <small>- sends data to the topic</small>
+    <strong>[ POST ]</strong>  <code>/api/v1/topics/:name​</code> <small>- sends data to the topic</small>
 </summary>
 
-<br> <strong>Parameters</strong>
+<small>If a given topic does not exist, Transform-Hub creates it and stores the sent data in the newly created topic. The data is stored in the topic until the data is not consumed (either by the Topic API or by the Instances subscribing to this topic).​</small>
+<br> <strong>**Parameters**</strong>
 
-<small><small>No parameters</small></small>
+No parameters
 
 <strong>Request Headers</strong>
 
-| Header         | Type                  | Description                                                             | Default                | Required |
-| -------------- | --------------------- | ----------------------------------------------------------------------- | ---------------------- | -------- |
-| `x-end-stream` | `boolean`             | If set to `true`, then close topic stream after processing the request. | false                  | no       |
-| `content-type` | `text`, `application` | Specifies data type of this topic                                       | `application/x-ndjson` | no       |
+<small>"x-end-stream"</small> <small>- close topic stream [optional, boolean]. If x-end-stream header value is true, the topic stream is closed after processing this request. The default value is false. </small>
 
-<small> Supported types: `text/x-ndjson`, `application/x-ndjson`, `application/x-ndjson`, `text/plain`, `application/octet-stream`</small>
+<small>"content-type"</small> <small>-specify stream content type [optional, boolean]. The content-type header specifies data type of this topic.
+The recognized values are: text/x-ndjson, application/x-ndjson, application/x-ndjson, text/plain, application/octet-stream. The default value is application/x-ndjson.​ </small>
 
 <strong>Responses</strong>
 
-| Name                 | Code  | Description                                                           |
-| :------------------- | :---- | :-------------------------------------------------------------------- |
-| Successful operation | `200` | data was sent with the header indicating the end of data              |
-| Successful operation | `202` | data was sent without the header indicating the end of data (default) |
+<small>Successful operation code: **200**</small> <small>- when data to topic is sent with the header indicating the end of data</small>
+<br> <small>Successful operation code: **202**</small> <small>- when data to topic is sent without the header indicating the end of data (default)</small>
 
 </details>
 
 <details>
 <summary>
-    <strong class="get">[ GET ]</strong>  <code>/api/v1/topics/:name​</code> <small>- get data from the topic</small>
+    <strong>[ GET ]</strong>  <code>/api/v1/topics/:name​</code> <small>- get data from the topic</small>
 </summary>
 
-<br> <strong>Parameters</strong>
+<small>If a given topic does not exist, Transform-Hub creates it and returns a new stream. When the data are sent to the topic they are written to the returned stream.</small>
+<br> <strong>**Parameters**</strong>
 
-<small>No parameters</small>
+No parameters
 
 <strong>Responses</strong>
 
 <small>Topic data stream.</small>
 
-<small>Successful operation code: `200`</small>
+<small>Successful operation code: **200**</small>
 
 ```json
 {

--- a/docs/api-client/classes/ClientError.md
+++ b/docs/api-client/classes/ClientError.md
@@ -1,0 +1,262 @@
+[@scramjet/client-utils](../README.md) / [Exports](../modules.md) / ClientError
+
+# Class: ClientError
+
+## Hierarchy
+
+- `Error`
+
+  ↳ **`ClientError`**
+
+## Table of contents
+
+### Properties
+
+- [body](ClientError.md#body)
+- [code](ClientError.md#code)
+- [message](ClientError.md#message)
+- [name](ClientError.md#name)
+- [prepareStackTrace](ClientError.md#preparestacktrace)
+- [reason](ClientError.md#reason)
+- [source](ClientError.md#source)
+- [stack](ClientError.md#stack)
+- [stackTraceLimit](ClientError.md#stacktracelimit)
+- [status](ClientError.md#status)
+
+### Methods
+
+- [captureStackTrace](ClientError.md#capturestacktrace)
+- [from](ClientError.md#from)
+- [toJSON](ClientError.md#tojson)
+
+### Constructors
+
+- [constructor](ClientError.md#constructor)
+
+## Properties
+
+### body
+
+• **body**: `any`
+
+#### Defined in
+
+[packages/client-utils/src/client-error.ts:53](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/client-error.ts#L53)
+
+___
+
+### code
+
+• **code**: `string`
+
+#### Defined in
+
+[packages/client-utils/src/client-error.ts:50](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/client-error.ts#L50)
+
+___
+
+### message
+
+• **message**: `any`
+
+#### Overrides
+
+Error.message
+
+#### Defined in
+
+[packages/client-utils/src/client-error.ts:52](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/client-error.ts#L52)
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+Error.name
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1028
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`See`**
+
+https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+Error.prepareStackTrace
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:11
+
+___
+
+### reason
+
+• `Optional` **reason**: `Error`
+
+#### Defined in
+
+[packages/client-utils/src/client-error.ts:48](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/client-error.ts#L48)
+
+___
+
+### source
+
+• `Optional` **source**: `Error`
+
+#### Defined in
+
+[packages/client-utils/src/client-error.ts:49](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/client-error.ts#L49)
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+Error.stack
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1030
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+Error.stackTraceLimit
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:13
+
+___
+
+### status
+
+• `Optional` **status**: `string`
+
+#### Defined in
+
+[packages/client-utils/src/client-error.ts:51](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/client-error.ts#L51)
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+Error.captureStackTrace
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:4
+
+___
+
+### from
+
+▸ `Static` **from**(`error`, `message?`, `source?`): [`ClientError`](ClientError.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `error` | `Error` \| `QueryError` |
+| `message?` | `string` |
+| `source?` | `Error` |
+
+#### Returns
+
+[`ClientError`](ClientError.md)
+
+#### Defined in
+
+[packages/client-utils/src/client-error.ts:67](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/client-error.ts#L67)
+
+___
+
+### toJSON
+
+▸ **toJSON**(): `Promise`<`unknown`\>
+
+#### Returns
+
+`Promise`<`unknown`\>
+
+#### Defined in
+
+[packages/client-utils/src/client-error.ts:89](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/client-error.ts#L89)
+
+## Constructors
+
+### constructor
+
+• **new ClientError**(`code`, `reason?`, `message?`, `source?`, `status?`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `code` | [`ClientErrorCode`](../modules.md#clienterrorcode) |
+| `reason?` | `string` \| `Error` |
+| `message?` | `string` |
+| `source?` | `Error` |
+| `status?` | `string` |
+
+#### Overrides
+
+Error.constructor
+
+#### Defined in
+
+[packages/client-utils/src/client-error.ts:55](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/client-error.ts#L55)

--- a/docs/api-client/classes/ClientUtils.md
+++ b/docs/api-client/classes/ClientUtils.md
@@ -1,0 +1,374 @@
+[@scramjet/client-utils](../README.md) / [Exports](../modules.md) / ClientUtils
+
+# Class: ClientUtils
+
+Provides HTTP communication methods.
+
+**`Classdesc`**
+
+Provides HTTP communication methods.
+
+## Hierarchy
+
+- `ClientUtilsBase`
+
+  ↳ **`ClientUtils`**
+
+## Implements
+
+- [`HttpClient`](../interfaces/HttpClient.md)
+
+## Table of contents
+
+### Methods
+
+- [addLogger](ClientUtils.md#addlogger)
+- [delete](ClientUtils.md#delete)
+- [get](ClientUtils.md#get)
+- [getStream](ClientUtils.md#getstream)
+- [post](ClientUtils.md#post)
+- [put](ClientUtils.md#put)
+- [sendStream](ClientUtils.md#sendstream)
+- [setDefaultHeaders](ClientUtils.md#setdefaultheaders)
+
+### Properties
+
+- [apiBase](ClientUtils.md#apibase)
+- [headers](ClientUtils.md#headers)
+
+### Constructors
+
+- [constructor](ClientUtils.md#constructor)
+
+## Methods
+
+### addLogger
+
+▸ **addLogger**(`logger`): `void`
+
+Sets given logger.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `logger` | `Partial`<[`RequestLogger`](../modules.md#requestlogger)\> | Logger to set. |
+
+#### Returns
+
+`void`
+
+#### Implementation of
+
+[HttpClient](../interfaces/HttpClient.md).[addLogger](../interfaces/HttpClient.md#addlogger)
+
+#### Inherited from
+
+ClientUtilsBase.addLogger
+
+#### Defined in
+
+[packages/client-utils/src/client-utils.ts:26](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/client-utils.ts#L26)
+
+___
+
+### delete
+
+▸ **delete**<`T`\>(`url`, `requestInit?`): `Promise`<`T`\>
+
+Performs DELETE request.
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `url` | `string` | Request URL. |
+| `requestInit` | `RequestInit` | RequestInit object to be passed to fetch. |
+
+#### Returns
+
+`Promise`<`T`\>
+
+Promise resolving to given type.
+
+#### Implementation of
+
+[HttpClient](../interfaces/HttpClient.md).[delete](../interfaces/HttpClient.md#delete)
+
+#### Inherited from
+
+ClientUtilsBase.delete
+
+#### Defined in
+
+[packages/client-utils/src/client-utils.ts:201](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/client-utils.ts#L201)
+
+___
+
+### get
+
+▸ **get**<`T`\>(`url`, `requestInit?`): `Promise`<`T`\>
+
+Performs get using request wrapper.
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `url` | `string` | Request URL. |
+| `requestInit` | `RequestInit` | RequestInit object to be passed to fetch. |
+
+#### Returns
+
+`Promise`<`T`\>
+
+Promise resolving to given type.
+
+#### Implementation of
+
+[HttpClient](../interfaces/HttpClient.md).[get](../interfaces/HttpClient.md#get)
+
+#### Inherited from
+
+ClientUtilsBase.get
+
+#### Defined in
+
+[packages/client-utils/src/client-utils.ts:115](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/client-utils.ts#L115)
+
+___
+
+### getStream
+
+▸ **getStream**(`url`, `requestInit?`): `Promise`<`any`\>
+
+Performs get request for streamed data.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `url` | `string` | Request URL. |
+| `requestInit` | `RequestInit` | RequestInit object to be passed to fetch. |
+
+#### Returns
+
+`Promise`<`any`\>
+
+Readable stream.
+
+#### Implementation of
+
+[HttpClient](../interfaces/HttpClient.md).[getStream](../interfaces/HttpClient.md#getstream)
+
+#### Inherited from
+
+ClientUtilsBase.getStream
+
+#### Defined in
+
+[packages/client-utils/src/client-utils.ts:126](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/client-utils.ts#L126)
+
+___
+
+### post
+
+▸ **post**<`T`\>(`url`, `data`, `requestInit?`, `config?`): `Promise`<`T`\>
+
+Performs POST request and returns response in given type.
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `url` | `string` | Request URL. |
+| `data` | `any` | Data to be send. |
+| `requestInit` | `RequestInit` | RequestInit object to be passed to fetch. |
+| `config` | `RequestConfig` | Request config. |
+
+#### Returns
+
+`Promise`<`T`\>
+
+Promise resolving to given type.
+
+#### Implementation of
+
+[HttpClient](../interfaces/HttpClient.md).[post](../interfaces/HttpClient.md#post)
+
+#### Inherited from
+
+ClientUtilsBase.post
+
+#### Defined in
+
+[packages/client-utils/src/client-utils.ts:139](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/client-utils.ts#L139)
+
+___
+
+### put
+
+▸ **put**<`T`\>(`url`, `data`, `requestInit?`, `config?`): `Promise`<`T`\>
+
+Performs PUT request and returns response in given type.
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `url` | `string` | Request URL. |
+| `data` | `any` | Data to be send. |
+| `requestInit` | `RequestInit` | RequestInit object to be passed to fetch. |
+| `config` | `RequestConfig` | Request config. |
+
+#### Returns
+
+`Promise`<`T`\>
+
+Promise resolving to given type.
+
+#### Inherited from
+
+ClientUtilsBase.put
+
+#### Defined in
+
+[packages/client-utils/src/client-utils.ts:171](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/client-utils.ts#L171)
+
+___
+
+### sendStream
+
+▸ **sendStream**<`T`\>(`url`, `stream`, `requestInit?`, `options?`): `Promise`<`T`\>
+
+Performs POST request for streamed data.
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `url` | `string` | Request url. |
+| `stream` | `any` | stream to be send. |
+| `requestInit` | `RequestInit` | RequestInit object to be passed to fetch. |
+| `options` | `Partial`<{ `end`: `boolean` ; `parseResponse?`: ``"text"`` \| ``"json"`` \| ``"stream"`` ; `put`: `boolean` ; `type`: `string`  }\> | send stream options. |
+
+#### Returns
+
+`Promise`<`T`\>
+
+Promise resolving to response of given type.
+
+#### Implementation of
+
+[HttpClient](../interfaces/HttpClient.md).[sendStream](../interfaces/HttpClient.md#sendstream)
+
+#### Inherited from
+
+ClientUtilsBase.sendStream
+
+#### Defined in
+
+[packages/client-utils/src/client-utils.ts:224](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/client-utils.ts#L224)
+
+___
+
+### setDefaultHeaders
+
+▸ `Static` **setDefaultHeaders**(`headers`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `headers` | `Headers` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+ClientUtilsBase.setDefaultHeaders
+
+#### Defined in
+
+[packages/client-utils/src/client-utils.ts:36](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/client-utils.ts#L36)
+
+## Properties
+
+### apiBase
+
+• **apiBase**: `string`
+
+#### Inherited from
+
+ClientUtilsBase.apiBase
+
+#### Defined in
+
+[packages/client-utils/src/client-utils.ts:14](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/client-utils.ts#L14)
+
+___
+
+### headers
+
+▪ `Static` **headers**: `Headers` = `{}`
+
+#### Inherited from
+
+ClientUtilsBase.headers
+
+#### Defined in
+
+[packages/client-utils/src/client-utils.ts:11](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/client-utils.ts#L11)
+
+## Constructors
+
+### constructor
+
+• **new ClientUtils**(`apiBase`, `ca?`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `apiBase` | `string` |
+| `ca?` | `string` \| `Buffer` |
+
+#### Overrides
+
+ClientUtilsBase.constructor
+
+#### Defined in
+
+[packages/client-utils/src/index.ts:30](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/index.ts#L30)

--- a/docs/api-client/classes/InstanceClient.md
+++ b/docs/api-client/classes/InstanceClient.md
@@ -161,7 +161,7 @@ Promise resolving to event data.
 
 #### Defined in
 
-[api-client/src/instance-client.ts:121](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L121)
+[api-client/src/instance-client.ts:115](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L115)
 
 ___
 
@@ -185,7 +185,7 @@ stream of events from Instance
 
 #### Defined in
 
-[api-client/src/instance-client.ts:131](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L131)
+[api-client/src/instance-client.ts:125](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L125)
 
 ___
 
@@ -203,7 +203,7 @@ Promise resolving to Instance health.
 
 #### Defined in
 
-[api-client/src/instance-client.ts:140](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L140)
+[api-client/src/instance-client.ts:134](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L134)
 
 ___
 
@@ -221,7 +221,7 @@ Promise resolving to Instance info.
 
 #### Defined in
 
-[api-client/src/instance-client.ts:149](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L149)
+[api-client/src/instance-client.ts:143](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L143)
 
 ___
 
@@ -245,7 +245,7 @@ Promise resolving to event data.
 
 #### Defined in
 
-[api-client/src/instance-client.ts:110](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L110)
+[api-client/src/instance-client.ts:104](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L104)
 
 ___
 
@@ -270,7 +270,7 @@ Promise resolving to readable stream.
 
 #### Defined in
 
-[api-client/src/instance-client.ts:160](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L160)
+[api-client/src/instance-client.ts:154](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L154)
 
 ___
 
@@ -282,10 +282,9 @@ Send kill command to Instance
 
 #### Parameters
 
-| Name | Type | Default value | Description |
-| :------ | :------ | :------ | :------ |
-| `opts` | `Object` | `undefined` | Options. |
-| `opts.removeImmediately` | `boolean` | `false` | If true, Instance lifetime extension delay will be bypassed. |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `opts` | `KillMessageData` | Options. |
 
 #### Returns
 
@@ -295,7 +294,7 @@ Promise resolving to kill Instance result.
 
 #### Defined in
 
-[api-client/src/instance-client.ts:76](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L76)
+[api-client/src/instance-client.ts:70](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L70)
 
 ___
 
@@ -320,7 +319,7 @@ Promise resolving to send event result.
 
 #### Defined in
 
-[api-client/src/instance-client.ts:92](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L92)
+[api-client/src/instance-client.ts:86](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L86)
 
 ___
 
@@ -346,7 +345,7 @@ Promise resolving to send stream result.
 
 #### Defined in
 
-[api-client/src/instance-client.ts:185](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L185)
+[api-client/src/instance-client.ts:179](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L179)
 
 ___
 
@@ -370,7 +369,7 @@ Promise resolving to send stream result.
 
 #### Defined in
 
-[api-client/src/instance-client.ts:195](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L195)
+[api-client/src/instance-client.ts:189](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L189)
 
 ___
 
@@ -397,7 +396,7 @@ Promise resolving to send stream result.
 
 #### Defined in
 
-[api-client/src/instance-client.ts:173](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L173)
+[api-client/src/instance-client.ts:167](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L167)
 
 ___
 

--- a/docs/api-client/interfaces/ClientProvider.md
+++ b/docs/api-client/interfaces/ClientProvider.md
@@ -1,0 +1,19 @@
+[@scramjet/client-utils](../README.md) / [Exports](../modules.md) / ClientProvider
+
+# Interface: ClientProvider
+
+## Table of contents
+
+### Properties
+
+- [client](ClientProvider.md#client)
+
+## Properties
+
+### client
+
+• **client**: [`HttpClient`](HttpClient.md)
+
+#### Defined in
+
+[packages/client-utils/src/index.ts:42](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/index.ts#L42)

--- a/docs/api-client/interfaces/HttpClient.md
+++ b/docs/api-client/interfaces/HttpClient.md
@@ -1,0 +1,203 @@
+[@scramjet/client-utils](../README.md) / [Exports](../modules.md) / HttpClient
+
+# Interface: HttpClient
+
+Nodejs HttpClient interface.
+
+## Hierarchy
+
+- `HttpClient`
+
+  ↳ **`HttpClient`**
+
+## Implemented by
+
+- [`ClientUtils`](../classes/ClientUtils.md)
+
+## Table of contents
+
+### Methods
+
+- [addLogger](HttpClient.md#addlogger)
+- [delete](HttpClient.md#delete)
+- [get](HttpClient.md#get)
+- [getStream](HttpClient.md#getstream)
+- [post](HttpClient.md#post)
+- [sendStream](HttpClient.md#sendstream)
+
+## Methods
+
+### addLogger
+
+▸ **addLogger**(`logger`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `logger` | [`RequestLogger`](../modules.md#requestlogger) |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+HttpClient.addLogger
+
+#### Defined in
+
+[packages/client-utils/src/types/index.ts:50](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/types/index.ts#L50)
+
+___
+
+### delete
+
+▸ **delete**<`T`\>(`url`, `requestInit?`): `Promise`<`T`\>
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `url` | `string` |
+| `requestInit?` | `RequestInit` |
+
+#### Returns
+
+`Promise`<`T`\>
+
+#### Inherited from
+
+HttpClient.delete
+
+#### Defined in
+
+[packages/client-utils/src/types/index.ts:54](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/types/index.ts#L54)
+
+___
+
+### get
+
+▸ **get**<`T`\>(`url`, `requestInit?`): `Promise`<`T`\>
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `url` | `string` |
+| `requestInit?` | `RequestInit` |
+
+#### Returns
+
+`Promise`<`T`\>
+
+#### Inherited from
+
+HttpClient.get
+
+#### Defined in
+
+[packages/client-utils/src/types/index.ts:51](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/types/index.ts#L51)
+
+___
+
+### getStream
+
+▸ **getStream**(`url`, `requestInit?`): `Promise`<`Readable`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `url` | `string` |
+| `requestInit?` | `RequestInit` |
+
+#### Returns
+
+`Promise`<`Readable`\>
+
+#### Overrides
+
+HttpClient.getStream
+
+#### Defined in
+
+[packages/client-utils/src/types/index.ts:62](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/types/index.ts#L62)
+
+___
+
+### post
+
+▸ **post**<`T`\>(`url`, `data`, `requestInit?`, `options?`): `Promise`<`T`\>
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `url` | `string` |
+| `data` | `any` |
+| `requestInit?` | `RequestInit` |
+| `options?` | { `json`: `boolean`  } & `RequestConfig` |
+
+#### Returns
+
+`Promise`<`T`\>
+
+#### Inherited from
+
+HttpClient.post
+
+#### Defined in
+
+[packages/client-utils/src/types/index.ts:53](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/types/index.ts#L53)
+
+___
+
+### sendStream
+
+▸ **sendStream**<`T`\>(`url`, `stream`, `requestInit?`, `options?`): `Promise`<`T`\>
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `url` | `string` |
+| `stream` | `string` \| `Readable` |
+| `requestInit?` | `RequestInit` |
+| `options?` | `Partial`<{ `end`: `boolean` ; `parseResponse?`: ``"text"`` \| ``"json"`` \| ``"stream"`` ; `put`: `boolean` ; `type`: `string`  }\> |
+
+#### Returns
+
+`Promise`<`T`\>
+
+#### Overrides
+
+HttpClient.sendStream
+
+#### Defined in
+
+[packages/client-utils/src/types/index.ts:63](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/types/index.ts#L63)

--- a/docs/api-client/modules.md
+++ b/docs/api-client/modules.md
@@ -1,36 +1,64 @@
-[@scramjet/api-client](README.md) / Exports
+[@scramjet/client-utils](README.md) / Exports
 
-# @scramjet/api-client
+# @scramjet/client-utils
 
 ## Table of contents
 
 ### Classes
 
-- [HostClient](classes/HostClient.md)
-- [InstanceClient](classes/InstanceClient.md)
-- [SequenceClient](classes/SequenceClient.md)
+- [ClientError](classes/ClientError.md)
+- [ClientUtils](classes/ClientUtils.md)
 
 ### Type Aliases
 
-- [InstanceInputStream](modules.md#instanceinputstream)
-- [InstanceOutputStream](modules.md#instanceoutputstream)
+- [ClientErrorCode](modules.md#clienterrorcode)
+- [RequestLogger](modules.md#requestlogger)
+- [SendStreamOptions](modules.md#sendstreamoptions)
+
+### Interfaces
+
+- [ClientProvider](interfaces/ClientProvider.md)
+- [HttpClient](interfaces/HttpClient.md)
 
 ## Type Aliases
 
-### InstanceInputStream
+### ClientErrorCode
 
-Ƭ **InstanceInputStream**: ``"stdin"`` \| ``"input"``
+Ƭ **ClientErrorCode**: ``"GENERAL_ERROR"`` \| ``"BAD_PARAMETERS"`` \| ``"NEED_AUTHENTICATION"`` \| ``"NOT_AUTHORIZED"`` \| ``"NOT_FOUND"`` \| ``"GONE"`` \| ``"SERVER_ERROR"`` \| ``"REQUEST_ERROR"`` \| ``"UNKNOWN_ERROR"`` \| ``"CANNOT_CONNECT"`` \| ``"INVALID_RESPONSE"`` \| ``"INSUFFICIENT_RESOURCES"`` \| ``"UNPROCESSABLE_ENTITY"``
 
 #### Defined in
 
-[api-client/src/instance-client.ts:5](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L5)
+[packages/client-utils/src/client-error.ts:32](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/client-error.ts#L32)
 
 ___
 
-### InstanceOutputStream
+### RequestLogger
 
-Ƭ **InstanceOutputStream**: ``"stdout"`` \| ``"stderr"`` \| ``"output"`` \| ``"log"``
+Ƭ **RequestLogger**: `Object`
+
+Request logger.
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `end` | (...`req`: `any`) => `void` |
+| `error` | (`res`: [`ClientError`](classes/ClientError.md)) => `void` |
+| `ok` | (`res`: `any`) => `void` |
+| `request` | (...`req`: `any`) => `void` |
 
 #### Defined in
 
-[api-client/src/instance-client.ts:6](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/api-client/src/instance-client.ts#L6)
+[packages/client-utils/src/types/index.ts:22](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/types/index.ts#L22)
+
+___
+
+### SendStreamOptions
+
+Ƭ **SendStreamOptions**: `Partial`<{ `end`: `boolean` ; `parseResponse?`: ``"json"`` \| ``"text"`` \| ``"stream"`` ; `put`: `boolean` ; `type`: `string`  }\>
+
+Options for sending sending stream.
+
+#### Defined in
+
+[packages/client-utils/src/types/index.ts:7](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/client-utils/src/types/index.ts#L7)

--- a/docs/host/classes/CSIController.md
+++ b/docs/host/classes/CSIController.md
@@ -98,7 +98,7 @@ Handles all Instance lifecycle, exposes instance's HTTP API.
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:151](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L151)
+[packages/host/src/lib/csi-controller.ts:152](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L152)
 
 ___
 
@@ -108,7 +108,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:121](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L121)
+[packages/host/src/lib/csi-controller.ts:122](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L122)
 
 ___
 
@@ -118,7 +118,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:120](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L120)
+[packages/host/src/lib/csi-controller.ts:121](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L121)
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:94](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L94)
+[packages/host/src/lib/csi-controller.ts:95](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L95)
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:171](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L171)
+[packages/host/src/lib/csi-controller.ts:172](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L172)
 
 ___
 
@@ -148,7 +148,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:97](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L97)
+[packages/host/src/lib/csi-controller.ts:98](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L98)
 
 ___
 
@@ -158,7 +158,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:141](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L141)
+[packages/host/src/lib/csi-controller.ts:142](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L142)
 
 ___
 
@@ -168,7 +168,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:115](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L115)
+[packages/host/src/lib/csi-controller.ts:116](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L116)
 
 ___
 
@@ -185,7 +185,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:114](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L114)
+[packages/host/src/lib/csi-controller.ts:115](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L115)
 
 ___
 
@@ -195,7 +195,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:117](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L117)
+[packages/host/src/lib/csi-controller.ts:118](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L118)
 
 ___
 
@@ -205,7 +205,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:73](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L73)
+[packages/host/src/lib/csi-controller.ts:74](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L74)
 
 ___
 
@@ -224,7 +224,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:99](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L99)
+[packages/host/src/lib/csi-controller.ts:100](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L100)
 
 ___
 
@@ -241,7 +241,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:113](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L113)
+[packages/host/src/lib/csi-controller.ts:114](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L114)
 
 ___
 
@@ -253,7 +253,7 @@ Topic to which the input stream should be routed
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:131](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L131)
+[packages/host/src/lib/csi-controller.ts:132](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L132)
 
 ___
 
@@ -263,7 +263,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:95](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L95)
+[packages/host/src/lib/csi-controller.ts:96](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L96)
 
 ___
 
@@ -273,7 +273,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:92](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L92)
+[packages/host/src/lib/csi-controller.ts:93](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L93)
 
 ___
 
@@ -283,7 +283,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:118](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L118)
+[packages/host/src/lib/csi-controller.ts:119](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L119)
 
 ___
 
@@ -295,7 +295,7 @@ Logger.
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:138](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L138)
+[packages/host/src/lib/csi-controller.ts:139](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L139)
 
 ___
 
@@ -307,7 +307,7 @@ Topic to which the output stream should be routed
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:126](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L126)
+[packages/host/src/lib/csi-controller.ts:127](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L127)
 
 ___
 
@@ -317,7 +317,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:110](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L110)
+[packages/host/src/lib/csi-controller.ts:111](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L111)
 
 ___
 
@@ -327,7 +327,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:111](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L111)
+[packages/host/src/lib/csi-controller.ts:112](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L112)
 
 ___
 
@@ -337,7 +337,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:98](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L98)
+[packages/host/src/lib/csi-controller.ts:99](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L99)
 
 ___
 
@@ -347,7 +347,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:93](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L93)
+[packages/host/src/lib/csi-controller.ts:94](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L94)
 
 ___
 
@@ -357,7 +357,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:96](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L96)
+[packages/host/src/lib/csi-controller.ts:97](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L97)
 
 ___
 
@@ -367,7 +367,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:105](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L105)
+[packages/host/src/lib/csi-controller.ts:106](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L106)
 
 ___
 
@@ -377,7 +377,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:91](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L91)
+[packages/host/src/lib/csi-controller.ts:92](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L92)
 
 ___
 
@@ -394,7 +394,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:106](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L106)
+[packages/host/src/lib/csi-controller.ts:107](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L107)
 
 ## Methods
 
@@ -439,7 +439,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:361](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L361)
+[packages/host/src/lib/csi-controller.ts:366](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L366)
 
 ___
 
@@ -453,7 +453,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:509](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L509)
+[packages/host/src/lib/csi-controller.ts:514](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L514)
 
 ___
 
@@ -516,7 +516,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:369](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L369)
+[packages/host/src/lib/csi-controller.ts:374](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L374)
 
 ___
 
@@ -530,7 +530,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:703](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L703)
+[packages/host/src/lib/csi-controller.ts:706](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L706)
 
 ___
 
@@ -544,7 +544,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:727](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L727)
+[packages/host/src/lib/csi-controller.ts:730](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L730)
 
 ___
 
@@ -558,7 +558,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:731](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L731)
+[packages/host/src/lib/csi-controller.ts:734](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L734)
 
 ___
 
@@ -590,7 +590,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:723](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L723)
+[packages/host/src/lib/csi-controller.ts:726](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L726)
 
 ___
 
@@ -610,7 +610,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:472](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L472)
+[packages/host/src/lib/csi-controller.ts:477](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L477)
 
 ___
 
@@ -630,7 +630,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:497](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L497)
+[packages/host/src/lib/csi-controller.ts:502](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L502)
 
 ___
 
@@ -650,7 +650,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:781](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L781)
+[packages/host/src/lib/csi-controller.ts:784](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L784)
 
 ___
 
@@ -670,7 +670,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:736](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L736)
+[packages/host/src/lib/csi-controller.ts:739](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L739)
 
 ___
 
@@ -690,7 +690,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:754](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L754)
+[packages/host/src/lib/csi-controller.ts:757](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L757)
 
 ___
 
@@ -704,7 +704,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:310](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L310)
+[packages/host/src/lib/csi-controller.ts:314](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L314)
 
 ___
 
@@ -724,7 +724,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:389](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L389)
+[packages/host/src/lib/csi-controller.ts:394](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L394)
 
 ___
 
@@ -738,7 +738,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:381](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L381)
+[packages/host/src/lib/csi-controller.ts:386](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L386)
 
 ___
 
@@ -812,7 +812,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:219](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L219)
+[packages/host/src/lib/csi-controller.ts:220](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L220)
 
 ___
 
@@ -1079,7 +1079,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:789](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L789)
+[packages/host/src/lib/csi-controller.ts:792](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L792)
 
 ___
 
@@ -1117,7 +1117,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:204](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L204)
+[packages/host/src/lib/csi-controller.ts:205](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L205)
 
 ___
 
@@ -1131,7 +1131,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:251](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L251)
+[packages/host/src/lib/csi-controller.ts:255](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L255)
 
 ## Constructors
 
@@ -1155,7 +1155,7 @@ TypedEmitter&lt;Events\&gt;.constructor
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:173](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L173)
+[packages/host/src/lib/csi-controller.ts:174](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L174)
 
 ## Accessors
 
@@ -1169,7 +1169,7 @@ TypedEmitter&lt;Events\&gt;.constructor
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:153](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L153)
+[packages/host/src/lib/csi-controller.ts:154](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L154)
 
 • `set` **endOfSequence**(`prm`): `void`
 
@@ -1185,7 +1185,7 @@ TypedEmitter&lt;Events\&gt;.constructor
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:161](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L161)
+[packages/host/src/lib/csi-controller.ts:162](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L162)
 
 ___
 
@@ -1199,7 +1199,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:143](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L143)
+[packages/host/src/lib/csi-controller.ts:144](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L144)
 
 ___
 
@@ -1213,7 +1213,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:367](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L367)
+[packages/host/src/lib/csi-controller.ts:372](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L372)
 
 ___
 
@@ -1227,4 +1227,4 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/csi-controller.ts:80](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L80)
+[packages/host/src/lib/csi-controller.ts:81](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/csi-controller.ts#L81)

--- a/docs/host/classes/Host.md
+++ b/docs/host/classes/Host.md
@@ -20,14 +20,18 @@ Can communicate with Manager.
 - [commonLogsPipe](Host.md#commonlogspipe)
 - [config](Host.md#config)
 - [cpmConnector](Host.md#cpmconnector)
+- [hostSize](Host.md#hostsize)
 - [instanceBase](Host.md#instancebase)
 - [instancesStore](Host.md#instancesstore)
+- [ipvAddress](Host.md#ipvaddress)
 - [loadCheck](Host.md#loadcheck)
 - [logger](Host.md#logger)
 - [publicConfig](Host.md#publicconfig)
 - [sequencesStore](Host.md#sequencesstore)
 - [serviceDiscovery](Host.md#servicediscovery)
 - [socketServer](Host.md#socketserver)
+- [telemetryAdapter](Host.md#telemetryadapter)
+- [telemetryEnvironmentName](Host.md#telemetryenvironmentname)
 - [topicsBase](Host.md#topicsbase)
 
 ### Accessors
@@ -47,6 +51,7 @@ Can communicate with Manager.
 - [getSequenceByName](Host.md#getsequencebyname)
 - [getSequenceInstances](Host.md#getsequenceinstances)
 - [getSequences](Host.md#getsequences)
+- [getSize](Host.md#getsize)
 - [getStatus](Host.md#getstatus)
 - [getTopics](Host.md#gettopics)
 - [handleAuditRequest](Host.md#handleauditrequest)
@@ -60,6 +65,7 @@ Can communicate with Manager.
 - [instanceMiddleware](Host.md#instancemiddleware)
 - [main](Host.md#main)
 - [performStartup](Host.md#performstartup)
+- [setTelemetry](Host.md#settelemetry)
 - [startCSIController](Host.md#startcsicontroller)
 - [stop](Host.md#stop)
 - [topicsMiddleware](Host.md#topicsmiddleware)
@@ -78,7 +84,7 @@ The Host's API Server.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:59](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L59)
+[packages/host/src/lib/host.ts:68](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L68)
 
 ___
 
@@ -90,7 +96,7 @@ Api path prefix based on initial configuration.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:64](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L64)
+[packages/host/src/lib/host.ts:73](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L73)
 
 ___
 
@@ -102,7 +108,7 @@ Host auditor.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:49](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L49)
+[packages/host/src/lib/host.ts:54](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L54)
 
 ___
 
@@ -112,7 +118,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:105](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L105)
+[packages/host/src/lib/host.ts:114](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L114)
 
 ___
 
@@ -124,7 +130,7 @@ Configuration.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:54](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L54)
+[packages/host/src/lib/host.ts:63](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L63)
 
 ___
 
@@ -136,7 +142,17 @@ Instance of CPMConnector used to communicate with Manager.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:78](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L78)
+[packages/host/src/lib/host.ts:87](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L87)
+
+___
+
+### hostSize
+
+• **hostSize**: `HostSizes`
+
+#### Defined in
+
+[packages/host/src/lib/host.ts:118](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L118)
 
 ___
 
@@ -148,7 +164,7 @@ Instance path prefix.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:69](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L69)
+[packages/host/src/lib/host.ts:78](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L78)
 
 ___
 
@@ -164,7 +180,17 @@ Object to store CSIControllers.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:83](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L83)
+[packages/host/src/lib/host.ts:92](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L92)
+
+___
+
+### ipvAddress
+
+• **ipvAddress**: `any`
+
+#### Defined in
+
+[packages/host/src/lib/host.ts:119](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L119)
 
 ___
 
@@ -176,7 +202,7 @@ Instance of class providing load check.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:98](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L98)
+[packages/host/src/lib/host.ts:107](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L107)
 
 ___
 
@@ -192,7 +218,7 @@ IComponent.logger
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:93](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L93)
+[packages/host/src/lib/host.ts:102](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L102)
 
 ___
 
@@ -202,7 +228,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:107](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L107)
+[packages/host/src/lib/host.ts:116](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L116)
 
 ___
 
@@ -214,7 +240,7 @@ Sequences store.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:88](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L88)
+[packages/host/src/lib/host.ts:97](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L97)
 
 ___
 
@@ -226,7 +252,7 @@ Service to handle topics.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:103](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L103)
+[packages/host/src/lib/host.ts:112](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L112)
 
 ___
 
@@ -236,7 +262,27 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:73](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L73)
+[packages/host/src/lib/host.ts:82](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L82)
+
+___
+
+### telemetryAdapter
+
+• `Optional` **telemetryAdapter**: `ITelemetryAdapter`
+
+#### Defined in
+
+[packages/host/src/lib/host.ts:56](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L56)
+
+___
+
+### telemetryEnvironmentName
+
+• **telemetryEnvironmentName**: `string` = `"not-set"`
+
+#### Defined in
+
+[packages/host/src/lib/host.ts:58](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L58)
 
 ___
 
@@ -246,7 +292,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:71](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L71)
+[packages/host/src/lib/host.ts:80](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L80)
 
 ## Accessors
 
@@ -260,7 +306,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:124](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L124)
+[packages/host/src/lib/host.ts:136](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L136)
 
 ___
 
@@ -274,7 +320,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:134](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L134)
+[packages/host/src/lib/host.ts:146](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L146)
 
 ___
 
@@ -288,7 +334,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:120](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L120)
+[packages/host/src/lib/host.ts:132](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L132)
 
 ___
 
@@ -302,7 +348,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:130](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L130)
+[packages/host/src/lib/host.ts:142](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L142)
 
 ## Methods
 
@@ -324,7 +370,7 @@ Setting up handlers for general Host API endpoints:
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:352](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L352)
+[packages/host/src/lib/host.ts:375](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L375)
 
 ___
 
@@ -340,7 +386,7 @@ Stops running servers.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:980](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L980)
+[packages/host/src/lib/host.ts:1033](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L1033)
 
 ___
 
@@ -356,7 +402,7 @@ Initializes connector and connects to Manager.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:327](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L327)
+[packages/host/src/lib/host.ts:350](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L350)
 
 ___
 
@@ -374,7 +420,7 @@ List of Instances.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:879](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L879)
+[packages/host/src/lib/host.ts:929](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L929)
 
 ___
 
@@ -398,7 +444,7 @@ Sequence info object.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:891](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L891)
+[packages/host/src/lib/host.ts:941](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L941)
 
 ___
 
@@ -418,7 +464,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:660](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L660)
+[packages/host/src/lib/host.ts:686](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L686)
 
 ___
 
@@ -442,7 +488,7 @@ List of Instances.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:931](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L931)
+[packages/host/src/lib/host.ts:981](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L981)
 
 ___
 
@@ -460,7 +506,21 @@ List of Sequences.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:915](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L915)
+[packages/host/src/lib/host.ts:965](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L965)
+
+___
+
+### getSize
+
+▸ **getSize**(): `HostSizes`
+
+#### Returns
+
+`HostSizes`
+
+#### Defined in
+
+[packages/host/src/lib/host.ts:1088](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L1088)
 
 ___
 
@@ -474,7 +534,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:951](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L951)
+[packages/host/src/lib/host.ts:1004](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L1004)
 
 ___
 
@@ -488,7 +548,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:942](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L942)
+[packages/host/src/lib/host.ts:995](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L995)
 
 ___
 
@@ -509,7 +569,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:516](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L516)
+[packages/host/src/lib/host.ts:538](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L538)
 
 ___
 
@@ -536,7 +596,7 @@ Promise resolving to operation result object.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:440](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L440)
+[packages/host/src/lib/host.ts:462](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L462)
 
 ___
 
@@ -557,7 +617,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:553](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L553)
+[packages/host/src/lib/host.ts:575](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L575)
 
 ___
 
@@ -583,7 +643,7 @@ Promise resolving to operation result.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:642](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L642)
+[packages/host/src/lib/host.ts:667](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L667)
 
 ___
 
@@ -603,7 +663,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:610](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L610)
+[packages/host/src/lib/host.ts:634](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L634)
 
 ___
 
@@ -631,7 +691,7 @@ Promise resolving to operation result object.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:683](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L683)
+[packages/host/src/lib/host.ts:709](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L709)
 
 ___
 
@@ -645,7 +705,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:497](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L497)
+[packages/host/src/lib/host.ts:519](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L519)
 
 ___
 
@@ -662,7 +722,7 @@ Used to recover Sequences information after restart.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:534](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L534)
+[packages/host/src/lib/host.ts:556](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L556)
 
 ___
 
@@ -692,7 +752,7 @@ Instance middleware.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:399](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L399)
+[packages/host/src/lib/host.ts:421](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L421)
 
 ___
 
@@ -712,7 +772,7 @@ Promise resolving to Instance of Host.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:221](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L221)
+[packages/host/src/lib/host.ts:236](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L236)
 
 ___
 
@@ -726,7 +786,21 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:281](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L281)
+[packages/host/src/lib/host.ts:304](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L304)
+
+___
+
+### setTelemetry
+
+▸ **setTelemetry**(): `Promise`<`void`\>
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Defined in
+
+[packages/host/src/lib/host.ts:1068](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L1068)
 
 ___
 
@@ -749,7 +823,7 @@ Creates new CSIController [CSIController](CSIController.md) object and handles i
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:738](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L738)
+[packages/host/src/lib/host.ts:769](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L769)
 
 ___
 
@@ -766,7 +840,7 @@ using its CSIController [CSIController](CSIController.md)
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:963](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L963)
+[packages/host/src/lib/host.ts:1016](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L1016)
 
 ___
 
@@ -788,7 +862,7 @@ ___
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:425](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L425)
+[packages/host/src/lib/host.ts:447](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L447)
 
 ## Constructors
 
@@ -809,4 +883,4 @@ Sets used modules with provided configuration.
 
 #### Defined in
 
-[packages/host/src/lib/host.ts:146](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L146)
+[packages/host/src/lib/host.ts:158](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/host/src/lib/host.ts#L158)

--- a/docs/sth-config/classes/ConfigService.md
+++ b/docs/sth-config/classes/ConfigService.md
@@ -29,7 +29,7 @@
 
 #### Defined in
 
-[sth-config/src/config-service.ts:85](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L85)
+[sth-config/src/config-service.ts:94](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L94)
 
 ## Methods
 
@@ -43,7 +43,7 @@
 
 #### Defined in
 
-[sth-config/src/config-service.ts:93](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L93)
+[sth-config/src/config-service.ts:102](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L102)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[sth-config/src/config-service.ts:105](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L105)
+[sth-config/src/config-service.ts:114](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L114)
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 #### Defined in
 
-[sth-config/src/config-service.ts:97](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L97)
+[sth-config/src/config-service.ts:106](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L106)
 
 ___
 
@@ -105,4 +105,4 @@ ___
 
 #### Defined in
 
-[sth-config/src/config-service.ts:101](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L101)
+[sth-config/src/config-service.ts:110](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L110)

--- a/docs/sth-config/modules.md
+++ b/docs/sth-config/modules.md
@@ -25,7 +25,7 @@
 
 #### Defined in
 
-[sth-config/src/config-service.ts:80](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L80)
+[sth-config/src/config-service.ts:89](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/sth-config/src/config-service.ts#L89)
 
 ## Functions
 

--- a/docs/telemetry/.nojekyll
+++ b/docs/telemetry/.nojekyll
@@ -1,0 +1,1 @@
+TypeDoc added this file to prevent GitHub Pages from using Jekyll. You can turn off this behavior by setting the `githubPages` option to false.

--- a/docs/telemetry/README.md
+++ b/docs/telemetry/README.md
@@ -1,0 +1,1 @@
+@scramjet/telemetry / [Exports](modules.md)

--- a/docs/telemetry/modules.md
+++ b/docs/telemetry/modules.md
@@ -1,0 +1,69 @@
+[@scramjet/telemetry](README.md) / Exports
+
+# @scramjet/telemetry
+
+## Table of contents
+
+### Interfaces
+
+- [ITelemetryAdapter](undefined)
+
+### Type Aliases
+
+- [TelemetryAdapter](undefined)
+- [logLevel](undefined)
+
+### Functions
+
+- [getTelemetryAdapter](undefined)
+
+## Interfaces
+
+### ITelemetryAdapter
+
+• **ITelemetryAdapter**: Interface ITelemetryAdapter
+
+#### Defined in
+
+[types.ts:6](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/telemetry/src/types.ts#L6)
+
+## Type Aliases
+
+### TelemetryAdapter
+
+Ƭ **TelemetryAdapter**: Object
+
+#### Defined in
+
+[types.ts:11](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/telemetry/src/types.ts#L11)
+
+___
+
+### logLevel
+
+Ƭ **logLevel**: "debug" \| "info" \| "warn" \| "error"
+
+#### Defined in
+
+[types.ts:4](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/telemetry/src/types.ts#L4)
+
+## Functions
+
+### getTelemetryAdapter
+
+▸ **getTelemetryAdapter**(`adapter`, `config`): Promise<ITelemetryAdapter\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `adapter` | string |
+| `config` | TelemetryAdaptersConfig |
+
+#### Returns
+
+Promise<ITelemetryAdapter\>
+
+#### Defined in
+
+[index.ts:8](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/telemetry/src/index.ts#L8)

--- a/docs/types/enums/InstanceStatus.md
+++ b/docs/types/enums/InstanceStatus.md
@@ -1,0 +1,85 @@
+[@scramjet/types](../README.md) / [Exports](../modules.md) / InstanceStatus
+
+# Enumeration: InstanceStatus
+
+## Table of contents
+
+### Enumeration Members
+
+- [COMPLETED](InstanceStatus.md#completed)
+- [ERRORED](InstanceStatus.md#errored)
+- [INITIALIZING](InstanceStatus.md#initializing)
+- [KILLING](InstanceStatus.md#killing)
+- [RUNNING](InstanceStatus.md#running)
+- [STARTING](InstanceStatus.md#starting)
+- [STOPPING](InstanceStatus.md#stopping)
+
+## Enumeration Members
+
+### COMPLETED
+
+• **COMPLETED** = ``"completed"``
+
+#### Defined in
+
+[packages/types/src/instance.ts:8](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/instance.ts#L8)
+
+___
+
+### ERRORED
+
+• **ERRORED** = ``"errored"``
+
+#### Defined in
+
+[packages/types/src/instance.ts:9](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/instance.ts#L9)
+
+___
+
+### INITIALIZING
+
+• **INITIALIZING** = ``"initializing"``
+
+#### Defined in
+
+[packages/types/src/instance.ts:3](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/instance.ts#L3)
+
+___
+
+### KILLING
+
+• **KILLING** = ``"killing"``
+
+#### Defined in
+
+[packages/types/src/instance.ts:7](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/instance.ts#L7)
+
+___
+
+### RUNNING
+
+• **RUNNING** = ``"running"``
+
+#### Defined in
+
+[packages/types/src/instance.ts:5](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/instance.ts#L5)
+
+___
+
+### STARTING
+
+• **STARTING** = ``"starting"``
+
+#### Defined in
+
+[packages/types/src/instance.ts:4](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/instance.ts#L4)
+
+___
+
+### STOPPING
+
+• **STOPPING** = ``"stopping"``
+
+#### Defined in
+
+[packages/types/src/instance.ts:6](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/instance.ts#L6)

--- a/docs/types/modules.md
+++ b/docs/types/modules.md
@@ -85,11 +85,11 @@
 - [InstanceMessage](modules.md#instancemessage)
 - [InstanceMessageData](modules.md#instancemessagedata)
 - [InstanceStats](modules.md#instancestats)
-- [InstanceStatus](modules.md#instancestatus)
 - [K8SAdapterConfiguration](modules.md#k8sadapterconfiguration)
 - [KeepAliveMessage](modules.md#keepalivemessage)
 - [KeepAliveMessageData](modules.md#keepalivemessagedata)
 - [KillHandler](modules.md#killhandler)
+- [KillMessageData](modules.md#killmessagedata)
 - [KillSequenceMessage](modules.md#killsequencemessage)
 - [KubernetesSequenceConfig](modules.md#kubernetessequenceconfig)
 - [LifeCycleError](modules.md#lifecycleerror)
@@ -171,6 +171,8 @@
 - [SynchronousStreamablePayload](modules.md#synchronousstreamablepayload)
 - [TFunction](modules.md#tfunction)
 - [TFunctionChain](modules.md#tfunctionchain)
+- [TelemetryAdaptersConfig](modules.md#telemetryadaptersconfig)
+- [TelemetryConfig](modules.md#telemetryconfig)
 - [TranformFunction](modules.md#tranformfunction)
 - [TransformApp](modules.md#transformapp)
 - [TransformAppAcceptableSequence](modules.md#transformappacceptablesequence)
@@ -180,6 +182,10 @@
 - [WritableApp](modules.md#writableapp)
 - [WriteFunction](modules.md#writefunction)
 - [WriteSequence](modules.md#writesequence)
+
+### Enumerations
+
+- [InstanceStatus](enums/InstanceStatus.md)
 
 ### Namespaces
 
@@ -455,7 +461,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/sth-configuration.ts:3](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L3)
+[packages/types/src/sth-configuration.ts:4](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L4)
 
 ___
 
@@ -472,7 +478,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/sth-configuration.ts:15](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L15)
+[packages/types/src/sth-configuration.ts:16](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L16)
 
 ___
 
@@ -596,7 +602,9 @@ ___
 | :------ | :------ |
 | `available` | `number` |
 | `fs` | `string` |
+| `mount?` | `string` |
 | `size` | `number` |
+| `type?` | `string` |
 | `use` | `number` |
 | `used` | `number` |
 
@@ -612,7 +620,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/runner-config.ts:28](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/runner-config.ts#L28)
+[packages/types/src/runner-config.ts:29](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/runner-config.ts#L29)
 
 ___
 
@@ -962,7 +970,7 @@ Host process configuration.
 
 #### Defined in
 
-[packages/types/src/sth-configuration.ts:40](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L40)
+[packages/types/src/sth-configuration.ts:41](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L41)
 
 ___
 
@@ -1047,7 +1055,7 @@ ___
 | `sequence` | `string` |
 | `sequenceArgs?` | `any`[] |
 | `started?` | `Date` |
-| `status?` | [`InstanceStatus`](modules.md#instancestatus) |
+| `status?` | [`InstanceStatus`](enums/InstanceStatus.md) |
 | `terminated?` | { `exitcode`: `number` ; `reason`: `string`  } |
 | `terminated.exitcode` | `number` |
 | `terminated.reason` | `string` |
@@ -1091,7 +1099,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/runner-config.ts:46](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/runner-config.ts#L46)
+[packages/types/src/runner-config.ts:47](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/runner-config.ts#L47)
 
 ___
 
@@ -1168,16 +1176,6 @@ ___
 
 ___
 
-### InstanceStatus
-
-Ƭ **InstanceStatus**: ``"initializing"`` \| ``"starting"`` \| ``"running"`` \| ``"stopping"`` \| ``"killing"`` \| ``"completed"`` \| ``"errored"``
-
-#### Defined in
-
-[packages/types/src/instance.ts:2](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/instance.ts#L2)
-
-___
-
 ### K8SAdapterConfiguration
 
 Ƭ **K8SAdapterConfiguration**: `Object`
@@ -1201,7 +1199,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/sth-configuration.ts:72](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L72)
+[packages/types/src/sth-configuration.ts:73](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L73)
 
 ___
 
@@ -1252,9 +1250,25 @@ ___
 
 ___
 
+### KillMessageData
+
+Ƭ **KillMessageData**: `Object`
+
+#### Type declaration
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `removeImmediately?` | `boolean` | Bypass waiting. |
+
+#### Defined in
+
+[packages/types/src/messages/kill-sequence.ts:3](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/messages/kill-sequence.ts#L3)
+
+___
+
 ### KillSequenceMessage
 
-Ƭ **KillSequenceMessage**: { `msgCode`: `RunnerMessageCode.KILL`  } & `KillMessageData`
+Ƭ **KillSequenceMessage**: { `msgCode`: `RunnerMessageCode.KILL`  } & [`KillMessageData`](modules.md#killmessagedata)
 
 Message instructing Runner to terminate Sequence using the kill signal.
 It causes an ungraceful termination of Sequence.
@@ -1272,7 +1286,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/runner-config.ts:40](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/runner-config.ts#L40)
+[packages/types/src/runner-config.ts:41](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/runner-config.ts#L41)
 
 ___
 
@@ -1302,7 +1316,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/load-check-stat.ts:22](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/load-check-stat.ts#L22)
+[packages/types/src/load-check-stat.ts:24](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/load-check-stat.ts#L24)
 
 ___
 
@@ -1322,7 +1336,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/load-check-stat.ts:31](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/load-check-stat.ts#L31)
+[packages/types/src/load-check-stat.ts:33](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/load-check-stat.ts#L33)
 
 ___
 
@@ -1342,7 +1356,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/load-check-stat.ts:9](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/load-check-stat.ts#L9)
+[packages/types/src/load-check-stat.ts:11](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/load-check-stat.ts#L11)
 
 ___
 
@@ -1476,7 +1490,7 @@ ___
 
 ### MessageDataType
 
-Ƭ **MessageDataType**<`T`\>: `T` extends `RunnerMessageCode.ACKNOWLEDGE` ? [`AcknowledgeMessageData`](modules.md#acknowledgemessagedata) : `T` extends `RunnerMessageCode.ALIVE` ? [`KeepAliveMessageData`](modules.md#keepalivemessagedata) : `T` extends `RunnerMessageCode.DESCRIBE_SEQUENCE` ? [`DescribeSequenceMessageData`](modules.md#describesequencemessagedata) : `T` extends `RunnerMessageCode.STATUS` ? [`StatusMessageData`](modules.md#statusmessagedata) : `T` extends `RunnerMessageCode.ERROR` ? [`ErrorMessageData`](modules.md#errormessagedata) : `T` extends `RunnerMessageCode.KILL` ? `KillMessageData` : `T` extends `RunnerMessageCode.MONITORING` ? [`MonitoringMessageData`](modules.md#monitoringmessagedata) : `T` extends `RunnerMessageCode.MONITORING_RATE` ? [`MonitoringRateMessageData`](modules.md#monitoringratemessagedata) : `T` extends `RunnerMessageCode.STOP` ? [`StopSequenceMessageData`](modules.md#stopsequencemessagedata) : `T` extends `RunnerMessageCode.PING` ? [`PingMessageData`](modules.md#pingmessagedata) : `T` extends `RunnerMessageCode.PONG` ? [`HandshakeAcknowledgeMessageData`](modules.md#handshakeacknowledgemessagedata) : `T` extends `RunnerMessageCode.PANG` ? [`PangMessageData`](modules.md#pangmessagedata) : `T` extends `RunnerMessageCode.SEQUENCE_COMPLETED` ? `SequenceCompleteMessageData` : `T` extends `RunnerMessageCode.SEQUENCE_STOPPED` ? [`SequenceStoppedMessageData`](modules.md#sequencestoppedmessagedata) : `T` extends `RunnerMessageCode.EVENT` ? [`EventMessageData`](modules.md#eventmessagedata) : `T` extends `CPMMessageCode.STH_ID` ? [`STHIDMessageData`](modules.md#sthidmessagedata) : `T` extends `CPMMessageCode.LOAD` ? [`LoadCheckStat`](modules.md#loadcheckstat) : `T` extends `CPMMessageCode.NETWORK_INFO` ? [`NetworkInfo`](modules.md#networkinfo)[] : `T` extends `CPMMessageCode.INSTANCES` ? [`InstanceBulkMessage`](modules.md#instancebulkmessage) : `T` extends `CPMMessageCode.INSTANCE` ? [`InstanceMessage`](modules.md#instancemessage) : `T` extends `CPMMessageCode.SEQUENCES` ? [`SequenceBulkMessage`](modules.md#sequencebulkmessage) : `T` extends `CPMMessageCode.SEQUENCE` ? [`SequenceMessage`](modules.md#sequencemessage) : `never`
+Ƭ **MessageDataType**<`T`\>: `T` extends `RunnerMessageCode.ACKNOWLEDGE` ? [`AcknowledgeMessageData`](modules.md#acknowledgemessagedata) : `T` extends `RunnerMessageCode.ALIVE` ? [`KeepAliveMessageData`](modules.md#keepalivemessagedata) : `T` extends `RunnerMessageCode.DESCRIBE_SEQUENCE` ? [`DescribeSequenceMessageData`](modules.md#describesequencemessagedata) : `T` extends `RunnerMessageCode.STATUS` ? [`StatusMessageData`](modules.md#statusmessagedata) : `T` extends `RunnerMessageCode.ERROR` ? [`ErrorMessageData`](modules.md#errormessagedata) : `T` extends `RunnerMessageCode.KILL` ? [`KillMessageData`](modules.md#killmessagedata) : `T` extends `RunnerMessageCode.MONITORING` ? [`MonitoringMessageData`](modules.md#monitoringmessagedata) : `T` extends `RunnerMessageCode.MONITORING_RATE` ? [`MonitoringRateMessageData`](modules.md#monitoringratemessagedata) : `T` extends `RunnerMessageCode.STOP` ? [`StopSequenceMessageData`](modules.md#stopsequencemessagedata) : `T` extends `RunnerMessageCode.PING` ? [`PingMessageData`](modules.md#pingmessagedata) : `T` extends `RunnerMessageCode.PONG` ? [`HandshakeAcknowledgeMessageData`](modules.md#handshakeacknowledgemessagedata) : `T` extends `RunnerMessageCode.PANG` ? [`PangMessageData`](modules.md#pangmessagedata) : `T` extends `RunnerMessageCode.SEQUENCE_COMPLETED` ? `SequenceCompleteMessageData` : `T` extends `RunnerMessageCode.SEQUENCE_STOPPED` ? [`SequenceStoppedMessageData`](modules.md#sequencestoppedmessagedata) : `T` extends `RunnerMessageCode.EVENT` ? [`EventMessageData`](modules.md#eventmessagedata) : `T` extends `CPMMessageCode.STH_ID` ? [`STHIDMessageData`](modules.md#sthidmessagedata) : `T` extends `CPMMessageCode.LOAD` ? [`LoadCheckStat`](modules.md#loadcheckstat) : `T` extends `CPMMessageCode.NETWORK_INFO` ? [`NetworkInfo`](modules.md#networkinfo)[] : `T` extends `CPMMessageCode.INSTANCES` ? [`InstanceBulkMessage`](modules.md#instancebulkmessage) : `T` extends `CPMMessageCode.INSTANCE` ? [`InstanceMessage`](modules.md#instancemessage) : `T` extends `CPMMessageCode.SEQUENCES` ? [`SequenceBulkMessage`](modules.md#sequencebulkmessage) : `T` extends `CPMMessageCode.SEQUENCE` ? [`SequenceMessage`](modules.md#sequencemessage) : `never`
 
 #### Type parameters
 
@@ -1823,7 +1837,7 @@ ___
 
 ### OpResponse
 
-Ƭ **OpResponse**<`PayloadType`\>: `PayloadType` & { `opStatus`: `ReasonPhrases.OK` \| `ReasonPhrases.ACCEPTED`  } \| { `error?`: `unknown` ; `opStatus`: `Exclude`<`ReasonPhrases`, `ReasonPhrases.OK` \| `ReasonPhrases.ACCEPTED`\>  }
+Ƭ **OpResponse**<`PayloadType`\>: `PayloadType` & { `message?`: `string` ; `opStatus`: `ReasonPhrases.OK` \| `ReasonPhrases.ACCEPTED`  } \| { `error?`: `string` \| `Error` \| `unknown` ; `opStatus`: `Exclude`<`ReasonPhrases`, `ReasonPhrases.OK` \| `ReasonPhrases.ACCEPTED`\>  }
 
 #### Type parameters
 
@@ -1931,7 +1945,7 @@ PreRunner container configuration.
 
 #### Defined in
 
-[packages/types/src/sth-configuration.ts:30](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L30)
+[packages/types/src/sth-configuration.ts:31](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L31)
 
 ___
 
@@ -1941,7 +1955,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/runner-config.ts:36](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/runner-config.ts#L36)
+[packages/types/src/runner-config.ts:37](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/runner-config.ts#L37)
 
 ___
 
@@ -1951,7 +1965,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/sth-configuration.ts:236](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L236)
+[packages/types/src/sth-configuration.ts:238](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L238)
 
 ___
 
@@ -2058,7 +2072,7 @@ Runner container configuration.
 
 #### Defined in
 
-[packages/types/src/sth-configuration.ts:35](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L35)
+[packages/types/src/sth-configuration.ts:36](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L36)
 
 ___
 
@@ -2114,6 +2128,7 @@ ___
 | `cpmSslCaPath?` | `string` |
 | `cpmUrl?` | `string` |
 | `docker` | `boolean` |
+| `environmentName?` | `string` |
 | `exitWithLastInstance` | `boolean` |
 | `exposeHostIp` | `string` |
 | `hostname` | `string` |
@@ -2143,10 +2158,11 @@ ___
 | `safeOperationLimit` | `number` |
 | `sequencesRoot` | `string` |
 | `startupConfig` | `string` |
+| `telemetry` | [`TelemetryConfig`](modules.md#telemetryconfig)[``"status"``] |
 
 #### Defined in
 
-[packages/types/src/sth-command-options.ts:3](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-command-options.ts#L3)
+[packages/types/src/sth-command-options.ts:4](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-command-options.ts#L4)
 
 ___
 
@@ -2184,6 +2200,7 @@ ___
 | `safeOperationLimit` | `number` | The amount of memory that must remain free. In megabytes. |
 | `sequencesRoot` | `string` | Only used when `noDocker` is true Where should ProcessSequenceAdapter save new Sequences |
 | `startupConfig` | `string` | Provides the location of a config file with the list of sequences to be started along with the host |
+| `telemetry` | [`TelemetryConfig`](modules.md#telemetryconfig) | - |
 | `timings` | { `heartBeatInterval`: `number` ; `instanceAdapterExitDelay`: `number` ; `instanceLifetimeExtensionDelay`: `number`  } | Various timeout and interval configurations |
 | `timings.heartBeatInterval` | `number` | Heartbeat interval in miliseconds |
 | `timings.instanceAdapterExitDelay` | `number` | Time to wait after Runner container exit. In this additional time Instance API is still available. |
@@ -2191,7 +2208,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/sth-configuration.ts:100](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L100)
+[packages/types/src/sth-configuration.ts:101](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/sth-configuration.ts#L101)
 
 ___
 
@@ -2257,7 +2274,7 @@ ___
 
 #### Defined in
 
-[packages/types/src/runner-config.ts:44](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/runner-config.ts#L44)
+[packages/types/src/runner-config.ts:45](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/runner-config.ts#L45)
 
 ___
 
@@ -2649,6 +2666,36 @@ ___
 #### Defined in
 
 [packages/types/src/functions.ts:43](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/functions.ts#L43)
+
+___
+
+### TelemetryAdaptersConfig
+
+Ƭ **TelemetryAdaptersConfig**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `loki?` | { `host`: `string` ; `interval?`: `number` ; `labels`: { `[key: string]`: `string`;  } ; `replaceTimestamp`: `boolean`  } |
+| `loki.host` | `string` |
+| `loki.interval?` | `number` |
+| `loki.labels` | { `[key: string]`: `string`;  } |
+| `loki.replaceTimestamp` | `boolean` |
+
+#### Defined in
+
+[packages/types/src/telemetry-config.ts:1](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/telemetry-config.ts#L1)
+
+___
+
+### TelemetryConfig
+
+Ƭ **TelemetryConfig**: { `adapter`: ``"loki"`` ; `environment?`: `string` ; `status`: `boolean`  } & [`TelemetryAdaptersConfig`](modules.md#telemetryadaptersconfig)
+
+#### Defined in
+
+[packages/types/src/telemetry-config.ts:10](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/telemetry-config.ts#L10)
 
 ___
 

--- a/docs/types/modules/MRestAPI.md
+++ b/docs/types/modules/MRestAPI.md
@@ -7,6 +7,7 @@
 ### Type Aliases
 
 - [ConnectedSTHInfo](MRestAPI.md#connectedsthinfo)
+- [ConnectedSTHInfoDetails](MRestAPI.md#connectedsthinfodetails)
 - [GetConfigResponse](MRestAPI.md#getconfigresponse)
 - [GetHealthCheckResponse](MRestAPI.md#gethealthcheckresponse)
 - [GetHostInfoResponse](MRestAPI.md#gethostinforesponse)
@@ -31,8 +32,26 @@
 | :------ | :------ |
 | `healthy` | `boolean` |
 | `id` | `string` |
-| `info` | { `[key: string]`: `any`;  } |
+| `info` | [`ConnectedSTHInfoDetails`](MRestAPI.md#connectedsthinfodetails) |
 | `isConnectionActive` | `boolean` |
+
+#### Defined in
+
+[packages/types/src/rest-api-manager/common.ts:7](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-manager/common.ts#L7)
+
+___
+
+### ConnectedSTHInfoDetails
+
+Ƭ **ConnectedSTHInfoDetails**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `created?` | `Date` |
+| `lastConnected?` | `Date` |
+| `lastDisconnected?` | `Date` |
 
 #### Defined in
 
@@ -169,4 +188,4 @@ ___
 
 #### Defined in
 
-[packages/types/src/rest-api-manager/common.ts:8](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-manager/common.ts#L8)
+[packages/types/src/rest-api-manager/common.ts:14](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-manager/common.ts#L14)

--- a/docs/types/modules/STHRestAPI.md
+++ b/docs/types/modules/STHRestAPI.md
@@ -141,11 +141,11 @@ ___
 
 ### GetSequenceInstancesResponse
 
-Ƭ **GetSequenceInstancesResponse**: readonly `string`[] \| `undefined`
+Ƭ **GetSequenceInstancesResponse**: readonly `string`[] \| { `error?`: `string` \| `Error` \| `unknown` ; `opStatus`: `Exclude`<`ReasonPhrases`, `ReasonPhrases.OK` \| `ReasonPhrases.ACCEPTED`\>  }
 
 #### Defined in
 
-[packages/types/src/rest-api-sth/get-sequence-instances.ts:1](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-sth/get-sequence-instances.ts#L1)
+[packages/types/src/rest-api-sth/get-sequence-instances.ts:3](https://github.com/scramjetorg/transform-hub/blob/HEAD/packages/types/src/rest-api-sth/get-sequence-instances.ts#L3)
 
 ___
 
@@ -274,7 +274,13 @@ ___
 
 ### StartSequenceResponse
 
-Ƭ **StartSequenceResponse**: { `id`: `string` ; `result`: ``"success"``  } \| { `error`: `unknown` ; `result`: ``"error"``  }
+Ƭ **StartSequenceResponse**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `id` | `string` |
 
 #### Defined in
 

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -38,6 +38,9 @@ const name = packageFile.value?.name || "unknown";
 
 const PARALLEL_SEQUENCE_STARTUP = 4;
 
+type HostSizes = "xs" | "s" | "m" | "l" | "xl";
+const GigaByte = 1024 << 20;
+
 /**
  * Host provides functionality to manage Instances and Sequences.
  * Using provided servers to set up API and server for communicating with Instance controllers.
@@ -51,6 +54,8 @@ export class Host implements IComponent {
     auditor: Auditor;
 
     telemetryAdapter?: ITelemetryAdapter;
+
+    telemetryEnvironmentName: string = "not-set";
 
     /**
      * Configuration.
@@ -168,7 +173,9 @@ export class Host implements IComponent {
         prettyLog.pipe(process.stdout);
 
         this.serviceDiscovery.logger.pipe(this.logger);
-        this.telemetryAdapter?.logger.pipe(this.logger);
+
+        if (sthConfig.telemetry.environment)
+            this.telemetryEnvironmentName = sthConfig.telemetry.environment;
 
         this.auditor = new Auditor();
         this.auditor.logger.pipe(this.logger);
@@ -210,6 +217,7 @@ export class Host implements IComponent {
         await this.setTelemetry().catch(() => {
             this.logger.error("Setting telemetry failed");
         });
+        this.telemetryAdapter?.logger.pipe(this.logger);
 
         this.logger.pipe(this.commonLogsPipe.getIn(), { stringified: true });
 
@@ -228,7 +236,7 @@ export class Host implements IComponent {
 
         this.logger.info(`Will use the "${adapter}" adapter for running Sequences`);
 
-        this.telemetryAdapter?.push("info", { message: "Host started", labels: { hostSize: this.hostSize, ip: this.ipvAddress, adapter: adapter } });
+        this.telemetryAdapter?.push("info", { message: "Host started", labels: { environment: this.telemetryEnvironmentName, hostSize: this.hostSize, ip: this.ipvAddress, adapter: adapter } });
 
         await this.socketServer.start();
 
@@ -587,7 +595,7 @@ export class Host implements IComponent {
             await this.cpmConnector?.sendSequenceInfo(id, SequenceMessageCode.SEQUENCE_CREATED);
 
             this.auditor.auditSequence(id, SequenceMessageCode.SEQUENCE_CREATED);
-            this.telemetryAdapter?.push("info", { message: "Sequence uploaded", labels: { language: config.language.toLowerCase(), hostSize: this.hostSize, seqId: id, ip: this.ipvAddress } });
+            this.telemetryAdapter?.push("info", { message: "Sequence uploaded", labels: { language: config.language.toLowerCase(), environment: this.telemetryEnvironmentName, hostSize: this.hostSize, seqId: id, ip: this.ipvAddress } });
 
             return {
                 id: config.id,
@@ -715,7 +723,7 @@ export class Host implements IComponent {
 
             this.logger.debug("Instance limits", csic.limits);
             this.auditor.auditInstanceStart(csic.id, req as AuditedRequest, csic.limits);
-            this.telemetryAdapter?.push("info", { message: "Instance started", labels: { id: csic.id, language: csic.sequence.config.language, hostSize: this.hostSize, seqId: csic.sequence.id, ip: this.ipvAddress } });
+            this.telemetryAdapter?.push("info", { message: "Instance started", labels: { id: csic.id, language: csic.sequence.config.language, environment: this.telemetryEnvironmentName, hostSize: this.hostSize, seqId: csic.sequence.id, ip: this.ipvAddress } });
 
             return {
                 opStatus: ReasonPhrases.OK,
@@ -723,7 +731,7 @@ export class Host implements IComponent {
                 id: csic.id
             };
         } catch (error: any) {
-            this.telemetryAdapter?.push("error", { message: "Instance start failed", labels: { error: error.message, hostSize: this.hostSize, ip: this.ipvAddress } });
+            this.telemetryAdapter?.push("error", { message: "Instance start failed", labels: { error: error.message, environment: this.telemetryEnvironmentName, hostSize: this.hostSize, ip: this.ipvAddress } });
 
             return {
                 opStatus: ReasonPhrases.BAD_REQUEST,
@@ -885,6 +893,7 @@ export class Host implements IComponent {
                     id: csic.id,
                     code: code.toString(),
                     hostSize: this.hostSize,
+                    environment: this.telemetryEnvironmentName,
                     seqId: csic.sequence.id
                 }
             });
@@ -1073,10 +1082,10 @@ export class Host implements IComponent {
      *
      * @returns {string} Size
      */
-    getSize(): string {
+    getSize(): HostSizes {
         return ["xs", "s", "m", "l", "xl"][Math.min(
             4, // maximum index in array
-            Math.floor((cpus().length + Math.ceil(totalmem() / (1024 << 20))) / 0.25)
-        )];
+            Math.floor(Math.log2(cpus().length) / 2 + Math.log2(totalmem() / GigaByte) / 4)
+        )] as HostSizes;
     }
 }

--- a/packages/sth-config/src/config-service.ts
+++ b/packages/sth-config/src/config-service.ts
@@ -68,6 +68,7 @@ const _defaultConfig: STHConfiguration = {
     telemetry: {
         status: true,
         adapter: "loki",
+        environment: process.env.SCP_ENVIRONMENT_NAME || "not-set",
         loki: {
             host: "https://analytics.scramjet.org/sth-usage",
             replaceTimestamp: true,

--- a/packages/sth/src/bin/hub.ts
+++ b/packages/sth/src/bin/hub.ts
@@ -48,7 +48,7 @@ const options: OptionValues & STHCommandOptions = program
     .option("--k8s-runner-resources-requests-memory <memory>", "Requests memory for pod e.g [128974848, 129e6, 129M,  128974848000m, 123Mi]")
     .option("--k8s-runner-resources-limits-cpu <cpu unit>", "Set limits for CPU  [1 CPU unit is equivalent to 1 physical CPU core, or 1 virtual core]")
     .option("--k8s-runner-resources-limits-memory <memory>", "Set limits for memory e.g [128974848, 129e6, 129M,  128974848000m, 123Mi]")
-    .option("--environment-name", "Sets the environment name for telemetry reporting (defaults to SCP_ENVIRONMENT_NAME env var or 'not-set')")
+    .option("--environment-name <name>", "Sets the environment name for telemetry reporting (defaults to SCP_ENVIRONMENT_NAME env var or 'not-set')")
     .option("--no-telemetry", "Disables telemetry", false)
     .parse(process.argv)
     .opts() as STHCommandOptions;

--- a/packages/sth/src/bin/hub.ts
+++ b/packages/sth/src/bin/hub.ts
@@ -48,6 +48,7 @@ const options: OptionValues & STHCommandOptions = program
     .option("--k8s-runner-resources-requests-memory <memory>", "Requests memory for pod e.g [128974848, 129e6, 129M,  128974848000m, 123Mi]")
     .option("--k8s-runner-resources-limits-cpu <cpu unit>", "Set limits for CPU  [1 CPU unit is equivalent to 1 physical CPU core, or 1 virtual core]")
     .option("--k8s-runner-resources-limits-memory <memory>", "Set limits for memory e.g [128974848, 129e6, 129M,  128974848000m, 123Mi]")
+    .option("--environment-name", "Sets the environment name for telemetry reporting (defaults to SCP_ENVIRONMENT_NAME env var or 'not-set')", process.env.SCP_ENVIRONMENT_NAME)
     .option("--no-telemetry", "Disables telemetry", false)
     .parse(process.argv)
     .opts() as STHCommandOptions;
@@ -118,7 +119,8 @@ const options: OptionValues & STHCommandOptions = program
             instanceLifetimeExtensionDelay: options.instanceLifetimeExtensionDelay
         },
         telemetry: {
-            status: options.telemetry
+            status: options.telemetry,
+            environment: options.environmentName
         }
     });
 

--- a/packages/sth/src/bin/hub.ts
+++ b/packages/sth/src/bin/hub.ts
@@ -48,7 +48,7 @@ const options: OptionValues & STHCommandOptions = program
     .option("--k8s-runner-resources-requests-memory <memory>", "Requests memory for pod e.g [128974848, 129e6, 129M,  128974848000m, 123Mi]")
     .option("--k8s-runner-resources-limits-cpu <cpu unit>", "Set limits for CPU  [1 CPU unit is equivalent to 1 physical CPU core, or 1 virtual core]")
     .option("--k8s-runner-resources-limits-memory <memory>", "Set limits for memory e.g [128974848, 129e6, 129M,  128974848000m, 123Mi]")
-    .option("--environment-name", "Sets the environment name for telemetry reporting (defaults to SCP_ENVIRONMENT_NAME env var or 'not-set')", process.env.SCP_ENVIRONMENT_NAME)
+    .option("--environment-name", "Sets the environment name for telemetry reporting (defaults to SCP_ENVIRONMENT_NAME env var or 'not-set')")
     .option("--no-telemetry", "Disables telemetry", false)
     .parse(process.argv)
     .opts() as STHCommandOptions;
@@ -120,7 +120,7 @@ const options: OptionValues & STHCommandOptions = program
         },
         telemetry: {
             status: options.telemetry,
-            environment: options.environmentName
+            environment: options.environmentName || process.env.SCP_ENVIRONMENT_NAME || "not-set"
         }
     });
 

--- a/packages/telemetry/src/adapters/loki.ts
+++ b/packages/telemetry/src/adapters/loki.ts
@@ -35,7 +35,7 @@ export default class LokiAdapter implements ITelemetryAdapter {
     }
 
     push(level: logLevel, { message, labels }: { message: string, labels: { [ key: string ]: string } }): void {
-        this.logger.debug("Pushing log entry", [message, labels]);
+        this.logger.debug("Pushing log entry", JSON.stringify([message, labels]));
         this.winstonLogger[level]({ message, labels });
     }
 }

--- a/packages/types/src/sth-command-options.ts
+++ b/packages/types/src/sth-command-options.ts
@@ -39,5 +39,6 @@ export type STHCommandOptions = {
     startupConfig: string;
     exitWithLastInstance: boolean;
     instanceLifetimeExtensionDelay: number;
+    environmentName?: string;
     telemetry: TelemetryConfig["status"]
 }

--- a/packages/types/src/telemetry-config.ts
+++ b/packages/types/src/telemetry-config.ts
@@ -9,5 +9,6 @@ export type TelemetryAdaptersConfig = {
 
 export type TelemetryConfig = {
     status: boolean,
+    environment?: string,
     adapter: "loki"
 } & TelemetryAdaptersConfig;


### PR DESCRIPTION
**What?**  <!-- Two-sentence summary, understandable for a junior. -->

This adds a new field to telemetry that can be set up with an env var or a command line. Thanks to this 
users can report telemetry from separate environemnts.

It also changes the host sizes to logarythimic scale so they can be distingished.

**Usage:**
<!-- Example (if applicable), how to verify (if not covered by tests). -->
- `SCP_ENVIRONMENT_NAME=verify-test dist/sth/bin/hub.js`
- `dist/sth/bin/hub.js --environment-name verify-test-2`

The reported telemetry should contain the environment name in `environment` key.

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [x] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [x] Documentation is updated or no changes

