### PR TITLE
(feat) adds initContainer to helm chart

### DIFF
--- a/docs/guides/kubernetes/charts/Chart.yaml
+++ b/docs/guides/kubernetes/charts/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart to deploy STH
 name: sth
-version: 0.0.1
+version: 0.0.2

--- a/docs/guides/kubernetes/charts/templates/sth-statefulset.yaml
+++ b/docs/guides/kubernetes/charts/templates/sth-statefulset.yaml
@@ -70,12 +70,16 @@ spec:
               fieldPath: metadata.name
         volumeMounts:
         - name: scramjet-sequences
-          mountPath: /root/.scramjet_sequences
+          mountPath: /root/.scramjet_k8s_sequences
         ports:
         - name: sth-api
           containerPort: {{ .Values.sthApi.service.port }}
         - name: sth-runner
           containerPort: {{ .Values.sthRunner.service.port }}
+      {{- if .Values.initContainers }}
+      initContainers:
+      {{- toYaml .Values.initContainers | nindent 6 }}
+      {{- end }}
       restartPolicy: Always
       terminationGracePeriodSeconds: 10
 {{- if not .Values.persistentVolume.enabled }}

--- a/docs/guides/kubernetes/charts/values.yaml
+++ b/docs/guides/kubernetes/charts/values.yaml
@@ -7,6 +7,7 @@ version: 0.28.3
 
 # -- Additional command line arguments to pass to STH If none set extraArgs: []
 extraArgs:
+  - "--identify-existing"
   - "--runtime-adapter=kubernetes"
   - "--k8s-runner-image=scramjetorg/runner:0.28.3"
   - "--k8s-runner-py-image=scramjetorg/runner-py:0.28.3"
@@ -62,3 +63,14 @@ persistentVolume:
   volumeMode: Filesystem
   size: 10Gi
   storageClassName: "csi-rbd-sc"
+
+# -- Init containers to add to the STH pod
+initContainers: []
+  # - name: download-sequence
+  #   image: alpine:3.8
+  #   command: [sh, -c]
+  #   args:
+  #     - mkdir -p /root/.scramjet_k8s_sequences/default && wget -qO- https://github.com/scramjetorg/reference-apps/releases/download/v0.24.12/hello-alice-out.tar.gz | tar -C /root/.scramjet_k8s_sequences/default -xzf- && echo 'Done'
+  #   volumeMounts:
+  #     - mountPath: /root/.scramjet_k8s_sequences
+  #       name: scramjet-sequences


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
STH helm chart added `initContainer` block

**Why?**  <!-- What is this needed for? You can link to an issue. -->

We can customize / prepare POD for STH e.g download sequence, so STH can find it if we pass `--identify-existing`

**Usage:**
1. pull transform-hub repo
2. [Install Helm](https://helm.sh/docs/intro/install/)
3. Use your k8s cluster or setup test cluster using [minikube](https://minikube.sigs.k8s.io/docs/start/)
    - `minikube start --extra-config=apiserver.service-node-port-range=[8000-65535]`
4. Edit values.yaml :
```bash
initContainers:
   - name: download-sequence
     image: alpine:3.8
     command: [sh, -c]
     args:
       - wget -qO- https://github.com/scramjetorg/reference-apps/releases/download/v0.24.12/hello-alice-out.tar.gz | tar -C /root/.scramjet_k8s_sequences/default -xzf- && echo 'Done'
     volumeMounts:
       - mountPath: /root/.scramjet_k8s_sequences
         name: scramjet-sequences
```
5. `helm upgrade --install sth charts/ -n default --force`


6. check STH logs
```bash
kubectl logs sth-0 sth  |head -n 4
2022-09-23T13:30:53.927Z INFO Host Telemetry is active. Adapter: loki 
2022-09-23T13:30:53.928Z INFO Host Log Level [ 'TRACE' ]
2022-09-23T13:30:53.928Z TRACE Host Host main called [ { version: '0.28.3' } ]
2022-09-23T13:30:53.935Z TRACE Host 1 sequences identified  <===
```
# check service IP:port
    - ` minikube service sth --url` 
In my case:
```bash
$ minikube service sth --url
http://192.168.49.2:8000
```
Then:
```bash
$  curl -s http://192.168.49.2:8000/api/v1/sequences |jq
[
  {
    "id": "default",
    "config": {
      "type": "kubernetes",
      "entrypointPath": "index",
      "version": "0.22.0",
      "name": "@scramjet/hello-alice-out",
      "id": "default",
      "sequenceDir": "/root/.scramjet_k8s_sequences/default",
      "engines": {
        "node": ">=10"
      },
      "description": "",
      "author": "Scramjet <open-source@scramjet.org>",
      "keywords": [],
      "repository": {
        "type": "git",
        "url": "https://github.com/scramjetorg/transform-hub.git"
      },
      "language": "js"
    },
    "instances": []
  }
]

```


**How it works:**
Allows to add helper containers

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

