### PR TITLE
Add --debug flag to attach debugger to runner

### DIFF
--- a/packages/adapters/src/process-instance-adapter.ts
+++ b/packages/adapters/src/process-instance-adapter.ts
@@ -1,7 +1,6 @@
 import { ObjLogger } from "@scramjet/obj-logger";
 import { streamToString } from "@scramjet/utility";
-import { STHConfiguration } from "@scramjet/types";
-import {
+import { STHConfiguration,
     ExitCode,
     IComponent,
     ILifeCycleAdapterMain,
@@ -81,7 +80,7 @@ class ProcessInstanceAdapter implements
 
             return [
                 "/usr/bin/env",
-                "python3", 
+                "python3",
                 ...debugFlags,
                 path.resolve(__dirname, runnerPath),
                 "./python-runner-startup.log",
@@ -89,7 +88,7 @@ class ProcessInstanceAdapter implements
         }
         if (this.sthConfig.debug)
             debugFlags = ["--inspect=9229", "--inspect-brk"];
-        
+
         return [
             isTSNode ? "ts-node" : process.execPath,
             ...debugFlags,

--- a/packages/adapters/src/process-instance-adapter.ts
+++ b/packages/adapters/src/process-instance-adapter.ts
@@ -87,7 +87,7 @@ class ProcessInstanceAdapter implements
             ];
         }
         if (this.sthConfig.debug)
-            debugFlags = ["--inspect=9229", "--inspect-brk"];
+            debugFlags = ["--inspect-brk=9229"];
 
         return [
             isTSNode ? "ts-node" : process.execPath,

--- a/packages/sth-config/src/config-service.ts
+++ b/packages/sth-config/src/config-service.ts
@@ -15,6 +15,7 @@ const _defaultConfig: STHConfiguration = {
         maxReconnections: 100,
         reconnectionDelay: 2000,
     },
+    debug: false,
     docker: {
         prerunner: {
             image: "",

--- a/packages/sth/src/bin/hub.ts
+++ b/packages/sth/src/bin/hub.ts
@@ -23,6 +23,7 @@ const options: OptionValues & STHCommandOptions = program
     .option("-X, --exit-with-last-instance", "Exits host when no more instances exist.")
     .option("-S, --startup-config <path>", "Only works with process adapter. The configuration of startup sequences.")
     .option("-D, --sequences-root <path>", "Works with --runtime-adapter='process' or --runtime-adapter='kubernetes' options. Specifies a location where the Sequence Adapter saves new Sequences.")
+    .option("--debug", "Runners are spawned with debuggers", false)
     .option("--no-docker", "Run all the instances on the host machine instead of in docker containers. UNSAFE FOR RUNNING ARBITRARY CODE.", false)
     .option("--instance-lifetime-extension-delay <ms>", "Instance lifetime extension delay in ms")
     .option("--safe-operation-limit <mb>", "Number of MB reserved by the host for safe operation")
@@ -75,6 +76,7 @@ const options: OptionValues & STHCommandOptions = program
             reconnectionDelay: options.cpmReconnectionDelay,
             maxReconnections: options.cpmMaxReconnections
         },
+        debug: options.debug,
         docker: {
             prerunner: {
                 image: options.prerunnerImage,

--- a/packages/types/src/sth-command-options.ts
+++ b/packages/types/src/sth-command-options.ts
@@ -31,6 +31,7 @@ export type STHCommandOptions = {
     k8sRunnerImage: string,
     k8sRunnerPyImage: string
     k8sSequencesRoot: string;
+    debug: boolean;
     docker: boolean;
     k8sRunnerCleanupTimeout: string,
     k8sRunnerResourcesRequestsCpu: string;

--- a/packages/types/src/sth-configuration.ts
+++ b/packages/types/src/sth-configuration.ts
@@ -140,7 +140,6 @@ export type STHConfiguration = {
      */
     debug: boolean;
 
-
     /**
      * Docker related configuration.
      */

--- a/packages/types/src/sth-configuration.ts
+++ b/packages/types/src/sth-configuration.ts
@@ -136,6 +136,12 @@ export type STHConfiguration = {
     }
 
     /**
+     * Add debugging flags to runner.
+     */
+    debug: boolean;
+
+
+    /**
      * Docker related configuration.
      */
     docker: {


### PR DESCRIPTION
Added **--debug** flag to use when running STH in a process:  
`DEVELOPMENT=1 node dist/sth/bin/hub.js --runtime-adapter=process --debug`.
Thanks to --debug flag, runner will be executed with the following flags:  
for **JS:**  
`--inspect=9229 --inspect-brk`
for **PY:**  
`-m pdb -c continue`
To attach to the process you need runner's PID. In VSCode, the following launch.json configuration will let you attach easily:  
```
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Attach to Process (Pick)",
            "type": "node",
            "request": "attach",
            "processId": "${command:PickProcess}",
            "port": 9229,
            "continueOnAttach": true,
        },
        {
            "name": "Python: Attach using Process Id",
            "type": "python",
            "request": "attach",
            "processId": "${command:pickProcess}"
        }
    ]
}
```

**Review checks:**

These aspects need to be checked by the reviewer:

- [x] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [x] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

