### PR TITLE
Added http url typeguard and validator

### DIFF
--- a/packages/utility/src/typeguards/index.ts
+++ b/packages/utility/src/typeguards/index.ts
@@ -6,4 +6,5 @@ export { isApiVersion } from "./is-api-version";
 export { isIdString } from "./is-id-string";
 export { isPort } from "./is-port";
 export { isUrlPath } from "./is-url-path";
+export { isHttpUrl } from "./is-http-url";
 export { isLogLevel } from "./is-log-level";

--- a/packages/utility/src/typeguards/is-http-url.ts
+++ b/packages/utility/src/typeguards/is-http-url.ts
@@ -9,7 +9,8 @@ import { URL } from "url";
  */
 export const isHttpUrl = (urlString: string): boolean => {
     try {
-        let url = new URL(urlString);
+        const url = new URL(urlString);
+
         return url.protocol === "http:" || url.protocol === "https:";
     } catch (_) {
         return false;

--- a/packages/utility/src/typeguards/is-http-url.ts
+++ b/packages/utility/src/typeguards/is-http-url.ts
@@ -1,0 +1,17 @@
+import { URL } from "url";
+
+/**
+ * Function checking if provided string is valid http url
+ *
+ * Example valid paterns: http[s]://hostname[:port][/path] etc.
+ * @param {string} urlString url to check
+ * @returns {boolean} true if url is valid
+ */
+export const isHttpUrl = (urlString: string): boolean => {
+    try {
+        let url = new URL(urlString);
+        return url.protocol === "http:" || url.protocol === "https:";
+    } catch (_) {
+        return false;
+    }
+};

--- a/packages/utility/src/validators/http-url.ts
+++ b/packages/utility/src/validators/http-url.ts
@@ -1,0 +1,4 @@
+import { Validator } from "@scramjet/types";
+import { isHttpUrl } from "../typeguards";
+
+export const httpUrlValidator: Validator = (message: string) => (value: string) => !isHttpUrl(value) ? message : true;

--- a/packages/utility/src/validators/index.ts
+++ b/packages/utility/src/validators/index.ts
@@ -7,5 +7,6 @@ export { idStringValidator } from "./id-string";
 export { logLevelValidator } from "./log-level";
 export { portValidator } from "./port";
 export { urlPathValidator } from "./url-path";
+export { httpUrlValidator } from "./http-url";
 export { fileExistsValidator } from "./fileExists";
 export { SchemaValidator } from "./schema-validator";


### PR DESCRIPTION
**What?**
Validator for http url used for example in provisioning configuration.


**Why?**
Finding the proper value for the provisioning configuration endpoint was tough.


**Usage:**
```
isHttpUrl("http://dummy.url.com")
httpUrlValidator("This is the message shown when provided url is invalid")("http://dummy.url.com");
```

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

