### PR TITLE
display space version

### DIFF
--- a/packages/cli/src/lib/commands/space.ts
+++ b/packages/cli/src/lib/commands/space.ts
@@ -13,7 +13,6 @@ import { displayProdOnlyMsg } from "../helpers/messages";
  */
 export const space: CommandDefinition = (program) => {
     const isProdEnv = isProductionEnv(profileManager.getProfileConfig().env);
-    const mwClient = getMiddlewareClient();
 
     if (!isProdEnv) {
         program.command("space", { hidden: true })
@@ -21,6 +20,7 @@ export const space: CommandDefinition = (program) => {
 
         return;
     }
+    const mwClient = getMiddlewareClient();
 
     const spaceCmd = program
         .command("space")


### PR DESCRIPTION
Display version of a manager using CLI command
- `si space version`
- `ts-node packages/cli/src/bin/index.ts hub version`
**Clickup Task:** <!-- Paste corresponding link to a clickup task -->
https://app.clickup.com/t/24308805/VDM-1313


**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

