### PR TITLE
Added new command options and types

### DIFF
--- a/packages/sth/src/bin/hub.ts
+++ b/packages/sth/src/bin/hub.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env ts-node
+/* eslint-disable complexity */
 
 import { Command, Option, OptionValues } from "commander";
 import { ConfigService, getRuntimeAdapterOption } from "@scramjet/sth-config";
@@ -20,6 +21,10 @@ const stringToIntSanitizer = (str : string) => {
 
 const program = new Command();
 const options: OptionValues & STHCommandOptions = program
+    .option("-desc, --description <description>", "Specify sth description")
+    .option("--custom-name <customName>", "Specify custom name")
+    .option("--tags <tags>", "Specifies tags", "")
+    .option("-sh, --self-hosted", "Specifies if the hub is self hosted", true)
     .option("-c, --config <path>", "Specifies path to config")
     .option("-L, --log-level <level>", "Specify log level")
     .option("--no-colors", "Disable colors in output", false)
@@ -67,7 +72,11 @@ const options: OptionValues & STHCommandOptions = program
 (async () => {
     const configService = new ConfigService();
     const resolveFile = (path: string) => path && resolve(process.cwd(), path);
+    const tags = options.tags.length ? options.tags.split(",") : [];
 
+    if (!tags.every((t:string) => t.length)) {
+        throw new Error("Tags cannot be empty");
+    }
     if (options.config) {
         const configFile = FileBuilder(options.config);
 
@@ -78,6 +87,10 @@ const options: OptionValues & STHCommandOptions = program
     }
 
     configService.update({
+        description: options.description,
+        customName: options.customName,
+        tags: tags,
+        selfHosted: options.selfHosted,
         cpmUrl: options.cpmUrl,
         cpmId: options.cpmId,
         cpmSslCaPath: options.cpmSslCaPath,

--- a/packages/types/src/sth-command-options.ts
+++ b/packages/types/src/sth-command-options.ts
@@ -2,6 +2,10 @@ import { LogLevel } from "./object-logger";
 import { TelemetryConfig } from "./telemetry-config";
 
 export type STHCommandOptions = {
+    description: string;
+    customName: string;
+    tags: string;
+    selfHosted:boolean;
     logLevel: LogLevel;
     colors: boolean,
     port: number;

--- a/packages/types/src/sth-configuration.ts
+++ b/packages/types/src/sth-configuration.ts
@@ -106,6 +106,22 @@ export type K8SAdapterConfiguration = {
 
 export type STHConfiguration = {
     /**
+     * Description set by user
+     */
+    description?:string;
+    /**
+     * User assigned tags
+     */
+    tags?:Array<string>;
+    /**
+     * Custom name to help identify sth
+     */
+    customName?:string;
+    /**
+     *  Is sth self hosted?
+     */
+    selfHosted?:boolean;
+    /**
      * Logging level.
      */
     logLevel: LogLevel


### PR DESCRIPTION

**What?**  
Added new options to be set for sth: 
- description
- custom name
- tags
- self hosted

**Why?**  
This will support identifying sth's useful for self hosted hub

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

