### PR TITLE
[CLI] Fix: c pr use config validation

### DIFF
--- a/packages/cli/src/lib/config/profileManager.ts
+++ b/packages/cli/src/lib/config/profileManager.ts
@@ -53,7 +53,7 @@ class ProfileManager {
     }
     profileExists(name: string) { return profileExists(name); }
     profileIsValid(name: string) {
-        return this.profileConfig.validateConfig(new ProfileConfig(profileNameToPath(name)));
+        return this.profileConfig.validateConfig(new ProfileConfig(profileNameToPath(name)).getConfig());
     }
 
     isPathSource() {


### PR DESCRIPTION
**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Fix for:
1. 
`si c pr create atgmail`

2. 
```
si c pr use atgmail
Error: Profile atgmail contain errors
```

**Why?**  <!-- What is this needed for? You can link to an issue. -->
CLI throws an error when selecting a newly created profile.

@ErykSol please look at it and check if this is the right way to fix this issue. You have a better overall understanding of the profile mechanism implementation. Thanks!

Before fix:
A config object passed to validateConfig func `this.profileConfig.validateConfig(new ProfileConfig(profileNameToPath(name)));`
```
ProfileConfig {
  filePath: '/home/agruzdz/.si/profiles/atgmail.json',
  validPath: true,
  defaultConfig: {
    configVersion: 1,
    apiUrl: 'http://127.0.0.1:8000/api/v1',
    middlewareApiUrl: '',
    env: 'development',
    scope: '',
    token: '',
    log: { debug: false, format: 'pretty' }
  },
  readOnlyConfig: false
}
```
==> 
In such case `config?.log` is undefined and https://github.com/scramjetorg/transform-hub/blob/88734139cfbf2152ae4c63ce2dc7c8911dc607cd/packages/cli/src/lib/config/profileConfig.ts#L51 returns false.

After fix:
A config object passed to validateConfig func t`his.profileConfig.validateConfig(new ProfileConfig(profileNameToPath(name)).getConfig());`

```
{
  configVersion: 1,
  apiUrl: 'http://127.0.0.1:8000/api/v1',
  middlewareApiUrl: '',
  env: 'development',
  scope: '',
  token: '',
  log: { debug: false, format: 'pretty' }
}
```

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass


