### PR TITLE
Fix missing socket methods

### DIFF
--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -653,7 +653,7 @@ export class Host implements IComponent {
 
             const config = await sequenceAdapter.identify(stream, id);
 
-            config.packageSize = stream.socket.bytesRead;
+            config.packageSize = stream.socket?.bytesRead;
 
             this.sequencesStore.set(id, { id, config, instances: new Set(), name: sequenceName });
 

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -746,37 +746,33 @@ export class Host implements IComponent {
     }
 
     async getExternalSequence(id: string): Promise<SequenceInfo> {
-        if (this.cpmConnector?.connected) {
-            let packageStream: IncomingMessage | undefined;
+        let packageStream: IncomingMessage | undefined;
 
-            try {
-                this.logger.info("Retrieving sequence", id);
+        try {
+            this.logger.info("Retrieving sequence", id);
 
-                const response = await this.s3Client?.getObject({ filename: id + ".tar.gz" });
+            const response = await this.s3Client?.getObject({ filename: id + ".tar.gz" });
 
-                this.logger.info("Sequence package retrieved");
+            this.logger.info("Sequence package retrieved");
 
-                if (!response) {
-                    throw new Error(ReasonPhrases.NOT_FOUND);
-                }
-
-                packageStream = response.data as IncomingMessage;
-                packageStream.headers = response.headers;
-
-                const result = (await this.handleNewSequence(
-                    packageStream as ParsedMessage,
-                    id
-                )) as STHRestAPI.SendSequenceResponse;
-
-                return this.sequencesStore.get(result.id)!;
-            } catch (e: any) {
-                this.logger.error("Error requesting sequence", e.message);
-
-                throw new Error(ReasonPhrases.SERVICE_UNAVAILABLE);
+            if (!response) {
+                throw new Error(ReasonPhrases.NOT_FOUND);
             }
-        }
 
-        throw new Error(ReasonPhrases.NOT_FOUND);
+            packageStream = response.data as IncomingMessage;
+            packageStream.headers = response.headers;
+
+            const result = (await this.handleNewSequence(
+                packageStream as ParsedMessage,
+                id
+            )) as STHRestAPI.SendSequenceResponse;
+
+            return this.sequencesStore.get(result.id)!;
+        } catch (e: any) {
+            this.logger.error("Error requesting sequence", e.message);
+
+            throw new Error(ReasonPhrases.NOT_FOUND);
+        }
     }
 
     /**
@@ -803,10 +799,12 @@ export class Host implements IComponent {
             this.sequencesStore.get(id) ||
             Array.from(this.sequencesStore.values()).find((seq: SequenceInfo) => seq.name === id);
 
-        sequence ||= await this.getExternalSequence(id).catch((error: ReasonPhrases) => {
-            this.logger.error("Error getting sequence from external sources", error);
-            return undefined;
-        });
+        if (this.cpmConnector?.connected) {
+            sequence ||= await this.getExternalSequence(id).catch((error: ReasonPhrases) => {
+                this.logger.error("Error getting sequence from external sources", error);
+                return undefined;
+            });
+        }
 
         if (!sequence) {
             return { opStatus: ReasonPhrases.NOT_FOUND };

--- a/packages/verser/src/lib/verser-client.ts
+++ b/packages/verser/src/lib/verser-client.ts
@@ -155,10 +155,13 @@ export class VerserClient extends TypedEmitter<Events> {
                     this.logger.error("Muxed stream error");
                 });
 
-                // some libs call it but it is not here, in BPMux.
+                // this socket is to be used as net.Socket but it is not one
+                // and it lacks of following net.Socket methods:
                 socket.setKeepAlive ||= (_enable?: boolean, _initialDelay?: number | undefined) => socket;
+                socket.unref ||= () => socket;
+                socket.setTimeout ||= (_timeout: number, _callback?: () => void) => socket;
 
-                this.logger.info("Creating connection to verser server");
+                this.logger.info("Creating muxed channel in verser connection");
 
                 return socket;
             } catch (error) {


### PR DESCRIPTION
**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Add missing methods to duplex stream created by BPMux in verser connection. This duplex stream is used as a `net.Socket` but it is not one.

**Why?**  <!-- What is this needed for? You can link to an issue. -->
Errors below appear when Sequence is provided over not real `net.Socket`

```
2022-12-20T21:46:47.140Z DEBUG DockerSequenceAdapter [1b145c4a] Starting PreRunner [ { image: 'scramjetorg/pre-runner:0.31.2', maxMem: 128 } ]
TypeError: socket.unref is not a function
    at Agent.keepSocketAlive (node:_http_agent:493:10)
    at Agent.<anonymous> (node:_http_agent:185:15)
    at Agent.emit (node:events:513:28)
    at Agent.emit (node:domain:489:12)
    at BPDuplex.onFree (node:_http_agent:386:11)
    at BPDuplex.emit (node:events:513:28)
    at BPDuplex.emit (node:domain:489:12)
    at emitFreeNT (node:_http_client:794:16)
    at processTicksAndRejections (node:internal/process/task_queues:81:21)
error Command failed with exit code 1.
```

then

```
2022-12-20T21:53:52.714Z DEBUG DockerSequenceAdapter [1b145c4a] Starting PreRunner [ { image: 'scramjetorg/pre-runner:0.31.2', maxMem: 128 } ]
TypeError: socket.setTimeout is not a function
    at Agent.keepSocketAlive (node:_http_agent:497:12)
    at Agent.<anonymous> (node:_http_agent:185:15)
    at Agent.emit (node:events:513:28)
    at Agent.emit (node:domain:489:12)
    at BPDuplex.onFree (node:_http_agent:386:11)
    at BPDuplex.emit (node:events:513:28)
    at BPDuplex.emit (node:domain:489:12)
    at emitFreeNT (node:_http_client:794:16)
    at processTicksAndRejections (node:internal/process/task_queues:81:21)
error Command failed with exit code 1.
```

and 

```
2022-12-20T21:55:17.705Z ERROR Host Error processing sequence [
  TypeError: Cannot read properties of null (reading 'bytesRead')
      at Host.handleIncomingSequence (/home/pfalba/github/scramjet-cpm-dev/sth/packages/host/src/lib/host.ts:656:48)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async Host.getExternalSequence (/home/pfalba/github/scramjet-cpm-dev/sth/packages/host/src/lib/host.ts:766:33)
      at async Host.handleStartSequence (/home/pfalba/github/scramjet-cpm-dev/sth/packages/host/src/lib/host.ts:806:22)
      at async opDataHandler (/home/pfalba/github/scramjet-cpm-dev/sth/packages/api-server/src/handlers/op.ts:106:24)
      at async handler (/home/pfalba/github/scramjet-cpm-dev/sth/packages/api-server/src/handlers/op.ts:187:28)
      at async /home/pfalba/github/scramjet-cpm-dev/sth/packages/api-server/src/index.ts:25:13
      at async /home/pfalba/github/scramjet-cpm-dev/sth/packages/api-server/src/index.ts:25:13
      at async /home/pfalba/github/scramjet-cpm-dev/sth/packages/api-server/src/index.ts:25:13
]
```

This PR fixes above errors.

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

