### PR TITLE
Fix for Hub Client error on Broken Streams

### DIFF
--- a/bdd/features/hub/HUB-002-host-iac.feature
+++ b/bdd/features/hub/HUB-002-host-iac.feature
@@ -20,11 +20,11 @@ Feature: HUB-002 Host started in Infrastructure as Code mode
 
     @ci-hub @starts-host
     Scenario: HUB-002 TC-003 Start host with hubclient controller
-        When hub process is started with random ports and parameters "--sequences-root data/sequences/ --identify-existing --startup-config data/sample-config-hubclient.json --runtime-adapter=process"
+        When hub process is started with random ports and parameters "--sequences-root data/sequences/ --identify-existing --startup-config iac-test-data/start-config-hubclient.json --runtime-adapter=process"
         Then host is running
         Then I get list of instances
         And there are some instances
-        And send kill message to instance of sequence "hub-client"
+        And send kill message to instances of sequence "hub-client"
         And wait for "500" ms
         And host is running
         * exit hub process

--- a/bdd/features/hub/HUB-002-host-iac.feature
+++ b/bdd/features/hub/HUB-002-host-iac.feature
@@ -17,3 +17,14 @@ Feature: HUB-002 Host started in Infrastructure as Code mode
         And there are some instances
         And the output of an instance of "args-config-test" is as in "data/sample-config-output.txt" file
         * exit hub process
+
+    @ci-hub @starts-host
+    Scenario: HUB-002 TC-003 Start host with hubclient controller
+        When hub process is started with random ports and parameters "--sequences-root data/sequences/ --identify-existing --startup-config data/sample-config-hubclient.json --runtime-adapter=process"
+        Then host is running
+        Then I get list of instances
+        And there are some instances
+        And send kill message to instance of sequence "hub-client"
+        And wait for "500" ms
+        And host is running
+        * exit hub process

--- a/bdd/features/hub/HUB-002-host-iac.feature
+++ b/bdd/features/hub/HUB-002-host-iac.feature
@@ -20,7 +20,7 @@ Feature: HUB-002 Host started in Infrastructure as Code mode
 
     @ci-hub @starts-host
     Scenario: HUB-002 TC-003 Start host with hubclient controller
-        When hub process is started with random ports and parameters "--sequences-root data/sequences/ --identify-existing --startup-config iac-test-data/start-config-hubclient.json --runtime-adapter=process"
+        When hub process is started with random ports and parameters "--sequences-root iac-test-data/sequences/ --identify-existing --startup-config iac-test-data/start-config-hubclient.json --runtime-adapter=process"
         Then host is running
         Then I get list of instances
         And there are some instances

--- a/bdd/iac-test-data/sequences/hub-client/index.js
+++ b/bdd/iac-test-data/sequences/hub-client/index.js
@@ -1,0 +1,44 @@
+const { stdout } = require("process");
+
+const defer = (ts) => new Promise(res => setTimeout(res, ts));
+
+// eslint-disable-next-line valid-jsdoc
+/**
+ * Simple Hubclient test
+ *
+ * @this {import("@scramjet/types").AppContext} this
+ * @param {never} _stream
+ * @returns {Proomise<void>}
+ */
+module.exports = async function(_stream) {
+    if (!this.hub)
+        throw new Error("Cannot run without hubClient");
+    const hub = this.hub;
+
+    await defer(10);
+
+    const infiniteSequence = await hub.getSequence("infinite");
+
+    if (infiniteSequence.instances.length === 0) {
+        const infiniteClient = hub.getSequenceClient("infinite");
+        const instance = await infiniteClient.start();
+
+        const output = await instance.getStream("output");
+        const log = await instance.getStream("log");
+
+        log.pipe(stdout);
+
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+            let bytes = output.read(16384);
+
+            if (bytes === null) {
+                await new Promise(res => output.on("readable", res));
+                bytes = output.read(16384);
+            }
+            this.logger.info("Read 16kB");
+
+            await defer(10000);
+        }
+    }
+};

--- a/bdd/iac-test-data/sequences/hub-client/package.json
+++ b/bdd/iac-test-data/sequences/hub-client/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "infinite-seq",
+  "version": "1.0.0",
+  "main": "index.js",
+  "engines": {"node": ">=16"},
+  "scripts": {
+    "build": "si pack -o ../hello-2.tar.gz ."
+  }
+}

--- a/bdd/iac-test-data/sequences/infinite/index.js
+++ b/bdd/iac-test-data/sequences/infinite/index.js
@@ -1,0 +1,23 @@
+const { Readable } = require("stream");
+
+function incrementLE(buffer) {
+    for (var i = 0; i < buffer.length; i++) {
+        if (buffer[i]++ !== 255) break;
+    }
+}
+
+module.exports = function(/** @this {import("@scramjet/types").AppContext} */) {
+    return Readable
+        .from(
+            (async function*(/** @type {import("stream").Readable} */ _stream) {
+                const buf = Buffer.alloc(16, 0);
+
+                while (true) {
+                    yield buf.toString("hex");
+                    incrementLE(buf);
+                }
+            })()
+        )
+        .on("pause", () => this.logger.info("Output paused at buf", buf.toString("hex")))
+        .on("resume", () => this.logger.info("Output resumed at buf", buf.toString("hex")));
+};

--- a/bdd/iac-test-data/sequences/infinite/package.json
+++ b/bdd/iac-test-data/sequences/infinite/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "infinite-seq",
+  "version": "1.0.0",
+  "main": "index.js",
+  "engines": {
+    "node": ">=16"
+  },
+  "scripts": {
+    "build": "si pack -o ../hello-2.tar.gz ."
+  },
+  "devDependencies": {
+    "@scramjet/types": "^0.33.4"
+  }
+}

--- a/bdd/iac-test-data/start-config-hubclient.json
+++ b/bdd/iac-test-data/start-config-hubclient.json
@@ -1,0 +1,5 @@
+{
+  "sequences": [
+    {"id": "hub-client"}
+  ]
+}

--- a/bdd/package.json
+++ b/bdd/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scramjet-bdd",
   "version": "0.33.4",
-  "description": "",
+  "description": "As the \"problem scope\" of the business problem that our technology solves is quite complex, we decided to use the BDD practice to support the development process. BDD is a methodology of high automation and agility. It describes a cycle of interactions with well-defined outcomes. As a result of these activities, we obtain working, tested software that has a real value.",
   "main": "_cucumber.js",
   "dependencies": {
     "@scramjet/api-client": "^0.33.3",
@@ -25,7 +25,16 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/scramjetorg/transform-hub.git"
+    "url": "git+https://github.com/scramjetorg/transform-hub.git"
   },
-  "private": true
+  "private": true,
+  "bugs": {
+    "url": "https://github.com/scramjetorg/transform-hub/issues"
+  },
+  "homepage": "https://github.com/scramjetorg/transform-hub#readme",
+  "directories": {
+    "lib": "lib"
+  },
+  "author": "",
+  "license": "ISC"
 }

--- a/bdd/step-definitions/e2e/host-steps.ts
+++ b/bdd/step-definitions/e2e/host-steps.ts
@@ -413,6 +413,17 @@ When(
     }
 );
 
+When("send kill message to instances of sequence {string}", async function(id) {
+    const seqClient = hostClient.getSequenceClient(id);
+    const instances = await seqClient.listInstances();
+
+    for (const instanceId of instances) {
+        const instance = await seqClient.getInstance(instanceId);
+
+        await instance.kill();
+    }
+});
+
 When("send kill message to instance", async function(this: CustomWorld) {
     const resp = await this.resources.instance?.kill();
 

--- a/packages/api-client/src/sequence-client.ts
+++ b/packages/api-client/src/sequence-client.ts
@@ -82,7 +82,7 @@ export class SequenceClient {
      * @param {ClientProvider} host Host client.
      * @returns {InstanceClient} Instance client.
      */
-    async getInstance(id: string, host: ClientProvider) {
+    async getInstance(id: string, host: ClientProvider = this.host) {
         return InstanceClient.from(id, host);
     }
 

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -556,6 +556,9 @@ export class CSIController extends TypedEmitter<Events> {
             this.createInstanceAPIRouter();
 
             this.bpmux = new BPMux(streams[8]);
+            this.bpmux.on("error", (e: any) => {
+                throw new Error("BPMux Carrier Error:" + e.message);
+            });
             this.bpmux.on("peer_multiplex", (socket: Duplex, _data: any) => this.hostProxy.onInstanceRequest(socket));
             await once(this, "pang");
             this.initResolver?.res();

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -557,7 +557,8 @@ export class CSIController extends TypedEmitter<Events> {
 
             this.bpmux = new BPMux(streams[8]);
             this.bpmux.on("error", (e: any) => {
-                throw new Error("BPMux Carrier Error:" + e.message);
+                this.logger.warn("Instance client multiplex connection errored", e.message);
+                streams[8]?.end();
             });
             this.bpmux.on("peer_multiplex", (socket: Duplex, _data: any) => this.hostProxy.onInstanceRequest(socket));
             await once(this, "pang");

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -383,6 +383,7 @@ export class Host implements IComponent {
             _config = configFile.read();
             this.logger.debug("Sequence config loaded", _config);
         } catch {
+            this.logger.error("Sequence config cannot be loaded", this.config.startupConfig);
             throw new HostError("SEQUENCE_STARTUP_CONFIG_READ_ERROR");
         }
 

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -663,9 +663,10 @@ export class Host implements IComponent {
             sequenceAdapter.logger.pipe(this.logger);
 
             for (const config of configs) {
+                this.logger.trace(`Sequence identified: ${config.id}`);
                 this.sequencesStore.set(config.id, { id: config.id, config: config, instances: new Set() });
             }
-            this.logger.trace(` ${configs.length} sequences identified`);
+            this.logger.info(` ${configs.length} sequences identified`);
         } catch (e: any) {
             this.logger.warn("Error while trying to identify existing sequences.", e);
         }

--- a/packages/types/src/api-client/client-utils.ts
+++ b/packages/types/src/api-client/client-utils.ts
@@ -2,6 +2,7 @@
 
 import { Agent as HTTPAgent } from "http";
 import { Agent as HTTPSAgent } from "https";
+import { Readable } from "stream";
 
 export declare class QueryError extends Error {
     readonly url: string;
@@ -50,7 +51,7 @@ export declare type RequestConfig = {
 export declare class HttpClient {
     addLogger(logger: RequestLogger): void;
     get<T>(url: string, requestInit?: RequestInit): Promise<T>;
-    getStream(url: string, requestInit?: RequestInit): Promise<any>;
+    getStream(url: string, requestInit?: RequestInit): Promise<Readable>;
     post<T>(url: string, data: any, requestInit?: RequestInit, options?: {
         json: boolean;
     } & RequestConfig): Promise<T>;


### PR DESCRIPTION
**What?**  <!-- Two-sentence summary, understandable for a junior. -->

The PR solves the issue of STH crashing when a sequence using `this.hub` is killed. The solution was to properly handle errors on disconnection of the additional stream in the connection between the runner and the hub.

**Why?**  <!-- What is this needed for? You can link to an issue. -->

Gotta fix bugs.

**Review checks:**

These aspects need to be checked by the reviewer:

- [x] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [x] Documentation is updated or no changes

