### PR TITLE
Fix/prod only messages

### DIFF
--- a/packages/cli/src/lib/commands/scope.ts
+++ b/packages/cli/src/lib/commands/scope.ts
@@ -3,6 +3,7 @@ import { CommandDefinition, isProductionEnv } from "../../types";
 import { listScopes, deleteScope, getScope, scopeExists } from "../helpers/scope";
 import { displayObject } from "../output";
 import { isProfileConfig, ProfileConfig, profileManager } from "../config";
+import { displayProdOnlyMsg } from "../helpers/messages";
 
 /**
  * Initializes `scope` command.
@@ -12,7 +13,12 @@ import { isProfileConfig, ProfileConfig, profileManager } from "../config";
 export const scope: CommandDefinition = (program) => {
     const isProdEnv = isProductionEnv(profileManager.getProfileConfig().env);
 
-    if (!isProdEnv) return;
+    if (!isProdEnv) {
+        program.command("scope", { hidden:true })
+            .action(() => displayProdOnlyMsg("scope"));
+
+        return;
+    }
 
     const scopeCmd = program
         .command("scope")

--- a/packages/cli/src/lib/commands/space.ts
+++ b/packages/cli/src/lib/commands/space.ts
@@ -4,6 +4,7 @@ import { CommandDefinition, isProductionEnv } from "../../types";
 import { profileManager, sessionConfig } from "../config";
 import { displayObject, displayStream } from "../output";
 import { getMiddlewareClient } from "../platform";
+import { displayProdOnlyMsg } from "../helpers/messages";
 
 /**
  * Initializes `space` command.
@@ -13,7 +14,12 @@ import { getMiddlewareClient } from "../platform";
 export const space: CommandDefinition = (program) => {
     const isProdEnv = isProductionEnv(profileManager.getProfileConfig().env);
 
-    if (!isProdEnv) return;
+    if (!isProdEnv) {
+        program.command("space", { hidden: true })
+            .action(() => displayProdOnlyMsg("space"));
+
+        return;
+    }
 
     const spaceCmd = program
         .command("space")

--- a/packages/cli/src/lib/commands/store.ts
+++ b/packages/cli/src/lib/commands/store.ts
@@ -1,6 +1,7 @@
 import { CommandDefinition, ExtendedHelpConfiguration, isProductionEnv } from "../../types";
 import { getReadStreamFromFile } from "../common";
 import { profileManager, sessionConfig } from "../config";
+import { displayProdOnlyMsg } from "../helpers/messages";
 import { displayObject } from "../output";
 import { getMiddlewareClient } from "../platform";
 
@@ -12,7 +13,12 @@ import { getMiddlewareClient } from "../platform";
 export const store: CommandDefinition = (program) => {
     const isProdEnv = isProductionEnv(profileManager.getProfileConfig().env);
 
-    if (!isProdEnv) return;
+    if (!isProdEnv) {
+        program.command("store", { hidden:true })
+            .action(() => displayProdOnlyMsg("store"));
+
+        return;
+    }
 
     const storeCmd = program
         .command("store")

--- a/packages/cli/src/lib/helpers/messages.ts
+++ b/packages/cli/src/lib/helpers/messages.ts
@@ -1,0 +1,8 @@
+import { displayError } from "../output";
+
+export const displayProdOnlyMsg = (command: string) => {
+    displayError(`'${command}' command is only available in production environment
+to change environment please use following command: 'si config set env production'
+or check out our documentation for more details: 'https://docs.scramjet.org/platform/get-started/'`);
+};
+

--- a/packages/cli/src/utils/envs.ts
+++ b/packages/cli/src/utils/envs.ts
@@ -5,3 +5,5 @@ export const envs = {
 };
 
 export const isDevelopment = () => envs.nodeEnv === "development";
+export const isTSNode = !!(process as any)[Symbol.for("ts-node.register.instance")];
+


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->
**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Display message informing user that command they entered is available only at production environment

**Why?**  <!-- What is this needed for? You can link to an issue. -->
https://github.com/scramjetorg/transform-hub/issues/809

**Usage:**
<!-- Example (if applicable), how to verify (if not covered by tests). -->
- si store
- si scope
- si space

<!--------------------- For non-trivial changes: ---------------------->

**How it works:**
<!-- Share some starting points for understanding the code. -->
- it informs the user that the command is unavailable at the current environment
- prints out the command for user to change envs
- prints out link to scramjet documentation

**Testing:**
set cli to development environment to see new errors:
`si c set env development`
To test how it will work when working with 'si' cli
- `Yarn build`
- `cd dist/cli`
- `npm i . -g`
- `si store`

To test with ts-node:
`ts-node packages/cli/src/bin/index.ts store`

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

