### PR TITLE
Missing handling of disconnect on Id drop

### DIFF
--- a/packages/host/src/lib/cpm-connector.ts
+++ b/packages/host/src/lib/cpm-connector.ts
@@ -258,8 +258,9 @@ export class CPMConnector extends TypedEmitter<Events> {
             .JSONParse()
             .map(async (message: EncodedControlMessage) => {
                 this.logger.trace("Received message", message);
+                const messageCode = message[0] as CPMMessageCode;
 
-                if (message[0] === CPMMessageCode.STH_ID) {
+                if (messageCode === CPMMessageCode.STH_ID) {
                     // eslint-disable-next-line no-extra-parens
                     this.info.id = (message[1] as STHIDMessageData).id;
 
@@ -276,7 +277,9 @@ export class CPMConnector extends TypedEmitter<Events> {
                     this.logger.updateBaseLog({ id: this.info.id });
                 }
 
-                if (message[0] === CPMMessageCode.KEY_REVOKED || message[0] === CPMMessageCode.LIMIT_EXCEEDED) {
+                const dropMessageCodes = [CPMMessageCode.KEY_REVOKED, CPMMessageCode.LIMIT_EXCEEDED, CPMMessageCode.ID_DROP];
+
+                if (dropMessageCodes.includes(messageCode)) {
                     this.logger.trace("Received pre drop message");
                     this.isAbandoned = true;
                 }


### PR DESCRIPTION
On disconnect from manager with Id param, sth is not seting abort signal from communiation channel. This PR fixes it.

How to verify:
1) start multi-manager
`yarn start:dev:multi-manager`
2) Start self-hosted sth:
`yarn start:dev`
3) Send /disconnect
curl 'http://127.0.0.1:11000/api/v1/cpm/<space_Id>/api/v1/disconnect' -H 'authorization: Bearer \<bearerToken\>' -H 'content-type: application/json' --data-raw '{"id":"SELF_HUB-1"}'

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [x] All STH tests pass
- [x] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [x] Documentation is updated or no changes

