### PR TITLE
Keep instance failed to start long as other errored instances

### DIFF
--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -211,8 +211,14 @@ export class CSIController extends TypedEmitter<Events> {
 
         i.then(() => this.main()).catch(async (e) => {
             this.logger.info("Instance status: errored", e);
-            this.status = InstanceStatus.ERRORED;
+            this.status ||= InstanceStatus.ERRORED;
+            this.setExitInfo(e.exitcode, e.message);
+
             this.emit("error", e);
+            this.emit("terminated", e.exitcode);
+
+            await defer(runnerExitDelay);
+
             this.emit("end", e.exitcode);
         });
 


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Do not remove instance from instances list when it failed to start. For example, when entrypoint is invalid. 
Set error code and reason for that instance, emit "terminated".

before
```
$ si seq deploy seqs/bad-main
Error: {
  message: 'Sequence entrypoint path ./app is invalid. Check `main` field in Sequence package.json',
  exitcode: 21,
  status: 'errored'
}

$ si inst ls
[]
```


with this change:
```
$ si seq deploy seqs/bad-main
Error: {
  message: 'Sequence entrypoint path ./app is invalid. Check `main` field in Sequence package.json',
  exitcode: 21,
  status: 'errored'
}

$ si inst ls
[
  {
    id: 'd063a2d1-8e22-4c2c-b55b-eea5232567d1',
    appConfig: {},
    sequence: '0e2584cb-8bb1-4f8e-b1ca-7cc8cb296817',
    sequenceInfo: {
      id: '0e2584cb-8bb1-4f8e-b1ca-7cc8cb296817',
      config: {
        type: 'docker',
        container: {
          image: 'scramjetorg/runner:0.31.1',
          maxMem: 512,
          exposePortsRange: [ 30000, 32767 ],
          hostIp: '0.0.0.0'
        },
        name: '@scramjet/hello-bad',
        version: '0.13.1',
        engines: {},
        config: {},
        sequenceDir: '/package',
        entrypointPath: './app',
        id: '0e2584cb-8bb1-4f8e-b1ca-7cc8cb296817',
        description: 'Sequence with wrong entrypoint (main)',
        author: 'Scramjet <open-source@scramjet.org>',
        repository: {
          type: 'git',
          url: 'https://github.com/scramjetorg/transform-hub.git'
        },
        language: 'unknown',
        packageSize: 832
      }
    },
    created: '2022-12-14T16:53:15.176Z',
    status: 'errored',
    terminated: {
      exitcode: 21,
      reason: 'Sequence entrypoint path ./app is invalid. Check `main` field in Sequence package.json'
    }
  }
]
```

**Why?**  <!-- What is this needed for? You can link to an issue. -->
Information about error

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

