### PR TITLE
fixed tags when starting sth with config file

### DIFF
--- a/packages/sth-config/src/config-service.ts
+++ b/packages/sth-config/src/config-service.ts
@@ -9,6 +9,9 @@ const imageConfig = require("./image-config.json");
 const _defaultConfig: STHConfiguration = {
     logLevel: "TRACE",
     logColors: true,
+    customName: "",
+    description: "",
+    tags: [],
     cpmUrl: "",
     cpmId: "",
     cpm: {

--- a/packages/sth-config/src/config-service.ts
+++ b/packages/sth-config/src/config-service.ts
@@ -11,7 +11,7 @@ const _defaultConfig: STHConfiguration = {
     logColors: true,
     customName: "",
     description: "",
-    tags: [],
+    tags: ["e", "f"],
     cpmUrl: "",
     cpmId: "",
     cpm: {

--- a/packages/sth/src/bin/hub.ts
+++ b/packages/sth/src/bin/hub.ts
@@ -77,7 +77,6 @@ const options: OptionValues & STHCommandOptions = program
 (async () => {
     const configService = new ConfigService();
     const resolveFile = (path: string) => path && resolve(process.cwd(), path);
-    let tags: string[] = [];
 
     if (options.config) {
         const configFile = FileBuilder(options.config);
@@ -86,18 +85,19 @@ const options: OptionValues & STHCommandOptions = program
         const configContents = configFile.read() as DeepPartial<STHConfiguration>;
 
         configService.update(configContents);
-        tags = configContents.tags as string[];
     }
-    tags = options.tags.length ? options.tags.split(",") : [];
 
-    if (!tags.every((t:string) => t.length)) {
+    if (options.tags.length) {
+        configService.update({ tags: options.tags.split(",") });
+    }
+
+    if (!configService.getConfig().tags?.every((t:string) => t.length)) {
         throw new Error("Tags cannot be empty");
     }
 
     configService.update({
         description: options.description,
         customName: options.customName,
-        tags: tags,
         selfHosted: options.selfHosted,
         cpmUrl: options.cpmUrl,
         cpmId: options.cpmId,

--- a/packages/sth/src/bin/hub.ts
+++ b/packages/sth/src/bin/hub.ts
@@ -77,11 +77,7 @@ const options: OptionValues & STHCommandOptions = program
 (async () => {
     const configService = new ConfigService();
     const resolveFile = (path: string) => path && resolve(process.cwd(), path);
-    const tags = options.tags.length ? options.tags.split(",") : [];
-
-    if (!tags.every((t:string) => t.length)) {
-        throw new Error("Tags cannot be empty");
-    }
+    let tags: string[] = [];
 
     if (options.config) {
         const configFile = FileBuilder(options.config);
@@ -90,6 +86,12 @@ const options: OptionValues & STHCommandOptions = program
         const configContents = configFile.read() as DeepPartial<STHConfiguration>;
 
         configService.update(configContents);
+        tags = configContents.tags as string[];
+    }
+    tags = options.tags.length ? options.tags.split(",") : [];
+
+    if (!tags.every((t:string) => t.length)) {
+        throw new Error("Tags cannot be empty");
     }
 
     configService.update({


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
fixed problem that when starting sth with config from config file tags weren't loaded properly 



**How it works:**
<!-- Share some starting points for understanding the code. -->
- Create sth-config.json file with following content: 
```
{
    "host": {
        "hostname": "0.0.0.0",
        "port": 9002,
        "instancesServerPort": 9003,
        "id": "SELF_HUB-tags"
    },
    "description": "lorem lorem ipsum",
    "tags": ["lorem", "ipsum"],
    "customName": "my Sth",
    "timings": {
        "instanceLifetimeExtensionDelay": 10000
    }
}
```
- run command: 
`DEVELOPMENT=1 yarn start:dev --runtime-adapter=process -c sth-config.json`

Expected result : 
![obraz](https://github.com/scramjetorg/transform-hub/assets/53794300/03f85d3f-bae9-451d-a461-ef5bd770fff4)

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

