### PR TITLE
Better validation messages with SchemaValidator utility

### DIFF
--- a/packages/api-server/src/config/ServerConfiguration.ts
+++ b/packages/api-server/src/config/ServerConfiguration.ts
@@ -1,32 +1,59 @@
-import { FileBuilder, ReadOnlyConfig } from "@scramjet/utility";
+import {
+    booleanValidator,
+    fileExistsValidator,
+    optionalValidator,
+    ReadOnlyConfig,
+    SchemaValidator,
+    stringValidator,
+} from "@scramjet/utility";
 import { ServerConfig } from "../types/ServerConfig";
 
+const schemaValidator = new SchemaValidator({
+    verbose: [optionalValidator, booleanValidator("Server verbose is not valid boolean value")],
+    server: [optionalValidator],
+    sslKeyPath: [
+        optionalValidator,
+        stringValidator("Server sslKeyPath is not valid string value"),
+        fileExistsValidator("Server sslKeyPath file does not exists or is not readable"),
+    ],
+    sslCertPath: [
+        optionalValidator,
+        stringValidator("Server sslCertPath is not valid string value"),
+        fileExistsValidator("Server sslCertPath file does not exists or is not readable"),
+    ],
+    router: [optionalValidator],
+});
+
 export class ServerConfiguration extends ReadOnlyConfig<ServerConfig> {
+    get verbose() {
+        return this.configuration.verbose;
+    }
+    get server() {
+        return this.configuration.server;
+    }
+    get sslKeyPath() {
+        return this.configuration.sslKeyPath;
+    }
+    get sslCertPath() {
+        return this.configuration.sslCertPath;
+    }
+    get router() {
+        return this.configuration.router;
+    }
+    get errors() {
+        return schemaValidator.errors;
+    }
+    static get schemaValidator() {
+        return schemaValidator;
+    }
+    validate(config: Record<string, any>): boolean {
+        return schemaValidator.validate(config);
+    }
     protected validateEntry(key: string, value: any): boolean | null {
-        return ServerConfiguration.validateEntry(key, value);
+        return schemaValidator.validateEntry(key, value);
     }
     // eslint-disable-next-line complexity
     static validateEntry(key: string, value: any): boolean | null {
-        switch (key) {
-            case "verbose":
-                if (value === undefined) return null;
-                if (typeof value === "boolean") return true;
-                return false;
-            case "server":
-                return null;
-            case "sslKeyPath":
-            case "sslCertPath":
-            {
-                if (value === undefined) return null;
-                if (typeof value !== "string") return false;
-                const sslFile = FileBuilder(value);
-
-                return sslFile.exists() && sslFile.isReadable();
-            }
-            case "router":
-                return null;
-            default:
-                return false;
-        }
+        return schemaValidator.validateEntry(key, value);
     }
 }

--- a/packages/api-server/src/config/ServerConfiguration.ts
+++ b/packages/api-server/src/config/ServerConfiguration.ts
@@ -52,7 +52,6 @@ export class ServerConfiguration extends ReadOnlyConfig<ServerConfig> {
     protected validateEntry(key: string, value: any): boolean | null {
         return schemaValidator.validateEntry(key, value);
     }
-    // eslint-disable-next-line complexity
     static validateEntry(key: string, value: any): boolean | null {
         return schemaValidator.validateEntry(key, value);
     }

--- a/packages/types/src/utils.ts
+++ b/packages/types/src/utils.ts
@@ -117,5 +117,5 @@ export type Port = number;
 export type ApiVersion = string;
 
 export type Validator = (message: string) => (value: any) => string | boolean;
-export type ValidationSchema = { [key: string]: (((value: any) => string | boolean) | ValidationSchema)[] };
+export type ValidationSchema = { [key: string]: ((value: any) => string | boolean)[] };
 export type ValidationResult = { name: string; isValid: boolean; message?: string };

--- a/packages/types/src/utils.ts
+++ b/packages/types/src/utils.ts
@@ -30,10 +30,10 @@ export type FReturns<T, Z extends any[] = any[]> = MaybePromise<T> | ((...args: 
  */
 export interface PipeableStream<Produces> extends Readable {
     read(count?: number): Produces[] | null;
-    pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean; }): T;
+    pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean }): T;
     // Again a hen-egg issue
     // eslint-disable-next-line no-use-before-define
-    pipe<T extends WritableStream<Produces>>(destination: T, options?: { end?: boolean; }): T;
+    pipe<T extends WritableStream<Produces>>(destination: T, options?: { end?: boolean }): T;
 }
 /**
  * A readable stream representation with generic chunks.
@@ -72,13 +72,15 @@ export type PassThoughStream<Passes> = DuplexStream<Passes, Passes>;
  */
 
 export type SynchronousStreamablePayload<Produces> =
-    PipeableStream<Produces> | AsyncGen<Produces, Produces> |
-    Gen<Produces, void> | Iterable<Produces> |
-    AsyncIterable<Produces>;
+    | PipeableStream<Produces>
+    | AsyncGen<Produces, Produces>
+    | Gen<Produces, void>
+    | Iterable<Produces>
+    | AsyncIterable<Produces>;
 
 export type HasTopicInformation = {
-    contentType?: string,
-    topic?: string
+    contentType?: string;
+    topic?: string;
 };
 
 export type SynchronousStreamable<Produces> = SynchronousStreamablePayload<Produces> & HasTopicInformation;
@@ -113,3 +115,7 @@ export type UrlPath = string;
 export type Port = number;
 
 export type ApiVersion = string;
+
+export type Validator = (message: string) => (value: any) => string | boolean;
+export type ValidationSchema = { [key: string]: (((value: any) => string | boolean) | ValidationSchema)[] };
+export type ValidationResult = { name: string; isValid: boolean; message?: string };

--- a/packages/utility/src/config/readOnlyConfig.ts
+++ b/packages/utility/src/config/readOnlyConfig.ts
@@ -22,15 +22,14 @@ export abstract class ReadOnlyConfig<Type extends Object> implements ReadOnlyCon
     }
 
     validate(config: Record<string, any>): boolean {
-        //Commented out - there is no way "any property defined" is proper validation here.
-        //if (Object.keys(config).length === 0) return false;
-
         for (const key in config) {
             if (this.validateEntry(key, config[key as keyof Object]) === false) return false;
         }
         return true;
     }
-    isValid() { return this.isValidConfig; }
+    isValid() {
+        return this.isValidConfig;
+    }
 
     has(key: keyof Type): boolean {
         return key in this.configuration;

--- a/packages/utility/src/config/readOnlyConfig.ts
+++ b/packages/utility/src/config/readOnlyConfig.ts
@@ -22,7 +22,8 @@ export abstract class ReadOnlyConfig<Type extends Object> implements ReadOnlyCon
     }
 
     validate(config: Record<string, any>): boolean {
-        if (Object.keys(config).length === 0) return false;
+        //Commented out - there is no way "any property defined" is proper validation here.
+        //if (Object.keys(config).length === 0) return false;
 
         for (const key in config) {
             if (this.validateEntry(key, config[key as keyof Object]) === false) return false;

--- a/packages/utility/src/index.ts
+++ b/packages/utility/src/index.ts
@@ -11,3 +11,4 @@ export * from "./stream-to-string";
 export * from "./config";
 export * from "./file";
 export * from "./constants";
+export * from "./validators";

--- a/packages/utility/src/typeguards/index.ts
+++ b/packages/utility/src/typeguards/index.ts
@@ -1,6 +1,7 @@
 export * from "./dto/sequence-start";
 export { isDefined } from "./is-defined";
 export { isBoolean } from "./is-boolean";
+export { isEmptyString } from "./is-empty-string";
 export { isApiVersion } from "./is-api-version";
 export { isIdString } from "./is-id-string";
 export { isPort } from "./is-port";

--- a/packages/utility/src/typeguards/index.ts
+++ b/packages/utility/src/typeguards/index.ts
@@ -1,5 +1,6 @@
-export * from "./is-defined";
 export * from "./dto/sequence-start";
+export { isDefined } from "./is-defined";
+export { isBoolean } from "./is-boolean";
 export { isApiVersion } from "./is-api-version";
 export { isIdString } from "./is-id-string";
 export { isPort } from "./is-port";

--- a/packages/utility/src/typeguards/is-boolean.ts
+++ b/packages/utility/src/typeguards/is-boolean.ts
@@ -1,0 +1,7 @@
+/**
+ * Function checking if incoming value is boolean
+ *
+ * @param value value to check
+ * @returns true if value is boolean
+ */
+export const isBoolean = (value: string) => typeof value === "boolean";

--- a/packages/utility/src/typeguards/is-empty-string.ts
+++ b/packages/utility/src/typeguards/is-empty-string.ts
@@ -1,0 +1,9 @@
+/**
+ * Returns true if given value is string and is empty.
+ *
+ * @param {any} value Value to check.
+ * @returns {boolean} Returns true if given value is empty string.
+ */
+export function isEmptyString(value: string) {
+    return typeof value === "string" && value === "";
+}

--- a/packages/utility/src/validators/api-version.ts
+++ b/packages/utility/src/validators/api-version.ts
@@ -1,0 +1,5 @@
+import { Validator } from "@scramjet/types";
+import { isApiVersion } from "../typeguards";
+
+export const apiVersionValidator: Validator = (message: string) => (version: string) =>
+    !isApiVersion(version) ? message : true;

--- a/packages/utility/src/validators/boolean.ts
+++ b/packages/utility/src/validators/boolean.ts
@@ -1,0 +1,4 @@
+import { Validator } from "@scramjet/types";
+import { isBoolean } from "../typeguards/is-boolean";
+
+export const booleanValidator: Validator = (message: string) => (value: any) => !isBoolean(value) ? message : true;

--- a/packages/utility/src/validators/defined.ts
+++ b/packages/utility/src/validators/defined.ts
@@ -1,0 +1,4 @@
+import { Validator } from "@scramjet/types";
+import { isDefined } from "../typeguards";
+
+export const definedValidator: Validator = (message: string) => (value: any) => !isDefined(value) ? message : true;

--- a/packages/utility/src/validators/defined.ts
+++ b/packages/utility/src/validators/defined.ts
@@ -1,4 +1,5 @@
 import { Validator } from "@scramjet/types";
-import { isDefined } from "../typeguards";
+import { isDefined, isEmptyString } from "../typeguards";
 
-export const definedValidator: Validator = (message: string) => (value: any) => !isDefined(value) ? message : true;
+export const definedValidator: Validator = (message: string) => (value: any) =>
+    isDefined(value) && !isEmptyString(value) ? true : message;

--- a/packages/utility/src/validators/fileExists.ts
+++ b/packages/utility/src/validators/fileExists.ts
@@ -1,0 +1,10 @@
+import { Validator } from "@scramjet/types";
+import { FileBuilder } from "../file";
+
+export const fileExistsValidator: Validator = (message: string) => (value: any) => {
+    if (typeof value !== "string") return message;
+
+    const file = FileBuilder(value);
+
+    return !file.exists() || !file.isReadable() ? message : true;
+};

--- a/packages/utility/src/validators/id-string.ts
+++ b/packages/utility/src/validators/id-string.ts
@@ -1,0 +1,4 @@
+import { Validator } from "@scramjet/types";
+import { isIdString } from "../typeguards";
+
+export const idStringValidator: Validator = (message: string) => (value: string) => !isIdString(value) ? message : true;

--- a/packages/utility/src/validators/index.ts
+++ b/packages/utility/src/validators/index.ts
@@ -5,3 +5,4 @@ export { idStringValidator } from "./id-string";
 export { logLevelValidator } from "./log-level";
 export { portValidator } from "./port";
 export { urlPathValidator } from "./url-path";
+export { SchemaValidator } from "./schema-validator";

--- a/packages/utility/src/validators/index.ts
+++ b/packages/utility/src/validators/index.ts
@@ -1,0 +1,7 @@
+export { apiVersionValidator } from "./api-version";
+export { booleanValidator } from "./boolean";
+export { definedValidator } from "./defined";
+export { idStringValidator } from "./id-string";
+export { logLevelValidator } from "./log-level";
+export { portValidator } from "./port";
+export { urlPathValidator } from "./url-path";

--- a/packages/utility/src/validators/index.ts
+++ b/packages/utility/src/validators/index.ts
@@ -1,8 +1,11 @@
 export { apiVersionValidator } from "./api-version";
 export { booleanValidator } from "./boolean";
+export { stringValidator } from "./string";
 export { definedValidator } from "./defined";
+export { optionalValidator } from "./optional";
 export { idStringValidator } from "./id-string";
 export { logLevelValidator } from "./log-level";
 export { portValidator } from "./port";
 export { urlPathValidator } from "./url-path";
+export { fileExistsValidator } from "./fileExists";
 export { SchemaValidator } from "./schema-validator";

--- a/packages/utility/src/validators/log-level.ts
+++ b/packages/utility/src/validators/log-level.ts
@@ -1,0 +1,4 @@
+import { Validator } from "@scramjet/types";
+import { isLogLevel } from "../typeguards";
+
+export const logLevelValidator: Validator = (message: string) => (value: string) => !isLogLevel(value) ? message : true;

--- a/packages/utility/src/validators/optional.ts
+++ b/packages/utility/src/validators/optional.ts
@@ -1,0 +1,4 @@
+import { Validator } from "@scramjet/types";
+import { isDefined } from "../typeguards";
+
+export const optionalValidator: Validator = () => (value: any) => isDefined(value);

--- a/packages/utility/src/validators/optional.ts
+++ b/packages/utility/src/validators/optional.ts
@@ -1,4 +1,3 @@
-import { Validator } from "@scramjet/types";
-import { isDefined } from "../typeguards";
+import { isDefined, isEmptyString } from "../typeguards";
 
-export const optionalValidator: Validator = () => (value: any) => isDefined(value);
+export const optionalValidator = (value: any) => isDefined(value) && !isEmptyString(value);

--- a/packages/utility/src/validators/port.ts
+++ b/packages/utility/src/validators/port.ts
@@ -1,0 +1,4 @@
+import { Validator } from "@scramjet/types";
+import { isPort } from "../typeguards";
+
+export const portValidator: Validator = (message: string) => (value: string) => !isPort(value) ? message : true;

--- a/packages/utility/src/validators/schema-validator.ts
+++ b/packages/utility/src/validators/schema-validator.ts
@@ -54,7 +54,6 @@ export class SchemaValidator {
         const validators = this.schema[key];
 
         if (!validators) {
-            console.warn(`No ${key} property in schema. No validation performed.`);
             return false;
         }
 

--- a/packages/utility/src/validators/schema-validator.ts
+++ b/packages/utility/src/validators/schema-validator.ts
@@ -1,0 +1,64 @@
+import { ValidationResult, ValidationSchema } from "@scramjet/types";
+
+export class SchemaValidator {
+    protected schema: ValidationSchema;
+
+    constructor(schema: ValidationSchema) {
+        this.schema = schema;
+    }
+
+    /**
+     * Validate object
+     * @param obj input object for validation
+     * @returns ValidationResult[] with validation info
+     */
+    validate(obj: Record<string, any>): ValidationResult[] {
+        const results: ValidationResult[] = [];
+
+        for (const key in this.schema) {
+            const result = this.validateEntry(key, obj[key as keyof Object]);
+
+            if (result === false) continue;
+
+            if (typeof result === "string") {
+                results.push({
+                    isValid: false,
+                    name: key,
+                    message: result,
+                });
+            }
+        }
+
+        return results;
+    }
+
+    /**
+     * Validate entry
+     * @param key entry key
+     * @param value entry value
+     * @returns for valid entry returns true if validation should continue
+     * or false if validation should be stopped.
+     * Returns string with error message when validation error occurs.
+     */
+    validateEntry(key: string, value: any): string | boolean {
+        const validators = this.schema[key];
+
+        if (!validators) {
+            console.warn(`No ${key} property in schema. No validation performed.`);
+            return false;
+        }
+
+        for (const validator of validators) {
+            if (typeof validator === "function") {
+                const result = validator(value);
+
+                if (result) {
+                    return result;
+                }
+            } else {
+            }
+        }
+
+        return false;
+    }
+}

--- a/packages/utility/src/validators/schema-validator.ts
+++ b/packages/utility/src/validators/schema-validator.ts
@@ -25,7 +25,7 @@ export class SchemaValidator {
     validateSchema(obj: Record<string, any>): ValidationResult[] {
         this._errors = [];
 
-        for (const key in this.schema) {
+        for (const key of Object.keys(this.schema)) {
             const result = this.validateSchemaElement(key, obj[key as keyof Object]);
 
             if (result === false) continue;

--- a/packages/utility/src/validators/schema-validator.ts
+++ b/packages/utility/src/validators/schema-validator.ts
@@ -1,5 +1,12 @@
 import { ValidationResult, ValidationSchema } from "@scramjet/types";
 
+/**
+ * Validates objects using schema and stores validation errors inside
+ *
+ * @export
+ * @class SchemaValidator
+ * @typedef {SchemaValidator}
+ */
 export class SchemaValidator {
     protected schema: ValidationSchema;
     protected _errors: ValidationResult[];
@@ -19,8 +26,8 @@ export class SchemaValidator {
 
     /**
      * Validates object
-     * @param obj input object for validation
-     * @returns ValidationResult[] with validation info
+     * @param {Record} obj input object for validation
+     * @returns {ValidationResult[]} with validation info
      */
     validateSchema(obj: Record<string, any>): ValidationResult[] {
         this._errors = [];
@@ -44,9 +51,9 @@ export class SchemaValidator {
 
     /**
      * Validates property using defined schema
-     * @param key property key
-     * @param value property value
-     * @returns for valid entry returns true if validation should continue
+     * @param {string} key property key
+     * @param {any} value property value
+     * @returns {string | boolean} for valid entry returns true if validation should continue
      * or false if validation should be stopped.
      * Returns string with error message when validation error occurs.
      */
@@ -74,8 +81,8 @@ export class SchemaValidator {
 
     /**
      * Validates object
-     * @param obj input object for validation
-     * @returns true if objech is valid with schema, false otherwise
+     * @param {Record} obj input object for validation
+     * @returns {boolean} true if objech is valid with schema, false otherwise
      */
     validate(obj: Record<string, any>): boolean {
         this.validateSchema(obj);
@@ -85,9 +92,9 @@ export class SchemaValidator {
 
     /**
      * Validate entry
-     * @param key entry key
-     * @param value entry value
-     * @returns true if entry is valid with schema, false otherwise
+     * @param {string} key entry key
+     * @param {any} value entry value
+     * @returns {boolean} true if entry is valid with schema, false otherwise
      */
     validateEntry(key: string, value: any): boolean {
         return typeof this.validateSchemaElement(key, value) === "boolean";

--- a/packages/utility/src/validators/string.ts
+++ b/packages/utility/src/validators/string.ts
@@ -1,0 +1,4 @@
+import { Validator } from "@scramjet/types";
+
+export const stringValidator: Validator = (message: string) => (value: any) =>
+    !(typeof value === "string") ? message : true;

--- a/packages/utility/src/validators/url-path.ts
+++ b/packages/utility/src/validators/url-path.ts
@@ -1,0 +1,4 @@
+import { Validator } from "@scramjet/types";
+import { isUrlPath } from "../typeguards";
+
+export const urlPathValidator: Validator = (message: string) => (value: string) => !isUrlPath(value) ? message : null;

--- a/packages/utility/src/validators/url-path.ts
+++ b/packages/utility/src/validators/url-path.ts
@@ -1,4 +1,4 @@
 import { Validator } from "@scramjet/types";
 import { isUrlPath } from "../typeguards";
 
-export const urlPathValidator: Validator = (message: string) => (value: string) => !isUrlPath(value) ? message : null;
+export const urlPathValidator: Validator = (message: string) => (value: string) => !isUrlPath(value) ? message : true;


### PR DESCRIPTION
**What?**
Wild SchemaValidator appeared! SchemaValidator used validation! It's super effective!

For now, the SchemaValidator is used in the ServerConfiguration. Later on, it's going to be used in every *Configuration
class within Orchestrator.And Middleware next.

**Why?**
For more descriptive configuration errors.

**Usage:**
You can build the schema using validators and provide them with proper error messages.

Example schemaValidator:
```ts
const schemaValidator = new SchemaValidator({
    verbose: [optionalValidator, booleanValidator("Server verbose is not valid boolean value")],
    server: [optionalValidator],
    sslKeyPath: [
        optionalValidator,
        stringValidator("Server sslKeyPath is not valid string value"),
        fileExistsValidator("Server sslKeyPath file does not exists or is not readable"),
    ],
    sslCertPath: [
        optionalValidator,
        stringValidator("Server sslCertPath is not valid string value"),
        fileExistsValidator("Server sslCertPath file does not exists or is not readable"),
    ],
    router: [optionalValidator],
});
```
Avaiable validators are here:
```
sth/packages/utility/src/validators/api-version.ts
sth/packages/utility/src/validators/boolean.ts
sth/packages/utility/src/validators/defined.ts
sth/packages/utility/src/validators/fileExists.ts
sth/packages/utility/src/validators/id-string.ts
sth/packages/utility/src/validators/index.ts
sth/packages/utility/src/validators/log-level.ts
sth/packages/utility/src/validators/optional.ts
sth/packages/utility/src/validators/port.ts
sth/packages/utility/src/validators/schema-validator.ts
sth/packages/utility/src/validators/string.ts
sth/packages/utility/src/validators/url-path.ts
```

**How it works:**
The SchemaValidator produces error messages based on the schema. The schemaValidator instance can be used within *Configuration file. It has nicely fitting methods like validate and validateEntry which behave same as those from the ReadOnlyConfig.

Look at the example here https://github.com/scramjetorg/transform-hub/commit/6c0288cfa19bc1ba8192ab1e711ee46443140ce7

**Review checks:**

These aspects need to be checked by the reviewer:

- [x] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [x] All STH tests pass
- [x] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [x] Documentation is updated or no changes

