### PR TITLE
si inst inout

### DIFF
--- a/packages/api-client/src/instance-client.ts
+++ b/packages/api-client/src/instance-client.ts
@@ -180,6 +180,10 @@ export class InstanceClient {
         return this.sendStream("input", stream, requestInit, options);
     }
 
+    async inout(stream: Parameters<HttpClient["sendStream"]>[1], requestInit?: RequestInit, options?: SendStreamOptions) {
+        return this.clientUtils.post<any>(`${this.instanceURL}/inout`, stream, requestInit, { ...options, json: false, parse: "stream" });
+    }
+
     /**
      * Pipes given stream to Instance "stdin".
      *

--- a/packages/cli/src/lib/commands/instance.ts
+++ b/packages/cli/src/lib/commands/instance.ts
@@ -5,7 +5,7 @@ import { attachStdio, getHostClient, getInstance, getReadStreamFromFile } from "
 import { getInstanceId, profileManager, sessionConfig } from "../config";
 import { displayEntity, displayObject, displayStream } from "../output";
 import { ClientError } from "@scramjet/client-utils";
-
+import { Option } from "commander";
 /**
  * Initializes `instance` command.
  *
@@ -104,6 +104,26 @@ export const instance: CommandDefinition = (program) => {
 
             await instanceClient.sendInput(filename ? await getReadStreamFromFile(filename) : process.stdin, {},
                 { type: contentType, end });
+        });
+
+    instanceCmd
+        .command("inout")
+        .argument("<id>", "Instance id or '-' for the last one started or selected")
+        .argument("[file]", "File with data")
+        .addOption(new Option("-t,--content-type <content-type>", "Content-Type").choices(["text/plain", "application/octet-stream", "application/x-ndjson"]))
+        .option("-e, --end", "Close the input stream of the Instance when this stream ends, \"x-end-stream\" header", false)
+        .description("See input and output")
+        .action(async (id: string, filename: string, { contentType, end }) => {
+            const instanceClient = getInstance(getInstanceId(id));
+
+            return displayStream(
+                await instanceClient.inout(
+                    filename ? await getReadStreamFromFile(filename) : process.stdin, {
+                        headers: { "content-type": contentType },
+                    },
+                    { type: contentType, end }
+                )
+            );
         });
 
     instanceCmd


### PR DESCRIPTION
**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Added command to `si`:
```
si inst inout <id|-> [-t contentType] [file]       
``` 
Works as `si inst input` + `si inst output` - Allows to send data to Instance input and received data produced on Instance output with one request.

**Why?**  <!-- What is this needed for? You can link to an issue. -->
One request, immediately get output - transformed data for example


**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

