### PR TITLE
(helm) sth support configMap

### DIFF
--- a/docs/guides/kubernetes/charts/templates/sth-config.yaml
+++ b/docs/guides/kubernetes/charts/templates/sth-config.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.config }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sth-cm
+  labels:
+    app.kubernetes.io/name: {{ include "sth.name" . }}
+    helm.sh/chart: {{ include "sth.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+{{- range $path, $config := .Values.config }}
+  {{ $path }}: |
+{{ tpl $config $ | indent 4 -}}
+{{- end -}}
+{{- end -}}

--- a/docs/guides/kubernetes/charts/templates/sth-statefulset.yaml
+++ b/docs/guides/kubernetes/charts/templates/sth-statefulset.yaml
@@ -69,8 +69,16 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         volumeMounts:
-        - name: scramjet-sequences
-          mountPath: /root/.scramjet_k8s_sequences
+          - name: scramjet-sequences
+            mountPath: /root/.scramjet_k8s_sequences
+          {{- if .Values.config }}
+          {{- $configDir := .Values.configDir -}}
+          {{- range $path, $config := .Values.config }}
+          - name: sth-cm
+            mountPath: {{ $configDir }}/{{ $path }}
+            subPath: {{ $path }}
+          {{- end }}
+          {{- end }}
         ports:
         - name: sth-api
           containerPort: {{ .Values.sthApi.service.port }}
@@ -82,10 +90,15 @@ spec:
       {{- end }}
       restartPolicy: Always
       terminationGracePeriodSeconds: 10
-{{- if not .Values.persistentVolume.enabled }}
       volumes:
-            - name: scramjet-sequences
-              emptyDir: {}
+          {{- if .Values.config }}
+          - name: sth-cm
+            configMap:
+              name: sth-cm
+          {{- end }}
+{{- if not .Values.persistentVolume.enabled }}
+          - name: scramjet-sequences
+            emptyDir: {}
 {{- else }}
   volumeClaimTemplates:
   - metadata:

--- a/docs/guides/kubernetes/charts/values.yaml
+++ b/docs/guides/kubernetes/charts/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 repo: scramjetorg
 app: sth
-version: 0.28.3
+version: 0.28.5
 
 # fullnameOverride: ""
 
@@ -9,8 +9,8 @@ version: 0.28.3
 extraArgs:
   - "--identify-existing"
   - "--runtime-adapter=kubernetes"
-  - "--k8s-runner-image=scramjetorg/runner:0.28.3"
-  - "--k8s-runner-py-image=scramjetorg/runner-py:0.28.3"
+  - "--k8s-runner-image=scramjetorg/runner:0.28.5"
+  - "--k8s-runner-py-image=scramjetorg/runner-py:0.28.5"
   - "--k8s-runner-cleanup-timeout=0"
   - "--no-colors"
 
@@ -54,6 +54,19 @@ sthRunner:
     type: NodePort
     port: 8001
     externalTrafficPolicy: Cluster
+
+
+## ConfigMaps
+configDir: /config/
+
+config: {}
+    # config.json: |
+    #   {
+    #     "sequences": [
+    #       { "id": "default", "args": [],  "appConfig": {} }
+    #     ]
+    #   }
+
 
 ## The storage volume used by each Pod in the StatefulSet.
 persistentVolume:


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
helm chart for STH -  added `config` block with STH configurtion for [IaC mode ](https://github.com/scramjetorg/transform-hub/pull/239)

**Why?**  <!-- What is this needed for? You can link to an issue. -->
allow to configure STH in IaC mode 


We can start STH from config file e.g  `--startup-config=/config/config.json`

**Usage:**
1. pull transform-hub repo
2. [Install Helm](https://helm.sh/docs/intro/install/)
3. Use your k8s cluster or setup test cluster using [minikube](https://minikube.sigs.k8s.io/docs/start/)
    - `minikube start --extra-config=apiserver.service-node-port-range=[8000-65535]`
4. Edit values.yaml :
```bash
## ConfigMaps
configDir: /config/

config:
    config.json: |
      {
        "sequences": [
          { "id": "default", "args": [],  "appConfig": {} }
        ]
      }
```
5. `helm upgrade --install sth charts/ -n default --force`

Then check if config exists:
```bash
$ kubectl exec -ti sth-0 sth -- cat /config/config.json

{
  "sequences": [
    { "id": "default", "args": [],  "appConfig": {} }
  ]
}
```


**How it works:**
Allows to add helper containers

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

