### PR TITLE
[FIX] Instance ID replacement in `si inst restart -`

### DIFF
--- a/packages/cli/src/lib/commands/instance.ts
+++ b/packages/cli/src/lib/commands/instance.ts
@@ -99,9 +99,12 @@ export const instance: CommandDefinition = (program) => {
         .argument("<id>", "Instance id or '-' for the last one started or selected")
         .description("Kills the instance and start the new one from root sequence")
         .action(async (id: string) => {
-            const instanceRestartResponse = await instanceRestart(id);
+            const instanceId = await getInstanceId(id);
+            const instanceRestartResponse = await instanceRestart(instanceId);
 
             displayObject(instanceRestartResponse, profileManager.getProfileConfig().format);
+
+            sessionConfig.setLastInstanceId(instanceId);
         });
 
     instanceCmd


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->

Id replacement `-` did not work in the command `si instance restart -`. 
Issue https://github.com/scramjetorg/transform-hub/issues/962

**To verify** 

- start sth
- deploy any sequence
- `yarn start:dev:cli instance restart -`
- after restart check if instance is running by using command:
```bash
yarn start:dev:cli instance info -
```



These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

