### PR TITLE
Fix "sequence unpack failed" error with kubernetes

### DIFF
--- a/packages/python-runner/unpack.sh
+++ b/packages/python-runner/unpack.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-tar zxf - -C /package 2>&2 && touch /package/.ready || touch $PACKAGE_DIR/.fail
+tar zxf - -C /package && touch /package/.ready || touch $PACKAGE_DIR/.fail

--- a/packages/python-runner/unpack.sh
+++ b/packages/python-runner/unpack.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-tar zxf - -C /package 2> $PACKAGE_DIR/.fail && touch /package/.ready || touch $PACKAGE_DIR/.fail
+tar zxf - -C /package 2>&2 && touch /package/.ready || touch $PACKAGE_DIR/.fail

--- a/packages/runner/unpack.sh
+++ b/packages/runner/unpack.sh
@@ -4,4 +4,4 @@ PACKAGE_DIR=${PACKAGE_DIR:-/package}
 
 set -e
 
-tar zxf - -C $PACKAGE_DIR 2> $PACKAGE_DIR/.fail && touch $PACKAGE_DIR/.ready || touch $PACKAGE_DIR/.fail
+tar zxf - -C $PACKAGE_DIR 2>&2 && touch $PACKAGE_DIR/.ready || touch $PACKAGE_DIR/.fail

--- a/packages/runner/unpack.sh
+++ b/packages/runner/unpack.sh
@@ -4,4 +4,4 @@ PACKAGE_DIR=${PACKAGE_DIR:-/package}
 
 set -e
 
-tar zxf - -C $PACKAGE_DIR 2>&2 && touch $PACKAGE_DIR/.ready || touch $PACKAGE_DIR/.fail
+tar zxf - -C $PACKAGE_DIR && touch $PACKAGE_DIR/.ready || touch $PACKAGE_DIR/.fail


### PR DESCRIPTION
The error occurs inside the [unpack.sh](https://github.com/scramjetorg/transform-hub/blob/devel/packages/runner/unpack.sh) file.  
Issue has been reported here: **[Sequence unpack error](https://github.com/scramjetorg/transform-hub/issues/755)**   
unpack.sh:  
```bash
...
tar zxf - -C $PACKAGE_DIR 2> $PACKAGE_DIR/.fail && touch $PACKAGE_DIR/.ready || touch $PACKAGE_DIR/.fail
```  
This is the culprit: `2> $PACKAGE_DIR/.fail`.  
Note:
- `$PACKAGE_DIR` is always "/package"  
- `-` is a stream of buffered Sequence archive  

This occurs mostly with Sequences above ~40MB and **only while using kubernetes adapter** (but may happen with Sequences of size <1MB). Pod crashes with the following error: 
`status: 'Failure', message: 'command terminated with non-zero exit code: Error executing in Docker Container: 137', reason: 'NonZeroExitCode'`  
While code 137 is related to insufficient RAM, I do not believe thats in case. I've removed any limits from pod runners, but the problem persists.

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

