### PR TITLE
(helm) liveness & readiness probe, fix port mapping

### DIFF
--- a/docs/guides/kubernetes/charts/Chart.yaml
+++ b/docs/guides/kubernetes/charts/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart to deploy STH
 name: sth
-version: 0.0.3
+version: 0.0.4

--- a/docs/guides/kubernetes/charts/templates/sth-statefulset.yaml
+++ b/docs/guides/kubernetes/charts/templates/sth-statefulset.yaml
@@ -50,6 +50,8 @@ spec:
         {{- if .Values.extraArgs }}
         {{- toYaml .Values.extraArgs | nindent 10 }}
         {{- end }}
+          - '--port={{ .Values.sthApi.service.port }}'
+          - '--instances-server-port={{ .Values.sthRunner.service.port }}'
           - '--id'
           - '$(POD_NAME)'
         {{- if .Values.kubernetesAdapter.runnerAutoNamespace }}
@@ -68,6 +70,30 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        {{- if .Values.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.livenessProbe.path }}
+            port: {{ .Values.sthApi.service.port }}
+            scheme: {{ .Values.livenessProbe.scheme }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.readinessProbe.path }}
+            port: {{ .Values.sthApi.service.port }}
+            scheme: {{ .Values.readinessProbe.scheme }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+        {{- end }}
         volumeMounts:
         - name: scramjet-sequences
           mountPath: /root/.scramjet_k8s_sequences

--- a/docs/guides/kubernetes/charts/values.yaml
+++ b/docs/guides/kubernetes/charts/values.yaml
@@ -44,7 +44,7 @@ sthApi:
   enabled: true
   service:
     type: NodePort
-    port: 8000
+    port: 30000
     externalTrafficPolicy: Local
 
 # -- Manage STH Runner API service
@@ -52,7 +52,7 @@ sthRunner:
   enabled: false
   service:
     type: NodePort
-    port: 8001
+    port: 30001
     externalTrafficPolicy: Cluster
 
 ## The storage volume used by each Pod in the StatefulSet.
@@ -74,3 +74,36 @@ initContainers: []
   #   volumeMounts:
   #     - mountPath: /root/.scramjet_k8s_sequences
   #       name: scramjet-sequences
+
+
+# -- livenessProbe for STH
+livenessProbe:
+  enabled: false
+  scheme: HTTP
+  path: /api/v1/version
+  # Number of seconds after the container has started before startup, liveness or readiness probes are initiated. Defaults to 0 seconds. Minimum value is 0.
+  initialDelaySeconds: 3
+  # How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+  periodSeconds: 10
+  # Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
+  timeoutSeconds: 5
+  # Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup Probes. Minimum value is 1.
+  successThreshold: 1
+  # When a probe fails, Kubernetes will try failureThreshold times before giving up. Giving up in case of liveness probe means restarting the container. In case of readiness probe the Pod will be marked Unready. Defaults to 3. Minimum value is 1.
+  failureThreshold: 5
+
+# -- readinessProbe for STH
+readinessProbe:
+  enabled: false
+  scheme: HTTP
+  path: /api/v1/version
+  # Number of seconds after the container has started before startup, liveness or readiness probes are initiated. Defaults to 0 seconds. Minimum value is 0.
+  initialDelaySeconds: 3
+  # How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+  periodSeconds: 10
+  # Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
+  timeoutSeconds: 5
+  # Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup Probes. Minimum value is 1.
+  successThreshold: 1
+  # When a probe fails, Kubernetes will try failureThreshold times before giving up. Giving up in case of liveness probe means restarting the container. In case of readiness probe the Pod will be marked Unready. Defaults to 3. Minimum value is 1.
+  failureThreshold: 5


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->

(helm) liveness & readiness probes

From Kubernetes DOCs:

> The [kubelet](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/) uses liveness probes to know when to restart a container. For example, liveness probes could catch a deadlock, where an application is running, but unable to make progress. Restarting a container in such a state can help to make the application more available despite bugs.

>The kubelet uses readiness probes to know when a container is ready to start accepting traffic. A Pod is considered ready when all of its containers are ready. One use of this signal is to control which Pods are used as backends for Services. When a Pod is not ready, it is removed from Service load balancers.


**Why?**  <!-- What is this needed for? You can link to an issue. -->

* Better failure detection, API crashes etc. Also with IaC mode we can monitor sequence status
* fixed port mappings fro mservice

**Usage:**
 Start kubernetes cluster

1. `minikube start --kubernetes-version=v1.23.0`
2. `cd docs/guides/kubernetes/charts`
3. edit `values.yaml` and enable probes
```yaml
livenessProbe:
  enabled: true
  (...)
readinessProbe:
  enabled: true
```
4. `helm upgrade --install probes . -f values.yaml `
5. `kubectl describe pod sth-0 `
```bash
...
    Liveness:       http-get http://:30000/api/v1/version delay=3s timeout=5s period=10s #success=1 #failure=5
    Readiness:      http-get http://:30000/api/v1/version delay=3s timeout=5s period=10s #success=1 #failure=5
...
```
Also in logs of sth `kubectl logs sth-0 -f`

we can find requests to /api/v1/version

```bash
2022-10-11T13:11:31.213Z DEBUG Host Request [
  'date: 2022-10-11T13:11:31.204Z, method: GET, url: /api/v1/version, status: 200'
]
```
**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

