### PR TITLE
Fix setting platform defaults

### DIFF
--- a/packages/cli/src/lib/config/sessionConfig.ts
+++ b/packages/cli/src/lib/config/sessionConfig.ts
@@ -28,19 +28,19 @@ export class SessionConfig extends ConfigFileDefault<SessionConfigEntity> {
     get sessionId() { return this.get().sessionId; }
 
     setLastPackagePath(lastPackagePath: string): boolean {
-        return this.setEntry("lastPackagePath", lastPackagePath) as boolean;
+        return this.setEntry("lastPackagePath", lastPackagePath);
     }
     setLastInstanceId(lastInstanceId: string): boolean {
-        return this.setEntry("lastInstanceId", lastInstanceId) as boolean;
+        return this.setEntry("lastInstanceId", lastInstanceId);
     }
     setLastSequenceId(lastSequenceId: string): boolean {
-        return this.setEntry("lastSequenceId", lastSequenceId) as boolean;
+        return this.setEntry("lastSequenceId", lastSequenceId);
     }
     setLastSpaceId(lastSpaceId: string): boolean {
-        return this.setEntry("lastSpaceId", lastSpaceId) as boolean;
+        return this.setEntry("lastSpaceId", lastSpaceId);
     }
     setLastHubId(lastHubId: string): boolean {
-        return this.setEntry("lastHubId", lastHubId) as boolean;
+        return this.setEntry("lastHubId", lastHubId);
     }
     protected validateEntry(key: string, value: any): boolean | null {
         switch (key) {
@@ -48,11 +48,10 @@ export class SessionConfig extends ConfigFileDefault<SessionConfigEntity> {
             case "lastSpaceId":
             case "lastSequenceId":
             case "lastHubId":
-                return null;
-            case "lastInstanceId":
-                return isUUID(value, 4);
             case "sessionId":
                 return null;
+            case "lastInstanceId":
+                return value === "" || isUUID(value, 4);
             default:
                 return false;
         }

--- a/packages/cli/src/lib/platform/common.ts
+++ b/packages/cli/src/lib/platform/common.ts
@@ -63,6 +63,7 @@ export const setPlatformDefaults = async () => {
         sessionConfig.setLastHubId(selectedHost.id);
 
         displayMessage(`Defaults set to: Space: ${selectedManager.id}, Hub: ${selectedHost.id}`);
+
         return true;
     } catch (_) {
         displayError("Unable to set platform defaults\n");

--- a/packages/utility/src/config/config.ts
+++ b/packages/utility/src/config/config.ts
@@ -65,6 +65,7 @@ export abstract class Config<Type extends Object> implements Configuration<Type>
     setEntry(key: keyof Type, value: any): boolean {
         if (this.validateEntry(key as string, value) === false) return false;
         this.configuration[key as keyof Object] = value;
+        this.isValidConfig = true;
         return true;
     }
     /**


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Fix setting config

New session:
```bash
$ alis@ecclesiarch:~$ si seq ls
Defaults set to: Space: org-9f10da37-a7e8-45d5-882c-93229b6ca701-manager, Hub: sth-0
Error: Failed to request 'https://api.beta.scramjet.cloud/api/v1/space/api/v1/sth/api/v1/sequences' with code 404.
$ alis@ecclesiarch:~$ si seq ls
[]
```
vs
```
$ alis@ecclesiarch:~$ si seq ls
Defaults set to: Space: org-9f10da37-a7e8-45d5-882c-93229b6ca701-manager, Hub: sth-0
[]
```

Configuration was left marked as invalid and returned default, empty values.

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

