### PR TITLE
Expose Instance Id in AppContext.

### DIFF
--- a/packages/runner/src/runner-app-context.ts
+++ b/packages/runner/src/runner-app-context.ts
@@ -33,14 +33,16 @@ implements AppContext<AppConfigType, State> {
     exitTimeout: number = 10000;
     logger: IObjectLogger = new ObjLogger("Sequence");
     hub: HostClient;
+    instanceId: string;
 
     constructor(config: AppConfigType, monitorStream: WritableStream<any>,
-        emitter: EventEmitter, runner: RunnerProxy, hostClient: HostClient) {
+        emitter: EventEmitter, runner: RunnerProxy, hostClient: HostClient, id: string) {
         this.config = config;
         this.monitorStream = monitorStream;
         this.emitter = emitter;
         this.runner = runner;
         this.hub = hostClient;
+        this.instanceId = id;
     }
 
     private handleSave(_state: any): void {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -436,7 +436,8 @@ export class Runner<X extends AppConfig> implements IComponent {
             this.hostClient.monitorStream,
             this.emitter,
             runner,
-            hostApiClient as HostClient
+            hostApiClient as HostClient,
+            this.instanceId
         );
         this._context.logger.pipe(this.logger);
 

--- a/packages/types/src/app-context.ts
+++ b/packages/types/src/app-context.ts
@@ -182,5 +182,8 @@ export interface AppContext<AppConfigType extends AppConfig, State extends any> 
     exitTimeout: number;
 
     /** Allows to access Hub */
-    hub?: HostClient
+    hub?: HostClient;
+
+    /** Instance Id */
+    instanceId: string;
 }


### PR DESCRIPTION
**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Expose Instance Id in AppContext.


**Why?**  <!-- What is this needed for? You can link to an issue. -->
Instance should be able to distinguish itself from other instances.

**Usage:**
Example sequence.
```
module.exports = async function(_stream: Readable) {
    const id = this.instanceId;
    const info = await this.hub.getInstanceInfo(id);

    console.log(info);
}
```

<!--------------------- For non-trivial changes: ---------------------->

**How it works:**
<!-- Share some starting points for understanding the code. -->
-
-
-

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

