### PR TITLE
Reject topic upstream request with conflicting content-type

### DIFF
--- a/packages/host/src/lib/sd-adapter.ts
+++ b/packages/host/src/lib/sd-adapter.ts
@@ -5,6 +5,7 @@ import { Duplex, PassThrough, Readable, Writable } from "stream";
 import { CPMConnector } from "./cpm-connector";
 import { ObjLogger } from "@scramjet/obj-logger";
 import { getRouter } from "@scramjet/api-server";
+import { ReasonPhrases } from "http-status-codes";
 
 /**
  * TODO: Refactor types below.
@@ -90,6 +91,8 @@ export class ServiceDiscovery {
                     { contentType, topic },
                     "api"
                 );
+            } else if (contentType !== target.contentType) {
+                return { opStatus: ReasonPhrases.UNSUPPORTED_MEDIA_TYPE, error: `Acceptable Content-Type for ${topic.name} is ${topic.contentType}` };
             }
 
             pipeToTopic(req, target);


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
HTTP 415 when stream data with mismatched content-type to existing topic

**Why?**  <!-- What is this needed for? You can link to an issue. -->
Fix for https://github.com/scramjetorg/transform-hub/issues/657

**Review checks:**
see issue above

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [x] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

