### PR TITLE
python-runner: replace classic EventEmitter with asynchronous one

### DIFF
--- a/packages/python-runner/requirements.txt
+++ b/packages/python-runner/requirements.txt
@@ -1,2 +1,2 @@
-pyee==8.2.2
+pyee==9.0.4
 scramjet-framework-py

--- a/packages/python-runner/runner.py
+++ b/packages/python-runner/runner.py
@@ -3,7 +3,7 @@ import sys
 import os
 import codecs
 import json
-from pyee.asyncio import AsyncIOEventEmitter
+from pyee._asyncio import AsyncIOEventEmitter
 import importlib.util
 from io import DEFAULT_BUFFER_SIZE as CHUNK_SIZE
 import types

--- a/packages/python-runner/runner.py
+++ b/packages/python-runner/runner.py
@@ -3,7 +3,7 @@ import sys
 import os
 import codecs
 import json
-from pyee._asyncio import AsyncIOEventEmitter
+from pyee.asyncio import AsyncIOEventEmitter
 import importlib.util
 from io import DEFAULT_BUFFER_SIZE as CHUNK_SIZE
 import types

--- a/packages/python-runner/runner.py
+++ b/packages/python-runner/runner.py
@@ -3,11 +3,10 @@ import sys
 import os
 import codecs
 import json
-from pyee import EventEmitter
+from pyee.asyncio import AsyncIOEventEmitter
 import importlib.util
 from io import DEFAULT_BUFFER_SIZE as CHUNK_SIZE
 import types
-
 from scramjet.streams import Stream
 from logging_setup import LoggingSetup
 from hardcoded_magic_values import CommunicationChannels as CC
@@ -33,7 +32,7 @@ class Runner:
         self.logger = log_setup.logger
         self.stop_handlers = []
         self.health_check = lambda: {'healthy': True}
-        self.emitter = EventEmitter()
+        self.emitter = AsyncIOEventEmitter()
         self.keep_alive_requested = False
 
 


### PR DESCRIPTION
**What?**  <!-- Two-sentence summary, understandable for a junior. -->

change pyee EvetEmitter to pyee AsyncEventEmitter in python runner

**Why?**  <!-- What is this needed for? You can link to an issue. -->
AIOEmitter can also handle coroutines

from EventEmitter docstring: 
"All callbacks are handled in a synchronous, blocking manner."
 
from AsyncEventEmitter docstring:
"An event emitter class which can run asyncio coroutines in addition to synchronous blocking functions (...) Unlike the case with the EventEmitter, all exceptions raised by event handlers are automatically emitted on the ``error`` event. This is important for asyncio coroutines specifically but is also handled for synchronous functions for consistency."


**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

