### PR TITLE
si seq delete SEQ_ID --force

### DIFF
--- a/packages/api-client/src/host-client.ts
+++ b/packages/api-client/src/host-client.ts
@@ -2,6 +2,7 @@ import { ClientProvider, ClientUtils, HttpClient } from "@scramjet/client-utils"
 import { STHRestAPI } from "@scramjet/types";
 import { InstanceClient } from "./instance-client";
 import { SequenceClient } from "./sequence-client";
+import { HostHeaders } from "@scramjet/symbols";
 
 /**
  * Host client.
@@ -74,7 +75,7 @@ export class HostClient implements ClientProvider {
      *
      * @param sequencePackage Stream with packed Sequence.
      * @param {RequestInit} requestInit RequestInit object to be passed to fetch.
-     * @param {boolean} update Send request with post or put method
+     * @param {boolean} update Send request with post or put method.
      * @returns {SequenceClient} Sequence client.
      */
     async sendSequence(
@@ -102,11 +103,16 @@ export class HostClient implements ClientProvider {
     /**
      * Deletes Sequence with given id.
      *
-     * @param {string} sequenceId Sequence id
+     * @param {string} sequenceId Sequence id.
+     * @param {any} opts Additional sequence delete options.
      * @returns {STHRestAPI.Promise<DeleteSequenceResponse>} Promise resolving to delete Sequence result.
      */
-    async deleteSequence(sequenceId: string): Promise<STHRestAPI.DeleteSequenceResponse> {
-        return this.client.delete<STHRestAPI.DeleteSequenceResponse>(`sequence/${sequenceId}`);
+    async deleteSequence(sequenceId: string, opts?: { force: boolean }): Promise<STHRestAPI.DeleteSequenceResponse> {
+        const headers: HeadersInit = {};
+
+        if (opts?.force) headers[HostHeaders.SEQUENCE_FORCE_REMOVE] = "true";
+
+        return this.client.delete<STHRestAPI.DeleteSequenceResponse>(`sequence/${sequenceId}`, { headers });
     }
 
     // REVIEW: move this to InstanceClient..getInfo()?

--- a/packages/cli/src/lib/helpers/sequence.ts
+++ b/packages/cli/src/lib/helpers/sequence.ts
@@ -197,8 +197,10 @@ export function sequenceParseArgs(argsStr: string): any[] {
     return args;
 }
 
-export const sequenceDelete = async (id: string, lastSequenceId = sessionConfig.lastSequenceId) => {
-    const deleteSequenceResponse = await getHostClient().deleteSequence(getSequenceId(id));
+export const sequenceDelete = async (
+    id: string, opts = { force: false }, lastSequenceId = sessionConfig.lastSequenceId
+) => {
+    const deleteSequenceResponse = await getHostClient().deleteSequence(getSequenceId(id), opts);
 
     if (lastSequenceId === id) {
         sessionConfig.setLastSequenceId("");

--- a/packages/symbols/src/headers/host.ts
+++ b/packages/symbols/src/headers/host.ts
@@ -1,0 +1,3 @@
+export enum HostHeaders {
+    SEQUENCE_FORCE_REMOVE = "x-seq-kill-inst"
+}

--- a/packages/symbols/src/headers/index.ts
+++ b/packages/symbols/src/headers/index.ts
@@ -1,0 +1,1 @@
+export * from "./host";

--- a/packages/symbols/src/index.ts
+++ b/packages/symbols/src/index.ts
@@ -8,3 +8,4 @@ export { SequenceMessageCode } from "./sequence-status-code";
 export { OpRecordCode } from "./op-record-code";
 export { APIErrorCode } from "./api-error-codes";
 
+export * from "./headers";

--- a/packages/types/src/api-client/host-client.ts
+++ b/packages/types/src/api-client/host-client.ts
@@ -59,7 +59,7 @@ export declare class HostClient {
     getLogStream(requestInit?: RequestInit): ReturnType<HttpClient["getStream"]>;
     sendSequence(sequencePackage: Parameters<HttpClient["sendStream"]>[1], requestInit?: RequestInit, update?: boolean): Promise<SequenceClient>;
     getSequence(sequenceId: string): Promise<STHRestAPI.GetSequenceResponse>;
-    deleteSequence(sequenceId: string): Promise<STHRestAPI.DeleteSequenceResponse>;
+    deleteSequence(sequenceId: string, opts?: { force: boolean }): Promise<STHRestAPI.DeleteSequenceResponse>;
     getInstanceInfo(instanceId: string): Promise<STHRestAPI.GetInstanceResponse>;
     getLoadCheck(): Promise<LoadCheckStat>;
     getVersion(): Promise<STHRestAPI.GetVersionResponse>;

--- a/packages/types/src/rest-api-sth/send-delete-sequence.ts
+++ b/packages/types/src/rest-api-sth/send-delete-sequence.ts
@@ -1,1 +1,3 @@
-export type DeleteSequenceResponse = {id: string}
+export type DeleteSequenceResponse = {
+    id: string
+}


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
```
DELETE /api/v1/sequence/SEQ_ID
```
Setting HTTP header defined as `HostHeaders.SEQUENCE_FORCE_REMOVE` to `"true"` forces sequence deletion with killing all instances running.


**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

