### PR TITLE
Fix CLI not to read space state when it's not needed

### DIFF
--- a/packages/cli/src/bin/index.ts
+++ b/packages/cli/src/bin/index.ts
@@ -3,41 +3,15 @@
 
 import commander from "commander";
 import completionMixin, { ComplitingCommand } from "commander-completion";
-import { ClientUtils } from "@scramjet/client-utils";
 
 import { errorHandler } from "../lib/errorHandler";
 import { commands } from "../lib/commands/index";
-import { setPlatformDefaults } from "../lib/platform";
-import { initConfig, profileManager } from "../lib/config";
+import { initConfig } from "../lib/config";
 import { initPaths } from "../lib/paths";
-import { configEnv, isProductionEnv } from "../types";
 import * as dns from "dns";
 
 const CommandClass = completionMixin(commander).Command;
-const profileConfig = profileManager.getProfileConfig();
 const program = new CommandClass() as ComplitingCommand;
-
-const platformRequirementsValid = (token: string, env: configEnv, middlewareApiUrl: string) =>
-    token &&
-    isProductionEnv(env) &&
-    middlewareApiUrl &&
-    !process.argv.includes((program as any)._helpShortFlag) &&
-    !process.argv.includes((program as any)._helpLongFlag);
-
-const initPlatform = async () => {
-    const { token, env, middlewareApiUrl } = profileConfig.get();
-
-    /**
-     * Set the default values for platform only when all required settings
-     * are provided in the profile configuration.
-     * Do not set the default platform values when displaying the help commands.
-     */
-    if (platformRequirementsValid(token, env, middlewareApiUrl)) {
-        ClientUtils.setDefaultHeaders({ Authorization: `Bearer ${token}`, });
-
-        await setPlatformDefaults();
-    }
-};
 
 /**
  * Start commander using defined config {@link Apple.seeds}
@@ -50,7 +24,6 @@ const initPlatform = async () => {
 
     initPaths();
     initConfig();
-    await initPlatform();
 
     commands.forEach((command) => command(program));
 

--- a/packages/cli/src/lib/commands/hub.ts
+++ b/packages/cli/src/lib/commands/hub.ts
@@ -3,7 +3,7 @@ import { CommandDefinition, isProductionEnv } from "../../types";
 import { getHostClient } from "../common";
 import { profileManager, sessionConfig } from "../config";
 import { displayEntity, displayObject, displayStream } from "../output";
-import { getMiddlewareClient } from "../platform";
+import { getMiddlewareClient, initPlatform } from "../platform";
 
 /**
  * Initializes `hub` command.
@@ -23,6 +23,7 @@ export const hub: CommandDefinition = (program) => {
     if (isProductionEnv(profileConfig.env)) {
         hubCmd
             .command("use")
+            .hook("preAction", initPlatform)
             .argument("<name|id>")
             .description("Specify the default Hub you want to work with, all subsequent requests will be sent to this Hub")
             .action(async (id: string) => {
@@ -42,6 +43,7 @@ export const hub: CommandDefinition = (program) => {
     if (isProductionEnv(profileConfig.env)) {
         hubCmd
             .command("list")
+            .hook("preAction", initPlatform)
             .alias("ls")
             .description("List all the Hubs in the default space")
             .action(async () => {
@@ -61,6 +63,7 @@ export const hub: CommandDefinition = (program) => {
     if (isProductionEnv(profileConfig.env)) {
         hubCmd
             .command("info")
+            .hook("preAction", initPlatform)
             .description("Display info about the default Hub")
             .action(async () => {
                 const { lastSpaceId: space, lastHubId: id } = sessionConfig.get();

--- a/packages/cli/src/lib/commands/hub.ts
+++ b/packages/cli/src/lib/commands/hub.ts
@@ -15,6 +15,7 @@ export const hub: CommandDefinition = (program) => {
 
     const hubCmd = program
         .command("hub")
+        .hook("preAction", initPlatform)
         .addHelpCommand(false)
         .configureHelp({ showGlobalOptions: true })
         .usage("[command] [options...]")
@@ -23,7 +24,6 @@ export const hub: CommandDefinition = (program) => {
     if (isProductionEnv(profileConfig.env)) {
         hubCmd
             .command("use")
-            .hook("preAction", initPlatform)
             .argument("<name|id>")
             .description("Specify the default Hub you want to work with, all subsequent requests will be sent to this Hub")
             .action(async (id: string) => {
@@ -43,7 +43,6 @@ export const hub: CommandDefinition = (program) => {
     if (isProductionEnv(profileConfig.env)) {
         hubCmd
             .command("list")
-            .hook("preAction", initPlatform)
             .alias("ls")
             .description("List all the Hubs in the default space")
             .action(async () => {
@@ -63,7 +62,6 @@ export const hub: CommandDefinition = (program) => {
     if (isProductionEnv(profileConfig.env)) {
         hubCmd
             .command("info")
-            .hook("preAction", initPlatform)
             .description("Display info about the default Hub")
             .action(async () => {
                 const { lastSpaceId: space, lastHubId: id } = sessionConfig.get();

--- a/packages/cli/src/lib/commands/instance.ts
+++ b/packages/cli/src/lib/commands/instance.ts
@@ -6,6 +6,7 @@ import { getInstanceId, profileManager, sessionConfig } from "../config";
 import { displayEntity, displayObject, displayStream } from "../output";
 import { ClientError } from "@scramjet/client-utils";
 import { Option } from "commander";
+import { initPlatform } from "../platform";
 /**
  * Initializes `instance` command.
  *
@@ -14,6 +15,7 @@ import { Option } from "commander";
 export const instance: CommandDefinition = (program) => {
     const instanceCmd = program
         .command("instance [command]")
+        .hook("preAction", initPlatform)
         .addHelpCommand(false)
         .configureHelp({ showGlobalOptions: true })
         .alias("inst")

--- a/packages/cli/src/lib/commands/sequence.ts
+++ b/packages/cli/src/lib/commands/sequence.ts
@@ -12,6 +12,7 @@ import { isDevelopment } from "../../utils/envs";
 import { resolve } from "path";
 import { sequenceDelete, sequencePack, sequenceParseArgs, sequenceSendPackage, sequenceStart } from "../helpers/sequence";
 import { ClientError } from "@scramjet/client-utils";
+import { initPlatform } from "../platform";
 
 /**
  * Initializes `sequence` command.
@@ -21,6 +22,7 @@ import { ClientError } from "@scramjet/client-utils";
 export const sequence: CommandDefinition = (program) => {
     const sequenceCmd = program
         .command("sequence")
+        .hook("preAction", initPlatform)
         .addHelpCommand(false)
         .configureHelp({ showGlobalOptions: true })
         .alias("seq")

--- a/packages/cli/src/lib/commands/space.ts
+++ b/packages/cli/src/lib/commands/space.ts
@@ -4,7 +4,7 @@ import { PostDisconnectPayload } from "@scramjet/types/src/rest-api-manager";
 import { CommandDefinition, isProductionEnv } from "../../types";
 import { profileManager, sessionConfig } from "../config";
 import { displayObject, displayStream } from "../output";
-import { getMiddlewareClient } from "../platform";
+import { getMiddlewareClient, initPlatform } from "../platform";
 import { displayProdOnlyMsg } from "../helpers/messages";
 import { Option } from "commander";
 import { isIdString } from "@scramjet/utility";
@@ -33,6 +33,7 @@ export const space: CommandDefinition = (program) => {
 
     const spaceCmd = program
         .command("space")
+        .hook("preAction", initPlatform)
         .addHelpCommand(false)
         .alias("spc")
         .usage("[command] [options...]")

--- a/packages/cli/src/lib/commands/store.ts
+++ b/packages/cli/src/lib/commands/store.ts
@@ -3,7 +3,7 @@ import { getReadStreamFromFile } from "../common";
 import { profileManager, sessionConfig } from "../config";
 import { displayProdOnlyMsg } from "../helpers/messages";
 import { displayObject } from "../output";
-import { getMiddlewareClient } from "../platform";
+import { getMiddlewareClient, initPlatform } from "../platform";
 
 /**
  * Initializes `store` command.
@@ -22,6 +22,7 @@ export const store: CommandDefinition = (program) => {
 
     const storeCmd = program
         .command("store")
+        .hook("preAction", initPlatform)
         .addHelpCommand(false)
         .configureHelp({ showGlobalOptions: true, developersOnly: true } as ExtendedHelpConfiguration)
         .usage("[command] [options...]")

--- a/packages/cli/src/lib/commands/topic.ts
+++ b/packages/cli/src/lib/commands/topic.ts
@@ -4,6 +4,7 @@ import { getHostClient, getReadStreamFromFile } from "../common";
 import { profileManager } from "../config";
 import { displayEntity, displayStream } from "../output";
 import { Option, Argument } from "commander";
+import { initPlatform } from "../platform";
 
 const validateTopicName = (topicName: string) => {
     if (topicName.match(/^[\\a-zA-Z0-9_+-]+$/)) {
@@ -27,6 +28,7 @@ export const topic: CommandDefinition = (program) => {
 
     const topicCmd = program
         .command("topic")
+        .hook("preAction", initPlatform)
         .addHelpCommand(false)
         .configureHelp({ showGlobalOptions: true })
         .usage("[command] [options...]")

--- a/packages/cli/src/lib/platform/common.ts
+++ b/packages/cli/src/lib/platform/common.ts
@@ -1,6 +1,9 @@
 import { MiddlewareClient } from "@scramjet/middleware-api-client";
 import { sessionConfig, profileManager } from "../config";
 import { displayError, displayMessage } from "../output";
+import { ClientUtils } from "@scramjet/client-utils";
+import { configEnv, isProductionEnv } from "../../types";
+import { Command } from "commander";
 
 /**
  * Returns host client for host pointed by command options.
@@ -69,5 +72,33 @@ export const setPlatformDefaults = async () => {
     } catch (_) {
         displayError("Unable to set platform defaults\n");
         return false;
+    }
+};
+
+const profileConfig = profileManager.getProfileConfig();
+const platformRequirementsValid = (
+    program: Command & { _helpShortFlag?: any, _helpLongFlag?: any },
+    token: string,
+    env: configEnv,
+    middlewareApiUrl: string
+) =>
+    token &&
+    isProductionEnv(env) &&
+    middlewareApiUrl &&
+    !process.argv.includes(program._helpShortFlag) &&
+    !process.argv.includes(program._helpLongFlag);
+
+export const initPlatform = async (program: Command) => {
+    const { token, env, middlewareApiUrl } = profileConfig.get();
+
+    /**
+     * Set the default values for platform only when all required settings
+     * are provided in the profile configuration.
+     * Do not set the default platform values when displaying the help commands.
+     */
+    if (platformRequirementsValid(program, token, env, middlewareApiUrl)) {
+        ClientUtils.setDefaultHeaders({ Authorization: `Bearer ${token}`, });
+
+        await setPlatformDefaults();
     }
 };

--- a/packages/cli/src/lib/platform/common.ts
+++ b/packages/cli/src/lib/platform/common.ts
@@ -97,6 +97,7 @@ const platformRequirementsValid = (
     !process.argv.includes(program._helpLongFlag);
 
 export const initPlatform = async (program: Command) => {
+    if (!isProductionEnv(profileConfig.env)) return;
     const { token, env, middlewareApiUrl } = profileConfig.get();
 
     /**

--- a/packages/cli/src/lib/platform/common.ts
+++ b/packages/cli/src/lib/platform/common.ts
@@ -1,5 +1,5 @@
 import { MiddlewareClient } from "@scramjet/middleware-api-client";
-import { sessionConfig, profileManager } from "../config";
+import { sessionConfig, profileManager, ProfileConfig } from "../config";
 import { displayError, displayMessage } from "../output";
 import { ClientUtils } from "@scramjet/client-utils";
 import { configEnv, isProductionEnv } from "../../types";
@@ -40,7 +40,15 @@ export const getMiddlewareClient = (): MiddlewareClient => {
 
 export const setPlatformDefaults = async () => {
     const middlewareClient = getMiddlewareClient();
-    const managers = await middlewareClient.getManagers();
+    const profileConfig = profileManager.getProfileConfig();
+    let managers;
+
+    try {
+        managers = await middlewareClient.getManagers();
+    } catch (_e) {
+        (profileConfig as ProfileConfig).setEnv("development");
+        throw new Error("Unable to get Space - forbidden access. Setting env to development...");
+    }
 
     const { lastSpaceId, lastHubId } = sessionConfig.get();
 


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->

Fixes CLI not to check space connectivity on every single setting.

**Why?**  <!-- What is this needed for? You can link to an issue. -->

If you're changing your config, there's no point in checking if the space is connected

**Usage:**
<!-- Example (if applicable), how to verify (if not covered by tests). -->
-
-
-

**Clickup Task:** <!-- Paste corresponding link to a clickup task -->


<!--------------------- For non-trivial changes: ---------------------->

**How it works:**
<!-- Share some starting points for understanding the code. -->
-
-
-

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

