### PR TITLE
cli_docs_generator

### DIFF
--- a/packages/cli/src/lib/commands/developerTools.ts
+++ b/packages/cli/src/lib/commands/developerTools.ts
@@ -1,0 +1,58 @@
+import { createWriteStream } from "fs";
+import { PassThrough } from "stream";
+import { CommandDefinition, ExtendedHelpConfiguration } from "../../types";
+import { profileManager } from "../config";
+import { cmdToJson, cmdToList, cmdToMd, rootCommand } from "../helpers/developerTools";
+import { displayObject, displayStream } from "../output";
+
+/**
+ * Initializes `developerTools` command.
+ *
+ * @param {Command} program Commander object.
+ */
+export const developerTools: CommandDefinition = (program) => {
+    const developerToolsCmd = program
+        .command("developerTools")
+        .alias("dev")
+        .addHelpCommand(false)
+        .configureHelp({ showGlobalOptions: true, developersOnly: true } as ExtendedHelpConfiguration)
+        .usage("[command] [options...]")
+        .description("Developer tools");
+
+    const cmdToFormat = async (formatCb: Function, output: string) => {
+        const stream = output ? createWriteStream(output) : new PassThrough();
+        const rootCmd = rootCommand(program);
+
+        formatCb(rootCmd, stream);
+        stream.end();
+
+        if (!output)
+            await displayStream(stream);
+    };
+
+    developerToolsCmd
+        .command("cmdToJson")
+        .description("Lists all commands structure in JSON format")
+        .option("-o, --output <fileName>", "Output to file instead of stdout")
+        .action(async ({ output }) => {
+            const rootCmd = rootCommand(program);
+            const cmdJson = cmdToJson(rootCmd);
+
+            if (output) {
+                createWriteStream(output).write(JSON.stringify(cmdJson, null, 2));
+            } else
+                displayObject(cmdJson, profileManager.getProfileConfig().format);
+        });
+
+    developerToolsCmd
+        .command("cmdToList")
+        .description("Lists all commands in CLI as string list")
+        .option("-o, --output <fileName>", "Output to file instead of stdout")
+        .action(async ({ output }) => await cmdToFormat(cmdToList, output));
+
+    developerToolsCmd
+        .command("cmdToMd")
+        .option("-o, --output <fileName>", "Output to file instead of stdout")
+        .description("Lists all commands in Markdown format")
+        .action(async ({ output }) => await cmdToFormat(cmdToMd, output));
+};

--- a/packages/cli/src/lib/commands/hub.ts
+++ b/packages/cli/src/lib/commands/hub.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 import { CommandDefinition, isProductionEnv } from "../../types";
-import { isDevelopment } from "../../utils/envs";
 import { getHostClient } from "../common";
 import { profileManager, sessionConfig } from "../config";
 import { displayEntity, displayObject, displayStream } from "../output";
@@ -19,25 +18,7 @@ export const hub: CommandDefinition = (program) => {
         .addHelpCommand(false)
         .configureHelp({ showGlobalOptions: true })
         .usage("[command] [options...]")
-        /* TODO: for future implementation
-            .option("--driver", "", "scp")
-            .option("--provider <value>", "specify provider: aws|cpm")
-            .option("--region <value>", "i.e.: us-east-1")
-    */
         .description("Allows to run programs in different data centers, computers or devices in local network");
-
-    if (isDevelopment() && isProductionEnv(profileConfig.env)) {
-        hubCmd
-            .command("create")
-            .argument("<name>")
-            .option("--json <json>")
-            .option("--file <pathToFile>")
-            .description("TO BE IMPLEMENTED / Create a Hub with parameters")
-            .action(() => {
-                // FIXME: implement me
-                throw new Error("Implement me");
-            });
-    }
 
     if (isProductionEnv(profileConfig.env)) {
         hubCmd
@@ -80,10 +61,6 @@ export const hub: CommandDefinition = (program) => {
     if (isProductionEnv(profileConfig.env)) {
         hubCmd
             .command("info")
-            /* TODO for future use
-            .argument("[name|id]")
-            .description("display chosen hub version if a name is not provided it displays a version of a current hub")
-            */
             .description("Display info about the default Hub")
             .action(async () => {
                 const { lastSpaceId: space, lastHubId: id } = sessionConfig.get();

--- a/packages/cli/src/lib/commands/index.ts
+++ b/packages/cli/src/lib/commands/index.ts
@@ -11,8 +11,11 @@ import { util } from "./util";
 import { init } from "./init";
 import { isDevelopment } from "../../utils/envs";
 import { store } from "./store";
+import { developerTools } from "./developerTools";
+import { si } from "./si";
 
 export const commands: CommandDefinition[] = [
+    si,
     hub,
     config,
     scope,
@@ -21,8 +24,9 @@ export const commands: CommandDefinition[] = [
     instance,
     topic,
     // waiting for working implementation
-    isDevelopment() ? init : () => {},
-    store,
+    isDevelopment() ? init : () => { },
+    isDevelopment() ? store : () => { },
     completion,
-    util
+    util,
+    isDevelopment() ? developerTools : () => { },
 ];

--- a/packages/cli/src/lib/commands/index.ts
+++ b/packages/cli/src/lib/commands/index.ts
@@ -25,7 +25,7 @@ export const commands: CommandDefinition[] = [
     topic,
     // waiting for working implementation
     isDevelopment() ? init : () => { },
-    isDevelopment() ? store : () => { },
+    store,
     completion,
     util,
     isDevelopment() ? developerTools : () => { },

--- a/packages/cli/src/lib/commands/init.ts
+++ b/packages/cli/src/lib/commands/init.ts
@@ -1,10 +1,10 @@
-import { CommandDefinition } from "../../types";
+import { CommandDefinition, ExtendedHelpConfiguration } from "../../types";
 
 export const init: CommandDefinition = (program) => {
     const initCmd = program
         .command("init")
         .addHelpCommand(false)
-        .configureHelp({ showGlobalOptions: true })
+        .configureHelp({ showGlobalOptions: true, developersOnly: true } as ExtendedHelpConfiguration)
         .alias("i")
         .usage("[command] [options...]");
 

--- a/packages/cli/src/lib/commands/scope.ts
+++ b/packages/cli/src/lib/commands/scope.ts
@@ -3,7 +3,6 @@ import { CommandDefinition, isProductionEnv } from "../../types";
 import { listScopes, deleteScope, getScope, scopeExists } from "../helpers/scope";
 import { displayObject } from "../output";
 import { isProfileConfig, ProfileConfig, profileManager } from "../config";
-import { isDevelopment } from "../../utils/envs";
 
 /**
  * Initializes `scope` command.
@@ -37,39 +36,6 @@ export const scope: CommandDefinition = (program) => {
 
             displayObject(scopeConfig, profileManager.getProfileConfig().format);
         });
-
-    if (isDevelopment()) {
-        scopeCmd
-            .command("create")
-            .argument("<scope-name>")
-            .description("TO BE IMPLEMENTED / Create scope")
-            .action(() => {
-            // TODO: implement me
-                throw new Error("Implement me");
-            });
-    }
-
-    if (isDevelopment())
-        scopeCmd
-            .command("add")
-            .argument("<name>")
-            .option("--hub <name> <id>", "Add a Hub to specified scope")
-            .option("--space <name> <apiUrl>", "Add space to specified scope")
-            .description("TO BE IMPLEMENTED / Add a Hub or space to specified scope")
-            .action(() => {
-                // FIXME: implement me
-                throw new Error("Implement me");
-            });
-
-    if (isDevelopment())
-        scopeCmd
-            .command("save")
-            .argument("<name>")
-            .description("TO BE IMPLEMENTED / Save current chosen space and Hub under a scope name")
-            .action(() => {
-                // FIXME: implement me
-                throw new Error("Implement me");
-            });
 
     scopeCmd
         .command("use")

--- a/packages/cli/src/lib/commands/si.ts
+++ b/packages/cli/src/lib/commands/si.ts
@@ -1,0 +1,28 @@
+import { CommandDefinition } from "../../types";
+import findPackage from "find-package-json";
+import chalk from "chalk";
+import { profileManager } from "../config";
+import { Command } from "commander";
+
+const version = findPackage(__dirname).next().value?.version || "unknown";
+
+/**
+ * Initializes `si` command.
+ *
+ * @param {Command} program Commander object.
+ */
+export const si: CommandDefinition = (program: Command) => {
+    program
+        .description("This is a Scramjet Command Line Interface to communicate with Transform Hub and Cloud Platform.")
+        .name("si")
+        .version(`SI version: ${version}`, "-v, --version", "Display current SI version")
+        .option("--config <profile-name>", "Use configuration from profile")
+        .option("--config-path <path>", "Use configuration from file")
+        .option("--progress", "Global flag, used to display progress (currently used only in 'si seq send/deploy' command")
+        .helpOption("-h, --help", "Display help for command")
+        .showHelpAfterError("(Use 'si --help' or 'si [command] --help' for additional information)")
+        .addHelpCommand(false)
+        .addHelpText("beforeAll", `Current profile: ${profileManager.getProfileName()}`)
+        .addHelpText("afterAll", `\n${chalk.greenBright("To find out more about CLI, please check out our docs at https://docs.scramjet.org/platform/cli-reference")}\n`)
+        .addHelpText("afterAll", `${chalk.hex("#7ed2e4")("Read more about Scramjet at https://scramjet.org/ 🚀\n")}`);
+};

--- a/packages/cli/src/lib/commands/space.ts
+++ b/packages/cli/src/lib/commands/space.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 import { CommandDefinition, isProductionEnv } from "../../types";
-import { isDevelopment } from "../../utils/envs";
 import { profileManager, sessionConfig } from "../config";
 import { displayObject, displayStream } from "../output";
 import { getMiddlewareClient } from "../platform";
@@ -24,23 +23,8 @@ export const space: CommandDefinition = (program) => {
         .option("-o, --output <file.tar.gz>", "Output path - defaults to dirname")
         .description("Operations on grouped and separated runtime environments that allow sharing the data within them");
 
-    if (isDevelopment())
-        spaceCmd
-            .command("create")
-            .argument("<name>")
-            .description("TO BE IMPLEMENTED / Create the space/workspace if name not provided will be generated")
-            .action(() => {
-                // FIXME: implement me
-                throw new Error("Implement me");
-            });
-
     spaceCmd
         .command("info")
-        /* TODO for future use
-    .argument("[<name>|<id>]")
-    // eslint-disable-next-line max-len
-    .description("display chosen space version if a name|id is not provided it displays a version of a current space")
-    */
         .description("Display info about the default space")
         .action(async () => {
             const spaceId = sessionConfig.lastSpaceId;
@@ -76,16 +60,10 @@ export const space: CommandDefinition = (program) => {
     spaceCmd
         .command("audit")
         .description("Fetch all audit messages from spaces")
-        // .argument("[<spacename>]", "The name of the space (defaults to all spaces)")
         .action(async () => {
             const mwClient = getMiddlewareClient();
 
-            // if (typeof spacename === "undefined")
             return displayStream(await mwClient.getAuditStream());
-
-            // const managerClient = mwClient.getManagerClient(spacename);
-
-            // return displayStream(await managerClient.getAuditStream());
         });
 
     spaceCmd
@@ -100,27 +78,4 @@ export const space: CommandDefinition = (program) => {
 
             await displayStream(await managerClient.getLogStream());
         });
-
-    if (isDevelopment())
-        spaceCmd
-            .command("delete")
-            .alias("rm")
-            .argument("<name|id>")
-            .description("TO BE IMPLEMENTED / User can only delete empty space")
-            .action(() => {
-                // FIXME: implement me
-                throw new Error("Implement me");
-            });
-
-    if (isDevelopment())
-        spaceCmd
-            .command("update")
-            .alias("up")
-            .argument("<id>", "id of space to update")
-            .option("--name", "")
-            .description("TO BE IMPLEMENTED / Update space parameters")
-            .action(() => {
-                // FIXME: implement me
-                throw new Error("Implement me");
-            });
 };

--- a/packages/cli/src/lib/commands/store.ts
+++ b/packages/cli/src/lib/commands/store.ts
@@ -1,4 +1,4 @@
-import { CommandDefinition, isProductionEnv } from "../../types";
+import { CommandDefinition, ExtendedHelpConfiguration, isProductionEnv } from "../../types";
 import { getReadStreamFromFile } from "../common";
 import { profileManager, sessionConfig } from "../config";
 import { displayObject } from "../output";
@@ -17,7 +17,7 @@ export const store: CommandDefinition = (program) => {
     const storeCmd = program
         .command("store")
         .addHelpCommand(false)
-        .configureHelp({ showGlobalOptions: true })
+        .configureHelp({ showGlobalOptions: true, developersOnly: true } as ExtendedHelpConfiguration)
         .usage("[command] [options...]")
         .description("Operations on a Store");
 

--- a/packages/cli/src/lib/commands/topic.ts
+++ b/packages/cli/src/lib/commands/topic.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 import { CommandDefinition } from "../../types";
-import { isDevelopment } from "../../utils/envs";
 import { getHostClient, getReadStreamFromFile } from "../common";
 import { profileManager } from "../config";
 import { displayEntity, displayStream } from "../output";
@@ -26,17 +25,6 @@ export const topic: CommandDefinition = (program) => {
         .usage("[command] [options...]")
         .description("Manage data flow through topics operations");
 
-    if (isDevelopment()) {
-        topicCmd
-            .command("create")
-            .argument("<topic-name>")
-            .description("TO BE IMPLEMENTED / Create topic")
-            .action(() => {
-            // FIXME: implement me
-                throw new Error("Implement me");
-            });
-    }
-
     topicCmd
         .command("get")
         .argument("<topic-name>")
@@ -47,18 +35,6 @@ export const topic: CommandDefinition = (program) => {
         .description("Get data from topic")
         .hook("preAction", (command) => { validateTopicName(command.args[0]); })
         .action(async (topicName) => displayStream(getHostClient().getNamedData(topicName)));
-
-    if (isDevelopment()) {
-        topicCmd
-            .command("delete")
-            .alias("rm")
-            .argument("<topic-name>")
-            .description("TO BE IMPLEMENTED / Delete data from topic")
-            .action(() => {
-            // FIXME: implement me
-                throw new Error("Implement me");
-            });
-    }
 
     topicCmd
         .command("send")

--- a/packages/cli/src/lib/helpers/developerTools.ts
+++ b/packages/cli/src/lib/helpers/developerTools.ts
@@ -1,0 +1,110 @@
+import { Command } from "commander";
+import { ExtendedHelpConfiguration } from "../../types";
+
+export const rootCommand = (command: Command) => {
+    while (command.parent !== null) {
+        command = command.parent;
+    }
+    return command as Command;
+};
+
+export const cmdToJson = (command: Command) => {
+    return {
+        command: command.name(),
+        alias: command.alias(),
+        description: command.description(),
+        usage: command.usage(),
+        arguments: command.args.toString(),
+        options: JSON.stringify(command.opts()),
+        commands: command.commands.map(cmdToJson as any),
+    };
+};
+
+export const cmdToList = (command: Command, stream: NodeJS.WritableStream, parentName: string = "") => {
+    const name = parentName ? `${parentName} ${command.name()}` : command.name();
+
+    stream.write(name);
+    stream.write("\n");
+    command.commands.forEach(cmd => {
+        cmdToList(cmd, stream, name);
+    });
+};
+
+export const getCmdFullName = (command: Command) => {
+    let name = command.name();
+
+    while (command.parent !== null) {
+        command = command.parent;
+        name = `${command.name()} ${name}`;
+    }
+    return name;
+};
+
+const parseHelp = (command: Command) => {
+    let help = "";
+
+    command.configureOutput({ writeOut: (str) => { help += str; } });
+    command.outputHelp();
+
+    const argumentsStart = help.indexOf("Arguments:\n");
+    let argumentsEnd: number, optionsEnd: number;
+    let args: string[] = [];
+    let opts: string[] = [];
+
+    if (argumentsStart !== -1) {
+        argumentsEnd = help.indexOf("\n\n", argumentsStart);
+        if (argumentsEnd !== -1)
+            args = help.slice(argumentsStart + 11, argumentsEnd).split("\n");
+    }
+
+    const optionsStart = help.indexOf("Options:\n");
+
+    if (optionsStart !== -1) {
+        optionsEnd = help.indexOf("\n\n", optionsStart);
+        if (optionsEnd !== -1)
+            opts = help.slice(optionsStart + 9, optionsEnd).split("\n");
+    }
+
+    return { args, opts };
+};
+
+export const cmdToMdFormat = (command: Command, stream: NodeJS.WritableStream) => {
+    const alias = command.alias() ? `|${command.alias()}` : "";
+    const cmdName = getCmdFullName(command);
+    const { args, opts } = parseHelp(command);
+
+    stream.write(`## $ ${cmdName}${alias}\n\n`);
+
+    stream.write("**Description**\n\n");
+    stream.write(`\`${command.description()}\`\n\n`);
+
+    stream.write("**Usage**\n\n");
+    stream.write(`\`${cmdName} ${command.usage()}\`\n\n`);
+
+    if (args.length) {
+        stream.write("**Arguments**\n\n");
+        args.forEach(arg => stream.write(`* ${arg}\n`));
+        // stream.write(args);
+        stream.write("\n");
+    }
+
+    if (opts.length) {
+        stream.write("**Options**\n\n");
+        opts.forEach(opt => stream.write(`* ${opt}\n`));
+        stream.write("\n");
+    }
+    stream.write("---\n\n");
+};
+
+export const cmdToMd = (command: Command, stream: NodeJS.WritableStream) => {
+    const { developersOnly } = command.configureHelp() as ExtendedHelpConfiguration;
+
+    if (developersOnly) return; // Skip printing developers commands
+
+    if (command.parent !== null)
+        cmdToMdFormat(command, stream);
+    command.commands.forEach(cmd => {
+        cmdToMd(cmd, stream);
+    });
+};
+

--- a/packages/cli/src/types/commander-completion.d.ts
+++ b/packages/cli/src/types/commander-completion.d.ts
@@ -26,16 +26,16 @@ declare module "commander-completion" {
   export type CompleteFunction = (
     params: { line: string, cursor: number | string },
     cb?: CompletionCallback
-  ) => Command; // eslint-disable-line no-use-before-define
-  export type CompletionFunction = (info: LineInfo, cb?: CompletionCallback) => Command; // eslint-disable-line no-use-before-define
+  ) => ComplitingCommand; // eslint-disable-line no-use-before-define
+  export type CompletionFunction = (info: LineInfo, cb?: CompletionCallback) => ComplitingCommand; // eslint-disable-line no-use-before-define
 
-  export class Command extends commander.Command {
+  export class ComplitingCommand extends commander.Command {
       complete: CompleteFunction;
       completion: CompletionFunction;
   }
 
   type CommanderDefaultExport = typeof commander;
 
-  export default function (c: CommanderDefaultExport) : CommanderDefaultExport & { Command: Command };
+  export default function (c: CommanderDefaultExport) : CommanderDefaultExport & { Command: ComplitingCommand };
 }
 

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -1,11 +1,17 @@
-import { Command } from "commander-completion";
+import { HelpConfiguration } from "commander";
+import { ComplitingCommand } from "commander-completion";
 
 /**
  * CommandDefinition is an object from commander.js
  * program.opts() - show options
  * program.args - show arguments passed by user
  */
-export type CommandDefinition = (program: Command) => void;
+export type CommandDefinition = (program: ComplitingCommand) => void;
+
+/**
+ * ExtendedHelpConfiguration is used to pass context options throughout commands
+ */
+export type ExtendedHelpConfiguration = HelpConfiguration & { developersOnly?: boolean }
 
 export type configEnv = "development" | "production";
 export const isConfigEnv = (env: string) => ["development", "production"].includes(env);
@@ -14,8 +20,8 @@ export const isProductionEnv = (env: configEnv): boolean => { return env === "pr
 
 export type displayFormat = "pretty" | "json";
 export const isConfigFormat = (format: string) => ["pretty", "json"].includes(format);
-export const isJsonFormat = (format: displayFormat):boolean => { return format === "json"; };
-export const isPrettyFormat = (format: displayFormat):boolean => { return format === "pretty"; };
+export const isJsonFormat = (format: displayFormat): boolean => { return format === "json"; };
+export const isPrettyFormat = (format: displayFormat): boolean => { return format === "pretty"; };
 
 export interface SiConfigEntity {
     profile: string;


### PR DESCRIPTION
**What?**  
Adds developer tools to generate list of commands in specified format

**Why?**  
To automate generating SI documentation on web page


**Usage:**
All options are visible under developer mode, to run it use i.e.
NODE_ENV=development yarn run start:dev:cli

Possible options:
`si dev cmdToJson`
`si dev cmdToList`
`si dev cmdToMd`

Default output is stdout, if you want to write it to file use: -o option i.e.:
`NODE_ENV=development yarn run start:dev:cli dev cmdToMd -o someMdFile.md`

These aspects need to be checked by the reviewer:

- [x] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [x] All STH tests pass
- [x] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

