### PR TITLE
Fix/audit stream

### DIFF
--- a/packages/api-client/src/host-client.ts
+++ b/packages/api-client/src/host-client.ts
@@ -50,7 +50,7 @@ export class HostClient implements ClientProvider {
     }
 
     /**
-     * Returns Host log stream.
+     * Returns Host audit stream.
      *
      * @param {RequestInit} requestInit RequestInit object to be passed to fetch.
      * @returns Promise resolving to response with log stream.

--- a/packages/types/src/api-client/host-client.ts
+++ b/packages/types/src/api-client/host-client.ts
@@ -55,6 +55,7 @@ export declare class HostClient {
     listSequences(): Promise<STHRestAPI.GetSequencesResponse>;
     listInstances(): Promise<STHRestAPI.GetInstancesResponse>;
     listEntities(): Promise<STHRestAPI.GetEntitiesResponse>;
+    getAuditStream(requestInit?: RequestInit): ReturnType<HttpClient["getStream"]>;
     getLogStream(requestInit?: RequestInit): ReturnType<HttpClient["getStream"]>;
     sendSequence(sequencePackage: Parameters<HttpClient["sendStream"]>[1], requestInit?: RequestInit, update?: boolean): Promise<SequenceClient>;
     getSequence(sequenceId: string): Promise<STHRestAPI.GetSequenceResponse>;


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Add `getAuditStream()` to HostClient types

**Why?**  <!-- What is this needed for? You can link to an issue. -->

to fix the error:
```
Error: packages/cli/src/lib/commands/space.ts(66,49): error TS2339: Property 'getAuditStream' does not exist on type 'MiddlewareClient'.
Error: packages/cli/src/lib/commands/hub.ts(83,59): error TS2339: Property 'getAuditStream' does not exist on type 'HostClient'.
```

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

