### PR TITLE
Check k8s quota before instance start

### DIFF
--- a/docs/guides/kubernetes/charts/Chart.yaml
+++ b/docs/guides/kubernetes/charts/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart to deploy STH
 name: sth
-version: 0.0.2
+version: 0.0.3

--- a/docs/guides/kubernetes/charts/templates/sth-role.yaml
+++ b/docs/guides/kubernetes/charts/templates/sth-role.yaml
@@ -20,4 +20,8 @@ rules:
   - apiGroups: [""]
     resources: ["pods/status"]
     verbs: ["get", "list"]
+
+  - apiGroups: [""]
+    resources: ["resourcequotas"]
+    verbs: ["get", "list"]
 {{- end }}

--- a/docs/guides/kubernetes/manifests/sth-rbac.yaml
+++ b/docs/guides/kubernetes/manifests/sth-rbac.yaml
@@ -18,6 +18,10 @@ rules:
     resources: ["pods/status"]
     verbs: ["get", "list"]
 
+  - apiGroups: [""]
+    resources: ["resourcequotas"]
+    verbs: ["get", "list"]
+
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/packages/adapters/src/kubernetes-client-adapter.ts
+++ b/packages/adapters/src/kubernetes-client-adapter.ts
@@ -137,12 +137,12 @@ class KubernetesClientAdapter {
         return response.body.status?.containerStatuses?.[0].state?.terminated?.reason;
     }
 
-    async isPodsLimitReached() {
+    async isPodsLimitReached(quotaName: string) {
         const kubeApi = this.config.makeApiClient(k8s.CoreV1Api);
 
         try {
             const getQuotaPromise =
-                await kubeApi.readNamespacedResourceQuota("object-counts", this._namespace);
+                await kubeApi.readNamespacedResourceQuota(quotaName, this._namespace);
 
             const responseBody = getQuotaPromise.body;
 

--- a/packages/adapters/src/kubernetes-config-decoder.ts
+++ b/packages/adapters/src/kubernetes-config-decoder.ts
@@ -4,6 +4,7 @@ import { JsonDecoder } from "ts.data.json";
 export const adapterConfigDecoder = JsonDecoder.object<K8SAdapterConfiguration>({
     authConfigPath: JsonDecoder.optional(JsonDecoder.string),
     namespace: JsonDecoder.string,
+    quotaName: JsonDecoder.string,
     sthPodHost: JsonDecoder.string,
     runnerImages: JsonDecoder.object({
         python3: JsonDecoder.string,

--- a/packages/adapters/src/kubernetes-instance-adapter.ts
+++ b/packages/adapters/src/kubernetes-instance-adapter.ts
@@ -93,7 +93,7 @@ IComponent {
             throw new Error(`Invalid config type for kubernetes adapter: ${config.type}`);
         }
 
-        if (await this.kubeClient.isPodsLimitReached()) {
+        if (this.adapterConfig.quotaName && await this.kubeClient.isPodsLimitReached(this.adapterConfig.quotaName)) {
             return RunnerExitCode.PODS_LIMIT_REACHED;
         }
 

--- a/packages/adapters/src/kubernetes-instance-adapter.ts
+++ b/packages/adapters/src/kubernetes-instance-adapter.ts
@@ -19,6 +19,7 @@ import { KubernetesClientAdapter } from "./kubernetes-client-adapter";
 import { adapterConfigDecoder } from "./kubernetes-config-decoder";
 import { getRunnerEnvEntries } from "./get-runner-env";
 import { PassThrough } from "stream";
+import { RunnerExitCode } from "@scramjet/symbols";
 
 /**
  * Adapter for running Instance by Runner executed in separate process.
@@ -90,6 +91,10 @@ IComponent {
     async run(config: InstanceConfig, instancesServerPort: number, instanceId: string): Promise<ExitCode> {
         if (config.type !== "kubernetes") {
             throw new Error(`Invalid config type for kubernetes adapter: ${config.type}`);
+        }
+
+        if (await this.kubeClient.isPodsLimitReached()) {
+            return RunnerExitCode.PODS_LIMIT_REACHED;
         }
 
         this.limits = config.limits;

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -299,7 +299,7 @@ export class CSIController extends TypedEmitter<Events> {
 
                 await this.cleanup();
 
-                return 213;
+                return error.code || 213;
             }
         };
 
@@ -331,6 +331,12 @@ export class CSIController extends TypedEmitter<Events> {
                 return Promise.reject({
                     message: "Runner was started with invalid configuration. This is probably a bug in STH.",
                     exitcode: RunnerExitCode.INVALID_ENV_VARS
+                });
+            }
+            case RunnerExitCode.PODS_LIMIT_REACHED: {
+                return Promise.reject({
+                    message: "Pods limit reached",
+                    exitcode: RunnerExitCode.PODS_LIMIT_REACHED
                 });
             }
             case RunnerExitCode.INVALID_SEQUENCE_PATH: {

--- a/packages/sth/src/bin/hub.ts
+++ b/packages/sth/src/bin/hub.ts
@@ -38,6 +38,7 @@ const options: OptionValues & STHCommandOptions = program
     .option("--cpm-max-reconnections <number>", "Maximum reconnection attempts (-1 no limit)")
     .option("--cpm-reconnection-delay <number>", "Time to wait before next reconnection attempt")
     .option("--k8s-namespace <namespace>", "Kubernetes namespace used in Sequence and Instance adapters.")
+    .option("--k8s-quota-name <name>", "Quota object name used in Instance adapter.")
     .option("--k8s-auth-config-path <path>", "Kubernetes authorization config path. If not supplied the mounted service account will be used.")
     .option("--k8s-sth-pod-host <host>", "Runner needs to connect to STH. This is the host (IP or hostname) that it will try to connect to.")
     .option("--k8s-runner-image <image>", "Runner image spawned in Nodejs Pod.")
@@ -101,6 +102,7 @@ const options: OptionValues & STHCommandOptions = program
         logLevel: options.logLevel,
         logColors: options.colors,
         kubernetes: {
+            quotaName: options.k8sQuotaName,
             namespace: options.k8sNamespace,
             authConfigPath: options.k8sAuthConfigPath,
             sthPodHost: options.k8sSthPodHost,

--- a/packages/symbols/src/runner-exit-code.ts
+++ b/packages/symbols/src/runner-exit-code.ts
@@ -7,5 +7,6 @@ export enum RunnerExitCode {
     KILLED = 137,
     STOPPED = 138,
     SUCCESS = 0,
-    CLEANUP_FAILED = 223
+    CLEANUP_FAILED = 223,
+    PODS_LIMIT_REACHED = 24
 }

--- a/packages/types/src/sth-command-options.ts
+++ b/packages/types/src/sth-command-options.ts
@@ -25,6 +25,7 @@ export type STHCommandOptions = {
     instancesServerPort: string;
     sequencesRoot: string;
     k8sNamespace: string;
+    k8sQuotaName: string;
     k8sAuthConfigPath: string;
     k8sSthPodHost: string;
     k8sRunnerImage: string,

--- a/packages/types/src/sth-configuration.ts
+++ b/packages/types/src/sth-configuration.ts
@@ -75,6 +75,12 @@ export type K8SAdapterConfiguration = {
      * The Kubernetes namespace to use for running sequences
      */
     namespace: string,
+
+    /**
+     * Quota object name to determine namespace limits.
+     */
+    quotaName: string;
+
     /**
      * Authentication configuration path
      */


### PR DESCRIPTION
**What?**  <!-- Two-sentence summary, understandable for a junior. -->
check that running a new Pod with Runner won't exceed the Pods limit on the k8s before trying to run it.

Return proper error message if limit is reached.

If Quota does't exist or request failed I set CSIC free to start.

```
$ kubectl get quota
NAME            AGE   REQUEST     LIMIT
object-limits   16h   pods: 2/4   
```

```
sth --k8s-quota-name object-limits
```

```
$ si seq deploy packages/endless-names-output.tar.gz --args=[10000]
{"_id":"286e87da-7c78-4191-b487-2cc9f509ae2a","host":{"apiBase":"http://192.168.49.2:8000/api/v1","client":{"apiBase":"http://192.168.49.2:8000/api/v1"}},"sequenceURL":"sequence/286e87da-7c78-4191-b487-2cc9f509ae2a"}
Error: { message: 'Pods limit reached', exitcode: 24 }
```

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [x] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [x] Documentation is updated or no changes

