### PR TITLE
Add audit and log endpoints to cli

### DIFF
--- a/packages/api-client/src/host-client.ts
+++ b/packages/api-client/src/host-client.ts
@@ -50,6 +50,16 @@ export class HostClient implements ClientProvider {
      * @param {RequestInit} requestInit RequestInit object to be passed to fetch.
      * @returns Promise resolving to response with log stream.
      */
+    async getAuditStream(requestInit?: RequestInit): ReturnType<HttpClient["getStream"]> {
+        return this.client.getStream("audit", requestInit);
+    }
+
+    /**
+     * Returns Host log stream.
+     *
+     * @param {RequestInit} requestInit RequestInit object to be passed to fetch.
+     * @returns Promise resolving to response with log stream.
+     */
     async getLogStream(requestInit?: RequestInit): ReturnType<HttpClient["getStream"]> {
         return this.client.getStream("log", requestInit);
     }

--- a/packages/cli/src/lib/commands/hub.ts
+++ b/packages/cli/src/lib/commands/hub.ts
@@ -101,6 +101,11 @@ export const hub: CommandDefinition = (program) => {
         .action(async () => displayStream(getHostClient().getLogStream()));
 
     hubCmd
+        .command("audit")
+        .description("Pipe running Hub audit information to stdout")
+        .action(async () => displayStream(getHostClient().getAuditStream()));
+
+    hubCmd
         .command("load")
         .description("Monitor CPU, memory and disk usage on the Hub")
         .action(async () => displayEntity(getHostClient().getLoadCheck(), profileConfig.format));

--- a/packages/cli/src/lib/commands/space.ts
+++ b/packages/cli/src/lib/commands/space.ts
@@ -75,17 +75,17 @@ export const space: CommandDefinition = (program) => {
 
     spaceCmd
         .command("audit")
-        .description("Fetch all audit messages from space")
-        .argument("[<space_name>]", "The name of the space (defaults to all spaces)")
-        .action(async (spaceName: string) => {
+        .description("Fetch all audit messages from spaces")
+        // .argument("[<spacename>]", "The name of the space (defaults to all spaces)")
+        .action(async () => {
             const mwClient = getMiddlewareClient();
 
-            if (typeof spaceName === "undefined")
-                return displayStream(await mwClient.getAuditStream());
+            // if (typeof spacename === "undefined")
+            return displayStream(await mwClient.getAuditStream());
 
-            const managerClient = mwClient.getManagerClient(spaceName);
+            // const managerClient = mwClient.getManagerClient(spacename);
 
-            return displayStream(await managerClient.getAuditStream());
+            // return displayStream(await managerClient.getAuditStream());
         });
 
     spaceCmd

--- a/packages/middleware-api-client/src/middleware-client.ts
+++ b/packages/middleware-api-client/src/middleware-client.ts
@@ -45,4 +45,13 @@ export class MiddlewareClient implements ClientProvider {
     async getVersion(): Promise<MWRestAPI.GetVersionResponse> {
         return this.client.get("version");
     }
+
+    /**
+     * Requests API for version of various API components
+     *
+     * @returns {Promise<MMRestAPI.GetManagersResponse>} List of manager ids
+     */
+    async getAuditStream(): Promise<ReadableStream<any>> {
+        return this.client.getStream("audit");
+    }
 }


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->

**What?**  <!-- Two-sentence summary, understandable for a junior. -->

Adding two endpoints to client:

* /audit
* /logs

These endpoints are exposed by STH and SCP, but are not fully accesible.

**Why?**  <!-- What is this needed for? You can link to an issue. -->

Users should be able to query the audit log in STH and SCP.

**Usage:**
<!-- Example (if applicable), how to verify (if not covered by tests). -->
- `si space audit` - fetches all audit messages from spaces
- `si space log` - fetches all logs from a given space (last space if omitted)
- `si hub audit` - fetches audit messages from a given hub

<!--------------------- For non-trivial changes: ---------------------->

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

