### PR TITLE
Python runner stderr fix for crashlog()

### DIFF
--- a/packages/python-runner/runner.py
+++ b/packages/python-runner/runner.py
@@ -24,6 +24,20 @@ def send_encoded_msg(stream, msg_code, data={}):
     stream.write(f'{message}\r\n'.encode())
 
 
+class StderrRedirector:
+    """A workaround class to write to both sys.stderr and the Instance stderr endpoint."""
+    def __init__(self, stream):
+        self.stream = stream
+
+    def write(self, message):
+        self.stream.write(message)
+        sys.__stderr__.write(message)
+
+    def flush(self):
+        self.stream.flush()
+        sys.__stderr__.flush()
+
+
 class Runner:
     def __init__(self, instance_id, sequence_path, log_setup) -> None:
         self.instance_id = instance_id
@@ -81,7 +95,7 @@ class Runner:
 
     def connect_stdio(self):
         sys.stdout = codecs.getwriter('utf-8')(self.streams[CC.STDOUT])
-        sys.stderr = codecs.getwriter('utf-8')(self.streams[CC.STDERR])
+        sys.stderr = StderrRedirector(codecs.getwriter('utf-8')(self.streams[CC.STDERR]))
         sys.stdin = Stream.read_from(self.streams[CC.STDIN]).decode('utf-8')
         # pretend to have API compatibiliy
         sys.stdout.flush = lambda: True


### PR DESCRIPTION
**What?**  
A custom, simple class to write to 2 _stderr_ channels (explained down below).

**Why?**  
Currently, Python runner **does not** produce errors to [Crashlog()](https://github.com/scramjetorg/transform-hub/blob/4284ddded385f980650543846346a85a1b92fcb4/packages/adapters/src/kubernetes-instance-adapter.ts#L207), but only and only to `si inst stderr`, so the aim is to capture and redirect errors from stderr to both the process's stderr and the Instance's stderr endpoint (so that they are shown in both crashlog and inst stderr).

**Usage:**  
You need to build, and use a custom runner-py docker image:
1. Clone this pr:D
2. `docker build --pull --rm -f "packages/python-runner/Dockerfile" -t runner:v1 "./"`
3. `yarn start:dev --runner-py-image=runner:v1`
4. Deploy any Python Sequence  that produces an exception, example Sequence: **[crash-py.tar.gz](https://github.com/scramjetorg/transform-hub/files/11946205/crash-py.tar.gz)**.
   `si seq deploy crash-py.tar.gz`

5. Verify that you can see the Exception message both in **Transform Hub's Crashlog** and **Instance's stderr** (as shown below):  
![crashlog](https://github.com/scramjetorg/transform-hub/assets/63969229/9ca17b99-4ed6-4464-bd87-f5e4386574db)


**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

https://app.clickup.com/t/24308805/VDM-993
