### PR TITLE
Show sequence upload progress in CLI with --progress flag

### DIFF
--- a/packages/cli/src/bin/index.ts
+++ b/packages/cli/src/bin/index.ts
@@ -65,6 +65,7 @@ const initPlatform = async () => {
         .version(`CLI version: ${version}`, "-v, --version", "Display current CLI version")
         .option("--config <name>", "Set global configuration profile")
         .option("--config-path <path>", "Set global configuration from file")
+        .option("--progress")
         .addHelpCommand(false)
         .addHelpText("beforeAll", `Current profile: ${profileManager.getProfileName()}`)
         .addHelpText(

--- a/packages/cli/src/lib/commands/sequence.ts
+++ b/packages/cli/src/lib/commands/sequence.ts
@@ -5,7 +5,7 @@ import { displayEntity, displayMessage, displayObject } from "../output";
 import { getHostClient } from "../common";
 import { getSequenceId, profileConfig, sessionConfig } from "../config";
 
-import { PassThrough } from "stream";
+import { PassThrough, Writable } from "stream";
 
 import { isDevelopment } from "../../utils/envs";
 
@@ -40,8 +40,8 @@ export const sequence: CommandDefinition = (program) => {
         .option("-o, --output <file.tar.gz>", "Output path - defaults to dirname")
         .description("Create archived file (package) with the Sequence for later use")
         .action((path, { stdout, output: fileoutput }) => {
-            const outputPath = fileoutput ? resolve(fileoutput) : `${resolve(path)}.tar.gz`;
-            const output = stdout ? process.stdout : createWriteStream(outputPath);
+            const outputPath: string = fileoutput ? resolve(fileoutput) : `${resolve(path)}.tar.gz`;
+            const output: Writable = stdout ? process.stdout : createWriteStream(outputPath);
 
             if (!stdout)
                 sessionConfig.setLastPackagePath(outputPath);
@@ -56,7 +56,7 @@ export const sequence: CommandDefinition = (program) => {
         .description("Send the Sequence package to the Hub")
         .action(
             async (sequencePackage: string, { name }) => {
-                const sequenceClient = await sequenceSendPackage(sequencePackage, { name });
+                const sequenceClient = await sequenceSendPackage(sequencePackage, { name }, false, { progress: sequenceCmd.parent?.getOptionValue("progress") });
 
                 displayObject(sequenceClient, profileConfig.format);
             }
@@ -159,7 +159,7 @@ export const sequence: CommandDefinition = (program) => {
                 await sequencePack(path, { output });
                 await sendSeqPromise;
             } else {
-                const sequenceClient = await sequenceSendPackage(path, {});
+                const sequenceClient = await sequenceSendPackage(path, {}, false, { progress: sequenceCmd.parent?.getOptionValue("progress") });
 
                 displayObject(sequenceClient, profileConfig.format);
             }

--- a/packages/cli/src/lib/helpers/sequence.ts
+++ b/packages/cli/src/lib/helpers/sequence.ts
@@ -13,6 +13,8 @@ import { Writable } from "stream";
 import { resolve } from "path";
 import { StringStream } from "scramjet";
 import { filter as mmfilter } from "minimatch";
+import * as fs from "fs";
+import { EOL } from "os";
 
 const { F_OK, R_OK } = constants;
 
@@ -79,7 +81,7 @@ export const sequencePack = async (directory: string, { output }: { output: Writ
 };
 
 export const sequenceSendPackage = async (
-    sequencePackage: string, options: SequenceUploadOptions = {}, update = false
+    sequencePackage: string, options: SequenceUploadOptions = {}, update = false, config: { progress?: boolean } = {}
 ): Promise<SequenceClient> => {
     try {
         const id = getSequenceId(options.name!);
@@ -92,10 +94,38 @@ export const sequenceSendPackage = async (
         }
 
         let seq: SequenceClient;
+        const sequenceStream = await getReadStreamFromFile(sequencePath);
+
+        if (config.progress) {
+            const barSize = 24;
+            let total = 0;
+            let text = "";
+
+            const { size } = fs.statSync(sequencePackage);
+
+            sequenceStream.on("data", async (chunk: Buffer) => {
+                total += chunk.length;
+
+                if (total <= size) {
+                    const proc = Math.round(total / size * 100);
+                    const filledCount = Math.floor(proc * (barSize / 100));
+
+                    text = `Uploading ${"".padEnd(filledCount, "█") + "".padEnd(barSize - filledCount, "░")} ${proc}%, ${(total >>> 10)}/${Math.floor(size >>> 10)}KB`;
+
+                    process.stderr.write(text);
+                    process.stderr.moveCursor(-text.length, 0);
+                }
+
+                if (total === size) {
+                    text = `Sequence package uploaded (size ${Math.round(size >>> 10)}KB)`.padEnd(text.length, " ") + EOL;
+                    process.stderr.write(text);
+                }
+            }).pause();
+        }
 
         if (update) {
             seq = await getHostClient().getSequenceClient(id)?.overwrite(
-                await getReadStreamFromFile(sequencePath),
+                sequenceStream,
             );
         } else {
             const headers: HeadersInit = {};
@@ -105,7 +135,7 @@ export const sequenceSendPackage = async (
             }
 
             seq = await getHostClient().sendSequence(
-                await getReadStreamFromFile(sequencePath),
+                sequenceStream,
                 { headers }
             );
         }


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->
edited.

**What?**  <!-- Two-sentence summary, understandable for a junior. -->
```
$ si seq <send|deploy> big-sequence.tar.gz --progress
Uploading... █████░░░░░░░░░░░░░░░░░░░ 21%, 512/2395KB
```
and summary
```
Sequence package uploaded (size 2395KB)
```

**Why?**  <!-- What is this needed for? You can link to an issue. -->
https://github.com/scramjetorg/transform-hub/issues/707

**Usage:**
```
si seq send big-sequence.tar.gz --progress
```

<!--------------------- For non-trivial changes: ---------------------->

**How it works:**
it breaks piping stdout to targets as it is writing progress to stdout.

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [x] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

