### PR TITLE
Fix KeyError on event emit

### DIFF
--- a/packages/python-runner/runner.py
+++ b/packages/python-runner/runner.py
@@ -142,7 +142,7 @@ class Runner:
             if code == msg_codes.STOP.value:
                 await self.handle_stop(data)
             if code == msg_codes.EVENT.value:
-                self.emitter.emit(data['eventName'], data['message'])
+                self.emitter.emit(data['eventName'], data['message'] if 'message' in data else None)
 
 
     async def handle_stop(self, data):


### PR DESCRIPTION
**What?**  <!-- Two-sentence summary, understandable for a junior. -->

Python runner was crashing on event emiting due to KeyError. 

**Why?**  <!-- What is this needed for? You can link to an issue. -->

Message key in data should be optional, not mandatory


**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

