### PR TITLE
cli init sequence

### DIFF
--- a/packages/cli/src/lib/commands/index.ts
+++ b/packages/cli/src/lib/commands/index.ts
@@ -24,8 +24,7 @@ export const commands: CommandDefinition[] = [
     sequence,
     instance,
     topic,
-    // waiting for working implementation
-    isDevelopment() ? init : () => { },
+    init,
     store,
     util,
     isDevelopment() ? developerTools : () => { },

--- a/packages/cli/src/lib/commands/init.ts
+++ b/packages/cli/src/lib/commands/init.ts
@@ -1,3 +1,5 @@
+import { Argument } from "commander";
+import { spawnSync } from "child_process";
 import { CommandDefinition, ExtendedHelpConfiguration } from "../../types";
 
 export const init: CommandDefinition = (program) => {
@@ -9,13 +11,14 @@ export const init: CommandDefinition = (program) => {
         .usage("[command] [options...]");
 
     initCmd
-        .command("template")
-        .alias("tmpl")
-        .argument("<projectName>")
-        .option("--lang <ts|js|py>", "Choose the language to develop the Sequence")
+        .command("sequence")
+        .alias("seq")
+        .addArgument(new Argument("[language]", "Choose the language to develop the sequence").choices(["ts", "js", "py"]).default("js"))
+        .addArgument(new Argument("[type]", "Choose transformation type of the sequence").choices(["generator", "transformer", "consumer"]).default("transformer"))
         .description("Create all the necessary files and start working on your Sequence")
-        .action((/* projectName, { lang } */) => {
-            // FIXME: implement me
-            throw new Error("Implement me");
+        .action(async (language: string, type: string) => {
+            const args = `init scramjetorg/sequence ${language}-${type}`;
+
+            spawnSync("npm", args.split(" "), { stdio: "inherit" });
         });
 };


### PR DESCRIPTION
**What?**  
Add command `si init sequence` to CLI

**Why?**  
To make life of a user simpler...

**Usage:**
In sequence folder run 
`si init sequence js`
`si init sequence py` (same as `si init sequence`)
`si init sequence ts`

run `si init sequence -h` to see possible arguments

**How it works:**
It spawns `npm init scramjetorg/sequence` with proper param as childprocess

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [x] All STH tests pass
- [x] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

Waiting for:
https://github.com/scramjetorg/create-sequence/pull/8