### PR TITLE
New Cli command that allows restarting instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,5 +157,5 @@ bdd/timing-log.ndjson
 timing-log.ndjson
 .all-deps
 
-# sth config
-packages/sth/sth-config.json
+# private working directories
+/temp

--- a/packages/cli/src/lib/commands/instance.ts
+++ b/packages/cli/src/lib/commands/instance.ts
@@ -93,6 +93,16 @@ export const instance: CommandDefinition = (program) => {
                 profileManager.getProfileConfig().format));
 
     instanceCmd
+        .command("restart")
+        .argument("<id>", "Instance id or '-' for the last one started or selected")
+        .description("Kills the instance and start the new one from root sequence")
+        .action(async (id: string) => {
+            const instanceRestartResponse = await instanceRestart(id);
+
+            displayObject(instanceRestartResponse, profileManager.getProfileConfig().format);
+        });
+
+    instanceCmd
         .command("input")
         .argument("<id>", "Instance id or '-' for the last one started or selected")
         .argument("[file]", "File with data")
@@ -205,14 +215,5 @@ export const instance: CommandDefinition = (program) => {
         .description("Pipe the running Instance stdout stream to stdout")
         .action((id: string) => {
             return displayStream(getInstance(getInstanceId(id)).getStream("stdout"));
-        });
-    instanceCmd
-        .command("restart")
-        .argument("<id>", "Instance id or '-' for the last one started or selected")
-        .description("Kills the instance and start the new one from root sequence")
-        .action(async (id: string) => {
-            const instanceRestartResponse = await instanceRestart(id);
-
-            displayObject(instanceRestartResponse, profileManager.getProfileConfig().format);
         });
 };

--- a/packages/cli/src/lib/commands/instance.ts
+++ b/packages/cli/src/lib/commands/instance.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { instanceKill } from "../helpers/instance";
+import { instanceKill, instanceRestart } from "../helpers/instance";
 import { CommandDefinition } from "../../types";
 import { attachStdio, getHostClient, getInstance, getReadStreamFromFile } from "../common";
 import { getInstanceId, profileManager, sessionConfig } from "../config";
@@ -205,5 +205,14 @@ export const instance: CommandDefinition = (program) => {
         .description("Pipe the running Instance stdout stream to stdout")
         .action((id: string) => {
             return displayStream(getInstance(getInstanceId(id)).getStream("stdout"));
+        });
+    instanceCmd
+        .command("restart")
+        .argument("<id>", "Instance id or '-' for the last one started or selected")
+        .description("Kills the instance and start the new one from root sequence")
+        .action(async (id: string) => {
+            const instanceRestartResponse = await instanceRestart(id);
+
+            displayObject(instanceRestartResponse, profileManager.getProfileConfig().format);
         });
 };

--- a/packages/cli/src/lib/helpers/instance.ts
+++ b/packages/cli/src/lib/helpers/instance.ts
@@ -3,7 +3,6 @@ import { getHostClient, getInstance } from "../common";
 import { getInstanceId, sessionConfig } from "../config";
 import { SequenceClient } from "@scramjet/api-client";
 import { defer } from "@scramjet/utility";
-//import { ConfigFileDefault } from "@scramjet/utility";
 
 /**
  * Wraper for kill instance method with config safety checks.

--- a/packages/cli/src/lib/helpers/instance.ts
+++ b/packages/cli/src/lib/helpers/instance.ts
@@ -31,7 +31,7 @@ export const instanceRestart = async (
     const instanceInfo = await getInstance(instanceId).getInfo();
     const sequenceId = instanceInfo.sequence;
     const sequenceClient = SequenceClient.from(sequenceId, getHostClient());
-    const args = instanceInfo.args;
+    const { provides, requires, args } = instanceInfo;
     const appConfig = instanceInfo.appConfig || {};
     const killResponse: STHRestAPI.SendKillInstanceResponse = await instanceKill(instanceId, true);
     let seqStartResponse: STHRestAPI.StartSequenceResponse = { id: "" };
@@ -49,7 +49,13 @@ export const instanceRestart = async (
         }
     }
     if (typeof sequenceId === "string") {
-        seqStartResponse = await sequenceClient.start({ instanceId, appConfig, args });
+        seqStartResponse = await sequenceClient.start({
+            instanceId,
+            appConfig,
+            args,
+            inputTopic: requires,
+            outputTopic: provides
+        });
     }
 
     return { killResponse, seqStartResponse };

--- a/packages/cli/src/lib/helpers/instance.ts
+++ b/packages/cli/src/lib/helpers/instance.ts
@@ -48,6 +48,7 @@ export const instanceRestart = async (
             }
         }
     }
+
     if (typeof sequenceId === "string") {
         seqStartResponse = await sequenceClient.start({
             instanceId,

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -780,6 +780,8 @@ export class CSIController extends TypedEmitter<Events> {
             id: this.id,
             appConfig: this.appConfig,
             args: this.args,
+            provides: this.provides,
+            requires: this.requires,
             sequence: this.sequence.id,
             sequenceInfo: {
                 id: this.sequence.id,

--- a/packages/types/src/instance-store.ts
+++ b/packages/types/src/instance-store.ts
@@ -7,6 +7,8 @@ export type Instance = {
     id: InstanceId,
     appConfig?: AppConfig,
     args?: InstanceArgs,
+    provides?: string,
+    requires?: string,
     sequence: string,
     ports?: Record<string, number>
     created?: Date,


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
```
si seq start XX
{ id: SEQ_ID }
```
```
si inst restart SEQ_ID
```

restarted instance keeps id, input topic, output topic if set.
 

**Why?**  <!-- What is this needed for? You can link to an issue. -->
`si seq start -` + `si inst kill -` + `si seq start - params` = `si inst restart -`

**Usage:**
<!-- Example (if applicable), how to verify (if not covered by tests). -->
-
-
-

<!--------------------- For non-trivial changes: ---------------------->

**How it works:**
<!-- Share some starting points for understanding the code. -->
-
-
-

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

