### PR TITLE
Add missing getLogStream to InstanceClient

### DIFF
--- a/packages/api-client/src/instance-client.ts
+++ b/packages/api-client/src/instance-client.ts
@@ -193,4 +193,12 @@ export class InstanceClient {
     async sendStdin(stream: Parameters<HttpClient["sendStream"]>[1] | string) {
         return this.sendStream("stdin", stream);
     }
+
+    /**
+     * Returns Instance log stream.
+     * @returns {Promise<Readable>} Log stream.
+     */
+    async getLogStream() {
+        return this.getStream("log");
+    }
 }

--- a/packages/cli/src/lib/commands/instance.ts
+++ b/packages/cli/src/lib/commands/instance.ts
@@ -63,7 +63,7 @@ export const instance: CommandDefinition = (program) => {
         .argument("<id>", "Instance id or '-' for the last one started or selected")
         .description("Pipe the running Instance log to stdout")
         .action((id: string) => {
-            return displayStream(getInstance(getInstanceId(id)).getStream("log"));
+            return displayStream(getInstance(getInstanceId(id)).getLogStream());
         });
 
     instanceCmd


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Add missing getLogStream to InstanceClient

**Why?**  <!-- What is this needed for? You can link to an issue. -->
was missing and `instanceClient.getStream("log")` workaround was needed

**Usage:**
<!-- Example (if applicable), how to verify (if not covered by tests). -->
```
await instanceClient.getLogStream()
```

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [x] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

