### PR TITLE
option to revoke all keys using --all flag

### DIFF
--- a/packages/cli/src/lib/commands/sequence.ts
+++ b/packages/cli/src/lib/commands/sequence.ts
@@ -183,12 +183,12 @@ export const sequence: CommandDefinition = (program) => {
         .description("Removes the Sequence from the Hub")
         .action(async (id: string, { force }) => {
             await sequenceDelete(id, { force }).then(
-                (res => { displayObject(res, profileManager.getProfileConfig().format); }),
-                (error => {
+                res => { displayObject(res, profileManager.getProfileConfig().format); },
+                error => {
                     displayError(
                         JSON.parse(error?.body || { body: "Unknown error" })
                     );
-                })
+                }
             );
         });
 

--- a/packages/middleware-api-client/src/middleware-client.ts
+++ b/packages/middleware-api-client/src/middleware-client.ts
@@ -2,6 +2,7 @@
 import { ClientProvider, ClientUtils } from "@scramjet/client-utils";
 import { ManagerClient } from "@scramjet/manager-api-client";
 import { MWRestAPI, MMRestAPI } from "@scramjet/types";
+import { GetAccessKeysResponse } from "@scramjet/types/src/rest-api-multi-manager";
 
 /**
  * Middleware client.
@@ -77,5 +78,19 @@ export class MiddlewareClient implements ClientProvider {
                 "x-revoke": accessKey
             }
         });
+    }
+    async revokeAllAccessKeys(spaceId: string, apiKeys: GetAccessKeysResponse)
+        : Promise<{message:string, keysRevoked: number}> {
+        for (const key of apiKeys.accessKeys) {
+            try {
+                await this.revokeAccessKey(spaceId, key.created.toString());
+            } catch (_e) {
+                throw new Error("Unable to revoke access keys");
+            }
+        }
+        return {
+            message: "Keys successfully revoked",
+            keysRevoked: apiKeys.accessKeys.length
+        };
     }
 }

--- a/packages/types/src/rest-api-multi-manager/access-key.ts
+++ b/packages/types/src/rest-api-multi-manager/access-key.ts
@@ -1,4 +1,6 @@
 export type GetAccessKeysResponse = {
-    created: number;
-    description?: string;
-}[];
+    accessKeys: {
+        created: number;
+        description: string;
+    }[]
+}


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Cli command that allows revoking all known space keys at once without providing them

**Why?**  <!-- What is this needed for? You can link to an issue. -->
https://github.com/scramjetorg/transform-hub/issues/892

**Usage:**
<!-- Example (if applicable), how to verify (if not covered by tests). -->
- si space access revoke --all
- ts-node  packages/cli/src/bin/index.ts space access revoke --all
-

**Clickup Task:** <!-- Paste corresponding link to a clickup task -->
https://app.clickup.com/t/24308805/VDM-1264

<!--------------------- For non-trivial changes: ---------------------->

**How it works:**
<!-- Share some starting points for understanding the code. -->
-
-
-

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

