### PR TITLE
Get package size information

### DIFF
--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -653,6 +653,8 @@ export class Host implements IComponent {
 
             const config = await sequenceAdapter.identify(stream, id);
 
+            config.packageSize = stream.socket.bytesRead;
+
             this.sequencesStore.set(id, { id, config, instances: new Set(), name: sequenceName });
 
             this.logger.info("Sequence identified", config);

--- a/packages/types/src/manager-configuration.ts
+++ b/packages/types/src/manager-configuration.ts
@@ -37,6 +37,7 @@ export type ManagerConfiguration = {
         bucket: string;
         useSSL: boolean,
         region: string
-        port: number
+        port: number,
+        bucketLimit: number
     }
 };

--- a/packages/types/src/runner-config.ts
+++ b/packages/types/src/runner-config.ts
@@ -26,6 +26,7 @@ type CommonSequenceConfig = {
         directory?: string;
     } | string;
     language: string;
+    packageSize?: number;
 }
 
 export type DockerSequenceConfig = CommonSequenceConfig & {


### PR DESCRIPTION
**What?**  <!-- Two-sentence summary, understandable for a junior. -->
```
$ si seq ls
[
  {
    id: '1ad07de9-62bd-494c-bd9a-27e83091b9ef',
    config: {
      type: 'docker',
      container: {
        image: 'scramjetorg/runner:0.30.4',
        maxMem: 512,
        exposePortsRange: [ 30000, 32767 ],
        hostIp: '0.0.0.0'
      },
      name: '@scramjet/hello-alice-out',
      version: '0.22.0',
      engines: { node: '>=10' },
      config: {},
      sequenceDir: '/package',
      entrypointPath: 'index',
      id: '1ad07de9-62bd-494c-bd9a-27e83091b9ef',
      author: 'Scramjet <open-source@scramjet.org>',
      repository: {
        type: 'git',
        url: 'https://github.com/scramjetorg/transform-hub.git'
      },
      language: 'js',
      packageSize: 363160               <-- new field
    },
    instances: []
  }
]
```

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

