### PR TITLE
Monitoring Server

### DIFF
--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -22,7 +22,7 @@
     "@scramjet/api-server": "^0.35.3",
     "@scramjet/load-check": "^0.35.3",
     "@scramjet/model": "^0.35.3",
-    "@scramjet/monitoring-server": "^0.35.3",
+    "@scramjet/module-loader": "^0.35.3",
     "@scramjet/obj-logger": "^0.35.3",
     "@scramjet/sth-config": "^0.35.3",
     "@scramjet/symbols": "^0.35.3",

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -22,6 +22,7 @@
     "@scramjet/api-server": "^0.35.3",
     "@scramjet/load-check": "^0.35.3",
     "@scramjet/model": "^0.35.3",
+    "@scramjet/monitoring-server": "^0.35.3",
     "@scramjet/obj-logger": "^0.35.3",
     "@scramjet/sth-config": "^0.35.3",
     "@scramjet/symbols": "^0.35.3",

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -13,6 +13,7 @@ import {
     IMonitoringServerConstructor,
     IObjectLogger,
     LogLevel,
+    MonitoringServerConfig,
     NextCallback,
     OpResponse,
     ParsedMessage,
@@ -224,7 +225,9 @@ export class Host implements IComponent {
         }
 
         if (sthConfig.monitorgingServer) {
-            this.startMonitoringServer(sthConfig.monitorgingServer.port).then(() => {}, (e) => {
+            this.startMonitoringServer(sthConfig.monitorgingServer).then((res) => {
+                this.logger.info("MonitoringServer started", res);
+            }, (e) => {
                 throw new Error(e);
             });
         }
@@ -261,17 +264,17 @@ export class Host implements IComponent {
         }
     }
 
-    private async startMonitoringServer(port: number): Promise<void> {
+    private async startMonitoringServer(config: MonitoringServerConfig): Promise<MonitoringServerConfig> {
         const { MonitoringServer } = await loadModule<{ MonitoringServer: IMonitoringServerConstructor }>({ name: "@scramjet/monitoring-server" });
 
-        this.logger.info("Starting monitoring server on port", port);
+        this.logger.info("Starting monitoring server with config", config);
 
         const monitoringServer = new MonitoringServer({
-            port,
+            ...config,
             check: async () => !!await this.loadCheck.getLoadCheck()
         });
 
-        monitoringServer.start();
+        return monitoringServer.start();
     }
 
     getId() {

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -259,11 +259,7 @@ export class Host implements IComponent {
         this.monitoringServer = new MonitoringServer({ port, validator: async () => {
             return await this.loadCheck.getLoadCheck();
         } });
-        try {
-            this.monitoringServer.startServer();
-        } catch (e: any) {
-            this.logger.error("unable to start monitoring server", e.message);
-        }
+        this.monitoringServer.startServer();
     }
     getId() {
         let id = this.config.host.id;

--- a/packages/module-loader/.eslintrc.js
+++ b/packages/module-loader/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+    ignorePatterns: [".eslintrc.js"],
+    parserOptions:{
+        project: "./tsconfig.json",
+        tsconfigRootDir: __dirname
+    }
+};

--- a/packages/module-loader/.nycrc.json
+++ b/packages/module-loader/.nycrc.json
@@ -1,0 +1,7 @@
+{
+    "all": true,
+    "include": [
+        "dist/**/*"
+    ],
+    "reporter": ["lcovonly", "text"]
+}

--- a/packages/module-loader/package.json
+++ b/packages/module-loader/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@scramjet/module-loader",
+  "version": "0.35.3",
+  "description": "Scramjet Module Loader",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "../../scripts/build-all.js --config-name=tsconfig.build.json --copy-dist",
+    "build:docs": "typedoc",
+    "clean": "rm -rf ./dist .bic_cache",
+    "watch": "tsc -b --watch",
+    "test": "npm run test:ava",
+    "test:ava": "# nyc ava"
+  },
+  "dependencies": {
+    "@scramjet/obj-logger": "^0.35.3"
+  },
+  "devDependencies": {
+    "@scramjet/types": "^0.35.3",
+    "@types/node": "15.12.5",
+    "ava": "^3.15.0",
+    "ts-node": "^10.9.1",
+    "nyc": "^15.1.0",
+    "typedoc": "^0.23.17",
+    "typedoc-plugin-markdown": "^3.13.6",
+    "typescript": "~4.7.4"
+  },
+  "ava": {
+    "extensions": [
+      "ts"
+    ],
+    "files": [
+      "**/*.spec.ts"
+    ],
+    "require": [
+      "ts-node/register"
+    ]
+  },
+  "author": "Scramjet <open-source@scramjet.org>",
+  "license": "AGPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scramjetorg/monitoring-server.git"
+  }
+}

--- a/packages/module-loader/src/index.ts
+++ b/packages/module-loader/src/index.ts
@@ -1,0 +1,28 @@
+import { ObjLogger } from "@scramjet/obj-logger";
+import { ModuleLoaderOpts } from "@scramjet/types";
+
+export const logger = new ObjLogger("ModuleLoader");
+export async function loadModule(opts: ModuleLoaderOpts): Promise<any> {
+    logger.info("Loading module", opts.name);
+
+    if (!opts.name) {
+        throw new Error("Name missing");
+    }
+
+    let module: ClassDecorator | null;
+
+    const heap = process.memoryUsage().heapUsed;
+
+    try {
+        module = await import(opts.name);
+
+        logger.debug("Memory diff after module load", heap - process.memoryUsage().heapUsed);
+
+        return module!;
+    } catch (e) {
+        logger.error(`Error loading module ${name}`);
+
+        throw new Error(`Error loading module ${name}`);
+    }
+}
+

--- a/packages/module-loader/src/index.ts
+++ b/packages/module-loader/src/index.ts
@@ -2,14 +2,14 @@ import { ObjLogger } from "@scramjet/obj-logger";
 import { ModuleLoaderOpts } from "@scramjet/types";
 
 export const logger = new ObjLogger("ModuleLoader");
-export async function loadModule(opts: ModuleLoaderOpts): Promise<any> {
+export async function loadModule<T>(opts: ModuleLoaderOpts): Promise<T> {
     logger.info("Loading module", opts.name);
 
     if (!opts.name) {
         throw new Error("Name missing");
     }
 
-    let module: ClassDecorator | null;
+    let module: T;
 
     const heap = process.memoryUsage().heapUsed;
 

--- a/packages/module-loader/tsconfig.build.json
+++ b/packages/module-loader/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/module-loader/tsconfig.json
+++ b/packages/module-loader/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "extends": "../../tsconfig.base.json",
+    "include": [
+        "./src",
+        "./test"
+    ],
+    "exclude": [
+        "node_modules"
+    ],
+    "typedocOptions": {
+        "entryPoints": [
+            "src/index.ts"
+        ],
+        "out": "../../docs/multi-manager-api-client",
+        "plugin": "typedoc-plugin-markdown",
+        "excludePrivate": "true",
+        "gitRevision": "HEAD",
+        "sort": "alphabetical"
+    }
+}

--- a/packages/monitoring-server/.eslintrc.js
+++ b/packages/monitoring-server/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+    ignorePatterns: [".eslintrc.js"],
+    parserOptions:{
+        project: "./tsconfig.json",
+        tsconfigRootDir: __dirname
+    }
+};

--- a/packages/monitoring-server/.nycrc.json
+++ b/packages/monitoring-server/.nycrc.json
@@ -1,0 +1,7 @@
+{
+    "all": true,
+    "include": [
+        "dist/**/*"
+    ],
+    "reporter": ["lcovonly", "text"]
+}

--- a/packages/monitoring-server/package.json
+++ b/packages/monitoring-server/package.json
@@ -9,13 +9,14 @@
     "clean": "rm -rf ./dist .bic_cache",
     "watch": "tsc -b --watch",
     "test": "npm run test:ava",
-    "test:ava": "ava"
+    "test:ava": "# nyc ava"
   },
   "devDependencies": {
     "@scramjet/types": "^0.35.3",
     "@types/node": "15.12.5",
     "ava": "^3.15.0",
     "ts-node": "^10.9.1",
+    "nyc": "^15.1.0",
     "typedoc": "^0.23.17",
     "typedoc-plugin-markdown": "^3.13.6",
     "typescript": "~4.7.4"

--- a/packages/monitoring-server/package.json
+++ b/packages/monitoring-server/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@scramjet/monitoring-server",
+  "version": "0.35.3",
+  "description": "Scramjet Monitoring Server",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "../../scripts/build-all.js --config-name=tsconfig.build.json --copy-dist",
+    "build:docs": "typedoc",
+    "clean": "rm -rf ./dist .bic_cache",
+    "watch": "tsc -b --watch",
+    "test": "npm run test:ava",
+    "test:ava": "ava"
+  },
+  "devDependencies": {
+    "@scramjet/types": "^0.35.3",
+    "@types/node": "15.12.5",
+    "ava": "^3.15.0",
+    "ts-node": "^10.9.1",
+    "typedoc": "^0.23.17",
+    "typedoc-plugin-markdown": "^3.13.6",
+    "typescript": "~4.7.4"
+  },
+  "ava": {
+    "extensions": [
+      "ts"
+    ],
+    "files": [
+      "**/*.spec.ts"
+    ],
+    "require": [
+      "ts-node/register"
+    ]
+  },
+  "author": "Scramjet <open-source@scramjet.org>",
+  "license": "AGPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scramjetorg/monitoring-server.git"
+  }
+}

--- a/packages/monitoring-server/src/index.ts
+++ b/packages/monitoring-server/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./monitoring-server";

--- a/packages/monitoring-server/src/monitoring-server.ts
+++ b/packages/monitoring-server/src/monitoring-server.ts
@@ -1,12 +1,23 @@
 import { createServer } from "http";
-import { IMonitoringServer, MonitoringServerOptions, MonitoringServerValidator as MonitoringServerHealthCheck } from "@scramjet/types";
+import { IMonitoringServer, MonitoringServerOptions, MonitoringServerValidator as MonitoringServerHealthCheck, MonitoringServerConfig } from "@scramjet/types";
 
 export class MonitoringServer implements IMonitoringServer {
     private options: MonitoringServerOptions;
     private checks: MonitoringServerHealthCheck[] = [];
+    private running = false;
 
     constructor(options: MonitoringServerOptions) {
+        if (!Number.isInteger(options.port) || (options.port < 0 || options.port > 65535)) {
+            throw Error(`Invalid port number ${options.port}`);
+        }
+
         this.options = options;
+
+        this.options.path ||= "healtz";
+
+        if ((/!^[a-zA-Z0-9\-_~:.@!$&'()*+,;=%]*$/).test(this.options.path)) {
+            throw Error(`Invalid path: ${this.options.path}`);
+        }
 
         if (Array.isArray(options.check)) {
             this.checks = options.check;
@@ -21,23 +32,35 @@ export class MonitoringServer implements IMonitoringServer {
         return Promise.all(this.checks.map(v => v())).then(res => res.every(v => v === true), () => false);
     }
 
-    start() {
-        createServer(async (req, res) => {
-            if (req.url === "/healtz" && req.method === "GET") {
-                const healtz = await this.handleHealtzRequest();
+    start(): Promise<MonitoringServerConfig> {
+        return new Promise<MonitoringServerConfig>((resolve, reject) => {
+            if (this.running) reject("MonitoringServer already running");
 
-                res.setHeader("Content-type", "text/plain");
+            createServer(async (req, res) => {
+                if (req.url === `/${this.options.path}` && req.method === "GET") {
+                    const healtz = await this.handleHealtzRequest();
 
-                if (healtz) {
-                    res.statusCode = 200;
-                    res.end("ok");
+                    res.setHeader("Content-type", "text/plain");
 
-                    return;
+                    if (healtz) {
+                        res.statusCode = 200;
+                        res.end("ok");
+
+                        return;
+                    }
+
+                    res.statusCode = 500;
+                    res.end();
                 }
+            }).listen(this.options.port, this.options.host, () => {
+                this.running = true;
 
-                res.statusCode = 500;
-                res.end();
-            }
-        }).listen(this.options.port);
+                resolve({
+                    port: this.options.port,
+                    host: this.options.host,
+                    path: this.options.path
+                });
+            });
+        });
     }
 }

--- a/packages/monitoring-server/src/monitoring-server.ts
+++ b/packages/monitoring-server/src/monitoring-server.ts
@@ -1,0 +1,35 @@
+import { createServer } from "http";
+import { IMonitoringServer, MonitoringServerOptions } from "@scramjet/types";
+
+export class MonitoringServer implements IMonitoringServer {
+    private options: MonitoringServerOptions;
+    constructor(options: MonitoringServerOptions) {
+        this.options = options;
+    }
+
+    startServer() {
+        const server = createServer(async (req, res) => {
+            if (req.url === "/healtz" && req.method === "GET") {
+                let ok = true;
+
+                if (this.options.validator) {
+                    ok = await this.options.validator();
+                }
+
+                res.setHeader("Content-type", "text/plain");
+                if (ok) {
+                    res.statusCode = 200;
+                    res.end("ok");
+                } else {
+                    res.statusCode = 500;
+                    res.end();
+                }
+            } else {
+                res.statusCode = 404;
+                res.end();
+            }
+        });
+
+        server.listen(this.options.port);
+    }
+}

--- a/packages/monitoring-server/src/monitoring-server.ts
+++ b/packages/monitoring-server/src/monitoring-server.ts
@@ -13,7 +13,12 @@ export class MonitoringServer implements IMonitoringServer {
                 let ok = true;
 
                 if (this.options.validator) {
-                    ok = await this.options.validator();
+                    try {
+                        ok = await this.options.validator();
+                    } catch (_e) {
+                        res.statusCode = 500;
+                        res.end();
+                    }
                 }
 
                 res.setHeader("Content-type", "text/plain");

--- a/packages/monitoring-server/src/monitoring-server.ts
+++ b/packages/monitoring-server/src/monitoring-server.ts
@@ -2,7 +2,10 @@ import { createServer } from "http";
 import { IMonitoringServer, MonitoringServerOptions } from "@scramjet/types";
 
 export class MonitoringServer implements IMonitoringServer {
+    id = "MonitoringServer";
+
     private options: MonitoringServerOptions;
+
     constructor(options: MonitoringServerOptions) {
         this.options = options;
     }
@@ -22,6 +25,7 @@ export class MonitoringServer implements IMonitoringServer {
                 }
 
                 res.setHeader("Content-type", "text/plain");
+
                 if (ok) {
                     res.statusCode = 200;
                     res.end("ok");

--- a/packages/monitoring-server/tsconfig.build.json
+++ b/packages/monitoring-server/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/monitoring-server/tsconfig.json
+++ b/packages/monitoring-server/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "extends": "../../tsconfig.base.json",
+    "include": [
+        "./src",
+        "./test"
+    ],
+    "exclude": [
+        "node_modules"
+    ],
+    "typedocOptions": {
+        "entryPoints": [
+            "src/index.ts"
+        ],
+        "out": "../../docs/multi-manager-api-client",
+        "plugin": "typedoc-plugin-markdown",
+        "excludePrivate": "true",
+        "gitRevision": "HEAD",
+        "sort": "alphabetical"
+    }
+}

--- a/packages/sth/src/bin/hub.ts
+++ b/packages/sth/src/bin/hub.ts
@@ -71,6 +71,7 @@ const options: OptionValues & STHCommandOptions = program
     .option("--environment-name <name>", "Sets the environment name for telemetry reporting (defaults to SCP_ENV_VALUE env var or 'not-set')")
     .option("--no-telemetry", "Disables telemetry", false)
     .option("--enable-federation-control", "Enables federation control", false)
+    .option("--monitoring-port <monitoring-port>", "Starts monitoring sever on a selected port")
     .parse(process.argv)
     .opts() as STHCommandOptions;
 
@@ -94,7 +95,6 @@ const options: OptionValues & STHCommandOptions = program
     if (!configService.getConfig().tags?.every((t:string) => t.length)) {
         throw new Error("Tags cannot be empty");
     }
-
     configService.update({
         description: options.description,
         customName: options.customName,
@@ -165,6 +165,9 @@ const options: OptionValues & STHCommandOptions = program
         telemetry: {
             status: options.telemetry,
             environment: options.environmentName || process.env.SCP_ENV_VALUE || "not-set"
+        },
+        monitorgingServer: {
+            port: options.monitoringPort
         }
     });
 

--- a/packages/sth/src/bin/hub.ts
+++ b/packages/sth/src/bin/hub.ts
@@ -71,7 +71,10 @@ const options: OptionValues & STHCommandOptions = program
     .option("--environment-name <name>", "Sets the environment name for telemetry reporting (defaults to SCP_ENV_VALUE env var or 'not-set')")
     .option("--no-telemetry", "Disables telemetry", false)
     .option("--enable-federation-control", "Enables federation control", false)
-    .option("--monitoring-port <monitoring-port>", "Starts monitoring sever on a selected port")
+    .option("--healtz-port <healtz-port>", "Starts monitoring sever on a selected port")
+    .option("--healtz-host <healtz-host>", "Starts monitoring sever on a specified interface e.g [\"0.0.0.0\"]. Requires --healtz-port")
+    .option("--healtz-path <healtz-path>", "Exposes monitoring endpoint on specified path. Requires --healtz-port")
+
     .parse(process.argv)
     .opts() as STHCommandOptions;
 
@@ -166,9 +169,11 @@ const options: OptionValues & STHCommandOptions = program
             status: options.telemetry,
             environment: options.environmentName || process.env.SCP_ENV_VALUE || "not-set"
         },
-        monitorgingServer: {
-            port: options.monitoringPort
-        }
+        monitorgingServer: options.healtzPort || options.healtzHost || options.healtzPath ? {
+            port: parseInt(options.healtzPort, 10),
+            host: options.healtzHost,
+            path: options.healtzPath
+        } : undefined
     });
 
     const tips = [

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -20,6 +20,8 @@ export * from "./lifecycle-adapters";
 export * from "./manager-configuration";
 export * from "./message-streams";
 export * from "./messages";
+export * from "./monitoring-server";
+export * from "./module-loader";
 export * from "./object-logger";
 export * from "./op-response";
 export * from "./runner-config";
@@ -54,4 +56,3 @@ export * from "./dto/index";
 
 export * from "./rest-api-error/rest-api-error";
 
-export * from "./monitoring-server";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -53,3 +53,5 @@ export * from "./sequence-adapter";
 export * from "./dto/index";
 
 export * from "./rest-api-error/rest-api-error";
+
+export * from "./monitoring-server";

--- a/packages/types/src/module-loader.ts
+++ b/packages/types/src/module-loader.ts
@@ -1,0 +1,4 @@
+export type ModuleLoaderOpts = {
+    name: string;
+}
+

--- a/packages/types/src/monitoring-server.ts
+++ b/packages/types/src/monitoring-server.ts
@@ -1,11 +1,14 @@
 import { MaybePromise } from "./utils";
 
 export type MonitoringServerOptions = {
-
     port: number,
     validator: MaybePromise<any>;
 }
 
 export interface IMonitoringServer {
     startServer(): void;
+}
+
+export interface IMonitoringServerConstructor {
+    new(opts: MonitoringServerOptions): IMonitoringServer;
 }

--- a/packages/types/src/monitoring-server.ts
+++ b/packages/types/src/monitoring-server.ts
@@ -1,12 +1,14 @@
 import { MaybePromise } from "./utils";
 
+export type MonitoringServerValidator = () => MaybePromise<boolean>;
+
 export type MonitoringServerOptions = {
     port: number,
-    validator: MaybePromise<any>;
+    check?: MonitoringServerValidator | MonitoringServerValidator[];
 }
 
 export interface IMonitoringServer {
-    startServer(): void;
+    start(): void;
 }
 
 export interface IMonitoringServerConstructor {

--- a/packages/types/src/monitoring-server.ts
+++ b/packages/types/src/monitoring-server.ts
@@ -1,14 +1,19 @@
 import { MaybePromise } from "./utils";
 
+export type MonitoringServerConfig = {
+    port: number;
+    host?: string;
+    path?: string;
+}
+
 export type MonitoringServerValidator = () => MaybePromise<boolean>;
 
-export type MonitoringServerOptions = {
-    port: number,
+export type MonitoringServerOptions = MonitoringServerConfig & {
     check?: MonitoringServerValidator | MonitoringServerValidator[];
 }
 
 export interface IMonitoringServer {
-    start(): void;
+    start(): Promise<MonitoringServerConfig>;
 }
 
 export interface IMonitoringServerConstructor {

--- a/packages/types/src/monitoring-server.ts
+++ b/packages/types/src/monitoring-server.ts
@@ -1,0 +1,11 @@
+import { MaybePromise } from "./utils";
+
+export type MonitoringServerOptions = {
+
+    port: number,
+    validator: MaybePromise<any>;
+}
+
+export interface IMonitoringServer {
+    startServer(): void;
+}

--- a/packages/types/src/sth-command-options.ts
+++ b/packages/types/src/sth-command-options.ts
@@ -51,4 +51,5 @@ export type STHCommandOptions = {
     instanceLifetimeExtensionDelay: number;
     environmentName?: string;
     telemetry: TelemetryConfig["status"]
+    monitoringServer: { port: number }
 }

--- a/packages/types/src/sth-configuration.ts
+++ b/packages/types/src/sth-configuration.ts
@@ -269,6 +269,10 @@ export type STHConfiguration = {
     };
 
     telemetry: TelemetryConfig;
+
+    monitorgingServer?: {
+        port: number;
+    }
 }
 
 export type PublicSTHConfiguration = Omit<Omit<Omit<STHConfiguration, "sequencesRoot">, "cpmSslCaPath">, "kubernetes"> & {

--- a/packages/types/src/sth-configuration.ts
+++ b/packages/types/src/sth-configuration.ts
@@ -1,3 +1,4 @@
+import { MonitoringServerConfig } from "./monitoring-server";
 import { LogLevel } from "./object-logger";
 import { TelemetryConfig } from "./telemetry-config";
 
@@ -270,9 +271,7 @@ export type STHConfiguration = {
 
     telemetry: TelemetryConfig;
 
-    monitorgingServer?: {
-        port: number;
-    }
+    monitorgingServer?: MonitoringServerConfig;
 }
 
 export type PublicSTHConfiguration = Omit<Omit<Omit<STHConfiguration, "sequencesRoot">, "cpmSslCaPath">, "kubernetes"> & {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1685,6 +1685,11 @@ ansi-regex@^6.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
   integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
 
+ansi-sequence-parser@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz#e0aa1cdcbc8f8bb0b5bca625aac41f5f056973cf"
+  integrity sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==
+
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -5455,7 +5460,7 @@ json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-jsonc-parser@^3.0.0:
+jsonc-parser@^3.0.0, jsonc-parser@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.0.tgz#31ff3f4c2b9793f89c67212627c51c6394f88e76"
   integrity sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==
@@ -5916,7 +5921,7 @@ map-age-cleaner@^0.1.1, map-age-cleaner@^0.1.3:
   dependencies:
     p-defer "^1.0.0"
 
-marked@^4.0.19:
+marked@^4.0.19, marked@^4.2.12:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"
   integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
@@ -6038,6 +6043,13 @@ minimatch@^5.0.1, minimatch@^5.1.0:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
   integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimatch@^7.1.3:
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-7.4.6.tgz#845d6f254d8f4a5e4fd6baf44d5f10c8448365fb"
+  integrity sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==
   dependencies:
     brace-expansion "^2.0.1"
 
@@ -7723,6 +7735,16 @@ shiki@^0.11.1:
     vscode-oniguruma "^1.6.1"
     vscode-textmate "^6.0.0"
 
+shiki@^0.14.1:
+  version "0.14.4"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.14.4.tgz#2454969b466a5f75067d0f2fa0d7426d32881b20"
+  integrity sha512-IXCRip2IQzKwxArNNq1S+On4KPML3Yyn8Zzs/xRgcgOWIr8ntIK3IKzjFPfjy/7kt9ZMjc+FItfqHRBg8b6tNQ==
+  dependencies:
+    ansi-sequence-parser "^1.1.0"
+    jsonc-parser "^3.2.0"
+    vscode-oniguruma "^1.7.0"
+    vscode-textmate "^8.0.0"
+
 side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
@@ -8590,6 +8612,13 @@ typedoc-plugin-markdown@3.13.6:
   dependencies:
     handlebars "^4.7.7"
 
+typedoc-plugin-markdown@^3.13.6:
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.16.0.tgz#98da250271aafade8b6740a8116a97cd3941abcd"
+  integrity sha512-eeiC78fDNGFwemPIHiwRC+mEC7W5jwt3fceUev2gJ2nFnXpVHo8eRrpC9BLWZDee6ehnz/sPmNjizbXwpfaTBw==
+  dependencies:
+    handlebars "^4.7.7"
+
 typedoc@0.23.17:
   version "0.23.17"
   resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.23.17.tgz#ca644e7ecac78be85cfd556f5436917a4ac76dda"
@@ -8599,6 +8628,16 @@ typedoc@0.23.17:
     marked "^4.0.19"
     minimatch "^5.1.0"
     shiki "^0.11.1"
+
+typedoc@^0.23.17:
+  version "0.23.28"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.23.28.tgz#3ce9c36ef1c273fa849d2dea18651855100d3ccd"
+  integrity sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==
+  dependencies:
+    lunr "^2.3.9"
+    marked "^4.2.12"
+    minimatch "^7.1.3"
+    shiki "^0.14.1"
 
 typescript@~4.7.4:
   version "4.7.4"
@@ -8796,7 +8835,7 @@ verror@^1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vscode-oniguruma@^1.6.1:
+vscode-oniguruma@^1.6.1, vscode-oniguruma@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz#439bfad8fe71abd7798338d1cd3dc53a8beea94b"
   integrity sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==
@@ -8805,6 +8844,11 @@ vscode-textmate@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-6.0.0.tgz#a3777197235036814ac9a92451492f2748589210"
   integrity sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==
+
+vscode-textmate@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-8.0.0.tgz#2c7a3b1163ef0441097e0b5d6389cd5504b59e5d"
+  integrity sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==
 
 walk-up-path@^1.0.0:
   version "1.0.0"
@@ -8943,6 +8987,7 @@ wordwrap@^1.0.0:
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
- Monitoring server package that allows checking health of a process such as STH/ manager
- `ModuleLoader` to load additional modules on demand. Module should be installed manually, for example with: 
`npm i @scramjet/monitoring-server -g` 


**Usage:**
- **Install `@scramjet/monitoring-server` package**.
- Start STH with a flag `--healtz-port 3030`
- make a `GET` request to `/healthz` endpoint (example `curl http://localhost:3030/healtz`)
- Will return `ok` with a status `200` if everything is working well, `500` otherwise.

- Available flags: 
```
  --healtz-port <healtz-port>              Starts monitoring sever on a selected port
  --healtz-host <healtz-host>              Starts monitoring sever on a specified interface e.g ["0.0.0.0"]. Requires --healtz-port
  --healtz-path <healtz-path>              Exposes monitoring endpoint on specified path. Requires --healtz-port
```


**Clickup Task:** <!-- Paste corresponding link to a clickup task -->
https://app.clickup.com/t/24308805/VDM-1350

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

