### PR TITLE
check instance id

### DIFF
--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -843,6 +843,7 @@ export class Host implements IComponent {
      * @param {ParsedMessage} req Request object.
      * @returns {Promise<STHRestAPI.StartSequenceResponse>} Promise resolving to operation result object.
      */
+    // eslint-disable-next-line complexity
     async handleStartSequence(req: ParsedMessage): Promise<OpResponse<STHRestAPI.StartSequenceResponse>> {
         if (await this.loadCheck.overloaded()) {
             return {
@@ -869,6 +870,13 @@ export class Host implements IComponent {
         }
 
         this.logger.info("Start sequence", sequence.id, sequence.config.name);
+
+        if (payload.instanceId && this.instancesStore[payload.instanceId]) {
+            return {
+                opStatus: ReasonPhrases.CONFLICT,
+                error: "Instance with a given ID already exists"
+            };
+        }
 
         try {
             const csic = await this.startCSIController(sequence, payload);


### PR DESCRIPTION
**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Added validataion when starting instance with a provided id

**Why?**  <!-- What is this needed for? You can link to an issue. -->]
When starting sequence there is an option to provide id which was not validated to check if it already exists.
In case of trying to starting multiple instances with same id

**How to verify**
- send sequence, assume it's id is `2b7accb6-1441-4db3-a2f5-f21db28f2be3`
- Start sequence with 
```
curl -X POST \
  '0.0.0.0:8000/api/v1/sequence/2b7accb6-1441-4db3-a2f5-f21db28f2be3/start' \
  --header 'Accept: */*' \
  --header 'Content-Type: application/json' \
  --data-raw '{ "instanceId": "7a0d1492-34b5-4c87-aa09-570a06624f8c" }'
```
  no errors.
- Start sequence with providing ```instanceId``` (existing already)
```
curl -X POST \
  '0.0.0.0:8000/api/v1/sequence/2b7accb6-1441-4db3-a2f5-f21db28f2be3/start' \
  --header 'Accept: */*' \
  --header 'Content-Type: application/json' \
  --data-raw '{ "instanceId": "7a0d1492-34b5-4c87-aa09-570a06624f8c" }'
```
```
409 Conflict
{
  "error": "Instance with a given ID already exists"
}
```
- Start sequence providing invalid ```instanceId```:
```
curl -X POST \
  '0.0.0.0:8000/api/v1/sequence/2b7accb6-1441-4db3-a2f5-f21db28f2be3/start' \
  --header 'Accept: */*' \
  --header 'Content-Type: application/json' \
  --data-raw '{ "instanceId": "NOT_AN_UUID4" }'
```
```
422 Unprocessable Entity
{
  "error": "Invalid Instance id"
}
```

These aspects need to be checked by the reviewer:

- [x] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [x] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

