### PR TITLE
fix/proper-permissions-after-unpack

### DIFF
--- a/packages/python-runner/unpack.sh
+++ b/packages/python-runner/unpack.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-tar zxf - -C /package && touch /package/.ready || touch $PACKAGE_DIR/.fail
+tar zxf - -C /package && chown -R 1200:1200 $PACKAGE_DIR && touch /package/.ready || touch $PACKAGE_DIR/.fail

--- a/packages/runner/unpack.sh
+++ b/packages/runner/unpack.sh
@@ -4,4 +4,4 @@ PACKAGE_DIR=${PACKAGE_DIR:-/package}
 
 set -e
 
-tar zxf - -C $PACKAGE_DIR && touch $PACKAGE_DIR/.ready || touch $PACKAGE_DIR/.fail
+tar zxf - -C $PACKAGE_DIR && chown -R 1200:1200 $PACKAGE_DIR && touch $PACKAGE_DIR/.ready || touch $PACKAGE_DIR/.fail


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->

**What?**  <!-- Two-sentence summary, understandable for a junior. -->

Proper permissions were assigned to the unpacked files to enable their processing by the sequence.

**Why?**  <!-- What is this needed for? You can link to an issue. -->

Improper permission assignment prevented the reading of the .wav file, resulting in the interruption of the sequence.

**Usage:**
<!-- Example (if applicable), how to verify (if not covered by tests). -->
- Run STH from the "fix/proper-permissions-after-unpack" branch 
- load and run the py-transcript sequence to verify the correctness of STH's operation.

<!--------------------- For non-trivial changes: ---------------------->

**Review checks:**

These aspects need to be checked by the reviewer:

- [*] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

[logs from testing](https://github.com/scramjetorg/transform-hub/files/11662541/py-transcript-logs.log)



