### PR TITLE
Rename Telemetry ENV name to the one described in the [SHN-832] task

### DIFF
--- a/packages/sth-config/src/config-service.ts
+++ b/packages/sth-config/src/config-service.ts
@@ -68,7 +68,7 @@ const _defaultConfig: STHConfiguration = {
     telemetry: {
         status: true,
         adapter: "loki",
-        environment: process.env.SCP_ENVIRONMENT_NAME || "not-set",
+        environment: process.env.SCP_ENV_VALUE || "not-set",
         loki: {
             host: "https://analytics.scramjet.org/sth-usage",
             replaceTimestamp: true,

--- a/packages/sth/src/bin/hub.ts
+++ b/packages/sth/src/bin/hub.ts
@@ -48,7 +48,7 @@ const options: OptionValues & STHCommandOptions = program
     .option("--k8s-runner-resources-requests-memory <memory>", "Requests memory for pod e.g [128974848, 129e6, 129M,  128974848000m, 123Mi]")
     .option("--k8s-runner-resources-limits-cpu <cpu unit>", "Set limits for CPU  [1 CPU unit is equivalent to 1 physical CPU core, or 1 virtual core]")
     .option("--k8s-runner-resources-limits-memory <memory>", "Set limits for memory e.g [128974848, 129e6, 129M,  128974848000m, 123Mi]")
-    .option("--environment-name <name>", "Sets the environment name for telemetry reporting (defaults to SCP_ENVIRONMENT_NAME env var or 'not-set')")
+    .option("--environment-name <name>", "Sets the environment name for telemetry reporting (defaults to SCP_ENV_VALUE env var or 'not-set')")
     .option("--no-telemetry", "Disables telemetry", false)
     .parse(process.argv)
     .opts() as STHCommandOptions;
@@ -120,7 +120,7 @@ const options: OptionValues & STHCommandOptions = program
         },
         telemetry: {
             status: options.telemetry,
-            environment: options.environmentName || process.env.SCP_ENVIRONMENT_NAME || "not-set"
+            environment: options.environmentName || process.env.SCP_ENV_VALUE || "not-set"
         }
     });
 


### PR DESCRIPTION
**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Changing the name of Telemetry ENV from the existing `SCP_ENVIRONMENT_NAME` to `SCP_ENV_VALUE` (https://github.com/scramjetorg/transform-hub/pull/683/)

**Why?**  <!-- What is this needed for? You can link to an issue. -->
It was how it was described in the [SHN-832] task and because it is more logical in the context of the new SCP value for this env proposed by @daro1337. 

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

