### PR TITLE
GPU in Python Runner (docker)

### DIFF
--- a/packages/adapters/src/docker-instance-adapter.ts
+++ b/packages/adapters/src/docker-instance-adapter.ts
@@ -210,7 +210,8 @@ IComponent {
             envs,
             autoRemove: true,
             maxMem: config.container.maxMem,
-            networkMode: networkSetup.network
+            networkMode: networkSetup.network,
+            gpu: this.limits.gpu
         });
 
         this.crashLogStreams = Promise.all(([streams.stdout, streams.stderr] as Readable[]).map(streamToString));

--- a/packages/adapters/src/dockerode-docker-helper.ts
+++ b/packages/adapters/src/dockerode-docker-helper.ts
@@ -103,7 +103,8 @@ export class DockerodeDockerHelper implements IDockerHelper {
             command?: string[],
             publishAllPorts: boolean,
             labels: { [key: string]: string },
-            networkMode?: string
+            networkMode?: string,
+            gpu?: boolean
         }
     ): Promise<DockerContainer> {
         containerCfg.ports = { ...containerCfg.ports };
@@ -129,6 +130,16 @@ export class DockerodeDockerHelper implements IDockerHelper {
             },
             Labels: containerCfg.labels || {},
         };
+
+        if (containerCfg.gpu === true) {
+            config.HostConfig!.DeviceRequests = [
+                {
+                    Count: -1,
+                    Driver: "nvidia",
+                    Capabilities: [["gpu"]],
+                },
+            ];
+        }
 
         if (containerCfg.command) {
             config.Cmd = [...containerCfg.command];
@@ -317,7 +328,8 @@ export class DockerodeDockerHelper implements IDockerHelper {
                 command: config.command,
                 labels: config.labels || {},
                 publishAllPorts: config.publishAllPorts || false,
-                networkMode: config.networkMode
+                networkMode: config.networkMode,
+                gpu: config.gpu
             }
         );
         // ------

--- a/packages/adapters/src/types.ts
+++ b/packages/adapters/src/types.ts
@@ -118,6 +118,8 @@ export type DockerAdapterRunConfig = {
     },
 
     networkMode?: string,
+
+    gpu?: boolean;
 };
 
 /**
@@ -211,7 +213,8 @@ export interface IDockerHelper {
             labels: {
                 [key: string]: string
             },
-            networkMode?: string
+            networkMode?: string,
+            gpu: boolean
         }
     ) => Promise<DockerContainer>;
 

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -186,7 +186,8 @@ export class CSIController extends TypedEmitter<Events> {
         this.inputTopic = payload.inputTopic;
         this.hostProxy = hostProxy;
         this.limits = {
-            memory: payload.limits?.memory || sthConfig.docker.runner.maxMem
+            memory: payload.limits?.memory || sthConfig.docker.runner.maxMem,
+            gpu: payload.limits?.gpu
         };
 
         this.instanceLifetimeExtensionDelay = +sthConfig.timings.instanceLifetimeExtensionDelay;

--- a/packages/python-runner/Dockerfile-tf-gpu
+++ b/packages/python-runner/Dockerfile-tf-gpu
@@ -1,0 +1,29 @@
+FROM tensorflow/tensorflow:latest-gpu as addons
+
+ENV PACKAGE_DIR=/package \
+    HUB_DIR=/opt/transform-hub
+
+ENV PYTHONPATH "${PYTHONPATH}:${PACKAGE_DIR}/__pypackages__"
+
+RUN groupadd -g 1200 runner \
+    && useradd -g 1200 -u 1200 -m -d ${HUB_DIR} -s /bin/false runner \
+    && mkdir -p ${PACKAGE_DIR} \
+    && chown runner:runner ${PACKAGE_DIR}
+
+RUN apt-get update \
+    && apt-get install -y git gosu tini --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY packages/python-runner/*.py ./
+COPY packages/python-runner/requirements.txt ./requirements.txt
+COPY packages/python-runner/docker-entrypoint.sh /usr/local/bin/
+COPY packages/runner/unpack.sh /usr/local/bin/
+COPY packages/runner/wait-for-sequence-and-start.sh /usr/local/bin/
+
+RUN pip install -r requirements.txt
+RUN pip install GPUtil numpy
+
+ENTRYPOINT [ "/usr/bin/tini", "--", "docker-entrypoint.sh" ]
+CMD [ "start-runner" ]
+
+

--- a/packages/python-runner/README.md
+++ b/packages/python-runner/README.md
@@ -2,6 +2,30 @@
 
 This package executes sequences written in Python and provides control mechanisms to them.
 
+# Docker Images
+
+## Python Base Image
+
+Our Python base image contains only the necessary libraries to operate. It's perfect for those who need a lightweight image for running Sequences written in Python.
+
+### TensorFlow GPU Image
+
+Our TensorFlow image enables the use of GPU, which is ideal for intensive computations such as machine learning.
+
+### How to Use
+
+Specify python docker image used by Instances when starting `sth`
+
+```
+sth --runner-py-image <image>
+```
+
+To take advantage of the GPU features, you need to run Sequence with the appropriate limits. For example:
+
+```
+si seq start --limits "{\"gpu\": true}
+```
+
 ## Scramjet Transform Hub
 
 This package is part of [Scramjet Transform Hub](https://www.npmjs.org/package/@scramjet/sth).

--- a/packages/python-runner/package.json
+++ b/packages/python-runner/package.json
@@ -8,7 +8,8 @@
     "build:only": "pip3 install --upgrade -r requirements.txt --target dist/__pypackages__",
     "build": "yarn build:only",
     "clean": "rm -rf dist/",
-    "build:docker": "docker build -t scramjetorg/runner-py:$(git rev-parse HEAD) -f Dockerfile ../../"
+    "build:docker": "docker build -t scramjetorg/runner-py:$(git rev-parse HEAD) -f Dockerfile ../../",
+    "build:docker-tf": "docker build -t scramjetorg/runner-py-tf:$(git rev-parse HEAD) -f Dockerfile-tf-gpu ../../"
   },
   "assets": [
     "hardcoded_magic_values.py",

--- a/packages/types/src/instance-limits.ts
+++ b/packages/types/src/instance-limits.ts
@@ -1,3 +1,4 @@
 export type InstanceLimits = {
-    memory?: number
+    memory?: number;
+    gpu?: boolean;
 }


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Start Runner container with GPU access enabled.

**Why?**  <!-- What is this needed for? You can link to an issue. -->
ML

**Usage:**
``` 
cd packages/python-runner
yarn build:docker-tf
```

```
sth --runner-py-image scramjetorg/runner-py-tf:5daaf8ea450d90e7b969be42e2d67c06c253b093
```

```
si seq send <SEQ_DIR>
si seq start - --limits "{\"gpu\": true}"
```

```
si seq deploy <SEQ_DIR>--limits "{\"gpu\": true}"
```

**Clickup Task:** <!-- Paste corresponding link to a clickup task -->
https://app.clickup.com/t/24308805/VDM-1364
https://app.clickup.com/t/862k8pzhh

<!--------------------- For non-trivial changes: ---------------------->

**How it works:**
<!-- Share some starting points for understanding the code. -->
https://docs.docker.com/compose/gpu-support/#enabling-gpu-access-to-service-containers

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

