### PR TITLE
Fix runner exit

### DIFF
--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -205,7 +205,7 @@ export class CSIController extends TypedEmitter<Events> {
             new PassThrough(),
             new PassThrough(),
             new PassThrough(),
-            new PassThrough({ highWaterMark: 0 }),
+            new PassThrough(),
             new PassThrough(),
         ];
     }


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Revert change causing runner to not exit on Instance end.

**How it works:**
`3dcc5640df486b350441e83c80d21b311c0ac2e4` introduced `highWaterMark: 0` on output stream in CSIC:

```
845eb62b01877ccc4f233e6f81eda9b574292185    Add Topic Router                                

2023-09-22T08:18:10.138Z TRACE CSIController [73ab476d] Got message: SEQUENCE_COMPLETED. 
2023-09-22T08:18:10.136Z DEBUG Runner [73ab476d] Sequence stream ended 
2023-09-22T08:18:10.137Z TRACE Runner [73ab476d] Sequence completed. Waiting 10000ms with exit. 
2023-09-22T08:18:10.139Z DEBUG SocketServer Channel [73ab476d-06de-4825-9e3d-44120e823fb6:6] ended 
2023-09-22T08:18:16.822Z INFO  Host List Instances 
2023-09-22T08:18:16.824Z DEBUG Host Request [ 'date: 2023-09-22T08:18:16.823Z, method: GET, url: /api/v1/instances, status: 200' ]
2023-09-22T08:18:20.341Z DEBUG SocketServer Channel [73ab476d-06de-4825-9e3d-44120e823fb6:0] ended 
2023-09-22T08:18:20.342Z DEBUG SocketServer Channel [73ab476d-06de-4825-9e3d-44120e823fb6:1] ended 
2023-09-22T08:18:20.342Z DEBUG SocketServer Channel [73ab476d-06de-4825-9e3d-44120e823fb6:2] ended 
2023-09-22T08:18:20.343Z DEBUG SocketServer Channel [73ab476d-06de-4825-9e3d-44120e823fb6:3] ended 
2023-09-22T08:18:20.343Z DEBUG SocketServer Channel [73ab476d-06de-4825-9e3d-44120e823fb6:4] ended 
2023-09-22T08:18:20.344Z DEBUG SocketServer Channel [73ab476d-06de-4825-9e3d-44120e823fb6:5] ended 
2023-09-22T08:18:20.345Z DEBUG SocketServer Channel [73ab476d-06de-4825-9e3d-44120e823fb6:7] ended 
2023-09-22T08:18:20.345Z DEBUG SocketServer Channel [73ab476d-06de-4825-9e3d-44120e823fb6:8] ended 
2023-09-22T08:18:20.369Z TRACE ProcessInstanceAdapter [73ab476d] Runner process exited [ 2968453 ]
2023-09-22T08:18:20.370Z INFO  CSIController [73ab476d] Cleanup completed 
2023-09-22T08:18:20.370Z TRACE CSIController [73ab476d] Instance ended with code [ 0 ]

3dcc5640df486b350441e83c80d21b311c0ac2e4    Fix circular references in ObjLogger    

2023-09-22T08:14:56.180Z TRACE CSIController [692496a2] Got message: SEQUENCE_COMPLETED. 
2023-09-22T08:14:56.179Z DEBUG Runner [692496a2] Sequence stream ended 
2023-09-22T08:14:56.179Z TRACE Runner [692496a2] Sequence completed. Waiting 10000ms with exit. 
2023-09-22T08:15:06.384Z DEBUG SocketServer Channel [692496a2-abfc-4390-ac81-f15db4f7fff0:0] ended 
2023-09-22T08:15:06.385Z DEBUG SocketServer Channel [692496a2-abfc-4390-ac81-f15db4f7fff0:1] ended 
2023-09-22T08:15:06.386Z DEBUG SocketServer Channel [692496a2-abfc-4390-ac81-f15db4f7fff0:2] ended 
2023-09-22T08:15:06.386Z DEBUG SocketServer Channel [692496a2-abfc-4390-ac81-f15db4f7fff0:3] ended 
2023-09-22T08:15:06.387Z DEBUG SocketServer Channel [692496a2-abfc-4390-ac81-f15db4f7fff0:4] ended 
2023-09-22T08:15:06.388Z DEBUG SocketServer Channel [692496a2-abfc-4390-ac81-f15db4f7fff0:5] ended 
2023-09-22T08:15:06.388Z DEBUG SocketServer Channel [692496a2-abfc-4390-ac81-f15db4f7fff0:7] ended 
2023-09-22T08:15:06.389Z DEBUG SocketServer Channel [692496a2-abfc-4390-ac81-f15db4f7fff0:8] ended 
2023-09-22T08:15:09.864Z INFO  Host List Instances 
2023-09-22T08:15:09.865Z DEBUG Host Request [ 'date: 2023-09-22T08:15:09.864Z, method: GET, url: /api/v1/instances, status: 200' ]
2023-09-22T08:15:11.181Z TRACE CSIController [692496a2] Sequence didn't terminate itself in expected time [ 15000 ]
2023-09-22T08:15:11.198Z TRACE ProcessInstanceAdapter [692496a2] Runner process exited [ 2966745 ]
2023-09-22T08:15:11.199Z WARN  ProcessInstanceAdapter [692496a2] Runner was killed by a signal, and didn't return a status code [ 'SIGTERM' ]
2023-09-22T08:15:11.199Z ERROR CSIController [692496a2] Crashlog [ [ '', '{"msg":"Monitoring interval removed","level":"TRACE","ts":1695370506382,"from":"Runner","Runner":{"id":"692496a2-abfc-4390-ac81-f15db4f7fff0"}}\n{"msg":"Cleaning up streams","level":"INFO","ts":1695370506382,"from":"Runner","Runner":{"id":"692496a2-abfc-4390-ac81-f15db4f7fff0"}}\n{"msg":"Disconnecting from host","level":"TRACE","ts":1695370506382,"from":"HostClient","HostClient":{"id":"692496a2-abfc-4390-ac81-f15db4f7fff0"},"Runner":{"id":"692496a2-abfc-4390-ac81-f15db4f7fff0"}}\n' ] ]
2023-09-22T08:15:11.199Z INFO  CSIController [692496a2] Cleanup completed 
2023-09-22T08:15:11.200Z TRACE CSIController [692496a2] Instance ended with code [ 137 ]
```

-
-
-

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

