### PR TITLE
Unhealthy bug

### DIFF
--- a/packages/api-server/src/lib/duplex-stream.ts
+++ b/packages/api-server/src/lib/duplex-stream.ts
@@ -27,6 +27,7 @@ export class DuplexStream extends Duplex {
         } else {
             this.output.on("drain", () => {
                 this.output.write(chunk);
+                this.resume();
             });
         }
 

--- a/packages/host/src/lib/auditor.ts
+++ b/packages/host/src/lib/auditor.ts
@@ -23,7 +23,7 @@ export class Auditor {
     auditStream = new StringStream();
     logger = new ObjLogger(this);
 
-    outStream = new ReReadable({ length: 1e5 });
+    outStream = new ReReadable({ length: 1e6 });
 
     getOutputStream(req: IncomingMessage, res: ServerResponse) {
         this.logger.info("request", req.url, req.method);
@@ -95,7 +95,7 @@ export class Auditor {
 
         this.logger.trace("Requestor, tx, rx", requestorId, req.auditData.rx, req.auditData.tx);
 
-        if (opCode) {
+        if (opCode !== OpRecordCode.NOT_PROCESSABLE) {
             this.write({
                 opState: status,
                 opCode,

--- a/packages/host/src/lib/cpm-connector.ts
+++ b/packages/host/src/lib/cpm-connector.ts
@@ -265,8 +265,6 @@ export class CPMConnector extends TypedEmitter<Events> {
             };
         }
 
-        //this.communicationChannel = duplex;
-
         StringStream.from(duplex.input as Readable)
             .JSONParse()
             .map(async (message: EncodedControlMessage) => {
@@ -303,6 +301,7 @@ export class CPMConnector extends TypedEmitter<Events> {
         );
 
         this.emit("connect");
+
         await this.setLoadCheckMessageSender();
 
         return new Promise((resolve, reject) => {
@@ -465,6 +464,8 @@ export class CPMConnector extends TypedEmitter<Events> {
         await this.communicationStream!.whenWrote(
             [CPMMessageCode.LOAD, await this.getLoad()]
         );
+
+        this.logger.debug("LoadCheck sent");
     }
 
     /**
@@ -475,7 +476,7 @@ export class CPMConnector extends TypedEmitter<Events> {
 
         this.loadInterval = setInterval(async () => {
             await this.sendLoad();
-        }, 5000);
+        }, 500);
     }
 
     /**

--- a/packages/host/src/lib/cpm-connector.ts
+++ b/packages/host/src/lib/cpm-connector.ts
@@ -395,6 +395,8 @@ export class CPMConnector extends TypedEmitter<Events> {
      * Tries to reconnect.
      */
     async handleConnectionClose() {
+        this.handleCommunicationRequestEnd();
+
         this.connection?.removeAllListeners();
         this.connected = false;
 
@@ -461,11 +463,15 @@ export class CPMConnector extends TypedEmitter<Events> {
     }
 
     async sendLoad() {
-        await this.communicationStream!.whenWrote(
-            [CPMMessageCode.LOAD, await this.getLoad()]
-        );
+        try {
+            await this.communicationStream!.whenWrote(
+                [CPMMessageCode.LOAD, await this.getLoad()]
+            );
 
-        this.logger.debug("LoadCheck sent");
+            this.logger.debug("LoadCheck sent");
+        } catch (e) {
+            this.logger.error("Error sending loadcheck");
+        }
     }
 
     /**
@@ -476,7 +482,7 @@ export class CPMConnector extends TypedEmitter<Events> {
 
         this.loadInterval = setInterval(async () => {
             await this.sendLoad();
-        }, 500);
+        }, 5000);
     }
 
     /**

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -220,8 +220,9 @@ export class Host implements IComponent {
         }
 
         (this.api.server as Server & { httpAllowHalfOpen?: boolean }).httpAllowHalfOpen = true;
-        this.api.server.keepAliveTimeout = 0;
+
         this.api.server.timeout = 0;
+        this.api.server.requestTimeout = 0;
 
         if (!!this.config.cpmUrl !== !!this.config.cpmId) {
             throw new HostError("CPM_CONFIGURATION_ERROR", "CPM URL and ID must be provided together");

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -2,7 +2,7 @@ import findPackage from "find-package-json";
 import { ReasonPhrases, StatusCodes } from "http-status-codes";
 
 import { Duplex, Readable, Writable } from "stream";
-import { IncomingMessage, Server, ServerResponse } from "http";
+import { IncomingHttpHeaders, IncomingMessage, Server, ServerResponse } from "http";
 import { AddressInfo } from "net";
 
 import {
@@ -199,7 +199,7 @@ export class Host implements IComponent {
             this.telemetryEnvironmentName = sthConfig.telemetry.environment;
 
         this.auditor = new Auditor();
-        this.auditor.logger.pipe(this.logger);
+        //this.auditor.logger.pipe(this.logger);
 
         const { safeOperationLimit, instanceRequirements } = this.config;
 
@@ -435,7 +435,7 @@ export class Host implements IComponent {
 
         this.api.use(this.topicsBase, (req, res, next) => this.topicsMiddleware(req, res, next));
         this.api.upstream(`${this.apiBase}/log`, () => this.commonLogsPipe.getOut());
-        this.api.duplex(`${this.apiBase}/platform`, (duplex: Duplex, headers) =>
+        this.api.duplex(`${this.apiBase}/platform`, (duplex: Duplex, headers: IncomingHttpHeaders) =>
             this.cpmConnector?.handleCommunicationRequest(duplex as unknown as DuplexStream, headers)
         );
         this.api.use(`${this.instanceBase}/:id`, (req, res, next) => this.instanceMiddleware(req, res, next));

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -1,7 +1,7 @@
 import findPackage from "find-package-json";
 import { ReasonPhrases, StatusCodes } from "http-status-codes";
 
-import { Readable, Writable } from "stream";
+import { Duplex, Readable, Writable } from "stream";
 import { IncomingMessage, Server, ServerResponse } from "http";
 import { AddressInfo } from "net";
 
@@ -44,6 +44,7 @@ import { AuditedRequest, Auditor } from "./auditor";
 import { getTelemetryAdapter, ITelemetryAdapter } from "@scramjet/telemetry";
 import { cpus, totalmem } from "os";
 import { S3Client } from "./s3-client";
+import { DuplexStream } from "@scramjet/api-server";
 
 const buildInfo = readJsonFile("build.info", __dirname, "..");
 const packageFile = findPackage(__dirname).next();
@@ -434,8 +435,8 @@ export class Host implements IComponent {
 
         this.api.use(this.topicsBase, (req, res, next) => this.topicsMiddleware(req, res, next));
         this.api.upstream(`${this.apiBase}/log`, () => this.commonLogsPipe.getOut());
-        this.api.duplex(`${this.apiBase}/platform`, (stream, headers) =>
-            this.cpmConnector?.handleCommunicationRequest(stream, headers)
+        this.api.duplex(`${this.apiBase}/platform`, (duplex: Duplex, headers) =>
+            this.cpmConnector?.handleCommunicationRequest(duplex as unknown as DuplexStream, headers)
         );
         this.api.use(`${this.instanceBase}/:id`, (req, res, next) => this.instanceMiddleware(req, res, next));
     }

--- a/packages/obj-logger/src/obj-logger.ts
+++ b/packages/obj-logger/src/obj-logger.ts
@@ -24,17 +24,17 @@ export class ObjLogger implements IObjectLogger {
     /**
      * Input log stream in object mode.
      */
-    inputLogStream = new PassThrough({ objectMode: true });
+    inputLogStream = new PassThrough({ objectMode: true }).resume();
 
     /**
      * Input log stream in string mode.
      */
-    inputStringifiedLogStream = new PassThrough({ objectMode: true });
+    inputStringifiedLogStream = new PassThrough({ objectMode: true }).resume();
 
     /**
      * Output stream in object mode.
      */
-    output = new DataStream({ objectMode: true });
+    output = new DataStream({ objectMode: true }).resume();
 
     /**
      * Name used to indicate the source of the log.

--- a/packages/obj-logger/src/obj-logger.ts
+++ b/packages/obj-logger/src/obj-logger.ts
@@ -163,8 +163,10 @@ export class ObjLogger implements IObjectLogger {
     }
 
     private _stringifiedOutput?: StringStream;
+
     get stringifiedOutput(): StringStream {
-        if (!this._stringifiedOutput) this._stringifiedOutput = this.output.JSONStringify();
+        // eslint-disable-next-line no-console
+        if (!this._stringifiedOutput) this._stringifiedOutput = this.output.JSONStringify().catch((e: any) => { console.error(e); });
         return this._stringifiedOutput;
     }
 
@@ -192,7 +194,7 @@ export class ObjLogger implements IObjectLogger {
      */
     pipe(
         target: Writable | IObjectLogger,
-        { end, stringified }: { end?: boolean, stringified?: boolean } = {}
+        { end = false, stringified }: { end?: boolean, stringified?: boolean } = {}
     ): typeof target {
         if (target instanceof ObjLogger) {
             this.baseLog.id ||= target.baseLog.id;
@@ -219,6 +221,12 @@ export class ObjLogger implements IObjectLogger {
      * @returns {Writable} Unpiped stream
      */
     unpipe(target: Writable | IObjectLogger | undefined, options: ObjLogPipeOptions = {}) {
+        if (!target) {
+            this.stringifiedOutput.unpipe();
+            this.output.unpipe();
+            return undefined;
+        }
+
         if (target instanceof ObjLogger) {
             this.logLevel = target.logLevel;
 

--- a/packages/symbols/src/cpm-message-code.ts
+++ b/packages/symbols/src/cpm-message-code.ts
@@ -9,5 +9,7 @@ export enum CPMMessageCode {
     INSTANCE = 7005,
     SEQUENCE = 7006,
 
-    TOPIC = 7007
+    TOPIC = 7007,
+
+    CONFIRM_MSG = 8000
 }

--- a/packages/symbols/src/op-record-code.ts
+++ b/packages/symbols/src/op-record-code.ts
@@ -58,5 +58,7 @@ export enum OpRecordCode {
      * The INSTANCE_STOPPED message is sent when an Instance terminated not
      * in response to the API request but gracefully by itself or by throwing an error.
      */
-    INSTANCE_STOPPED = -1 // NOT YET IMPLEMENTED
+    INSTANCE_STOPPED = -1, // NOT YET IMPLEMENTED
+
+    NOT_PROCESSABLE
 }

--- a/packages/types/src/object-logger.ts
+++ b/packages/types/src/object-logger.ts
@@ -67,7 +67,7 @@ export interface IObjectLogger {
     addSerializedLoggerSource(source: Readable): void;
 
     pipe(target: Writable | IObjectLogger, options?: { end?: boolean; stringified?: boolean }): void;
-    unpipe(target: Writable | IObjectLogger): void;
+    unpipe(target?: Writable | IObjectLogger): void;
 
     updateBaseLog(entry: LogEntry): void;
 }

--- a/packages/verser/src/lib/verser-connection.ts
+++ b/packages/verser/src/lib/verser-connection.ts
@@ -19,7 +19,7 @@ const BPMux = require("bpmux").BPMux;
  * Provides methods for handling connection to Verser server and streams in connection socket.
  */
 export class VerserConnection {
-    private logger = new ObjLogger(this);
+    logger = new ObjLogger(this);
 
     private request: IncomingMessage;
     private bpmux?: { [key: string]: any };
@@ -168,6 +168,7 @@ export class VerserConnection {
         return new Promise((resolve, reject) => {
             const clientRequest = httpRequest({ ...options, agent: this.agent })
                 .on("response", (incomingMessage: IncomingMessage) => {
+                    this.logger.debug("Got Response", options);
                     resolve({ incomingMessage, clientRequest });
                 })
                 .on("error", (error: Error) => {
@@ -177,6 +178,8 @@ export class VerserConnection {
 
             clientRequest.setSocketKeepAlive(true);
             clientRequest.flushHeaders();
+
+            this.logger.debug("makeRequest headers sent", options);
         });
     }
 

--- a/packages/verser/src/lib/verser-connection.ts
+++ b/packages/verser/src/lib/verser-connection.ts
@@ -175,6 +175,7 @@ export class VerserConnection {
                     reject(error);
                 });
 
+            clientRequest.setSocketKeepAlive(true);
             clientRequest.flushHeaders();
         });
     }
@@ -200,7 +201,7 @@ export class VerserConnection {
             // TODO: Error handling?
         });
 
-        this.agent = new Agent() as Agent & { createConnection: typeof createConnection }; // lack of types?
+        this.agent = new Agent({ keepAlive: true }) as Agent & { createConnection: typeof createConnection }; // lack of types?
         this.agent.createConnection = () => {
             try {
                 const socket = this.bpmux!.multiplex() as Socket;

--- a/packages/verser/src/lib/verser.ts
+++ b/packages/verser/src/lib/verser.ts
@@ -33,7 +33,13 @@ export class Verser extends TypedEmitter<Events> {
             const connection = new VerserConnection(req, socket);
 
             this.connections.push(connection);
+            this.logger.info("Total connections:", this.connections.length);
+
             this.emit("connect", connection);
+
+            socket.once("close", () => {
+                this.logger.info("Connect request closed");
+            });
         });
     }
 


### PR DESCRIPTION

[Change platform endpoint handler](https://github.com/scramjetorg/transform-hub/pull/745/commits/5e2951f08ec5042717d8c3fb9ddac7cca985dadd) 
- Refactor. Change StringStream to read from DuplexStream.input. 
- Simplify sending messages.



[set keep alive for muxed requests](https://github.com/scramjetorg/transform-hub/pull/745/commits/21838de8e929781ff0f312e367d10dbe72d90652)

- Add keep alive to Agents. 


[Resume streams, restore duplex handler for /platform](https://github.com/scramjetorg/transform-hub/pull/745/commits/3a05b4886420611f65bec00bf3026a6f8238563d)

- Resume stream not need to be paused.


[More logs](https://github.com/scramjetorg/transform-hub/pull/745/commits/f392947276227c7998a3d2d9db69f5de35a04728)

- Add more logs to communitcation.

[Verser request timeout, Server timeout](https://github.com/scramjetorg/transform-hub/pull/745/commits/5bac27bce2ec177bef83c13cb63c4e517295f490)
- Patch for Node 18.