### PR TITLE
[CLI] Add `si seq start <seq-id> --inst-id` to CLI command

### DIFF
--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -139,7 +139,7 @@ Feature: CLI tests
 
 
     @ci-api @cli
-    Scenario: E2E-010 TC-016 Test Instance 'restart' option
+    Scenario: E2E-010 TC-017 Test Instance 'restart' option
         When I execute CLI with "seq deploy ../packages/hello.tar.gz"
         When I execute CLI with "inst restart -"
         Then I confirm instance status is "killing"

--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -145,3 +145,16 @@ Feature: CLI tests
         Then I confirm instance status is "killing"
         When I execute CLI with "inst info -"
         Then I confirm instance status is "running"
+
+    ##
+    #    If you change name of instanceId, keep remember it should consist of 36 chars!!!
+    ##
+    @ci-api @cli
+    Scenario: E2E-010 TC-018 Test Set instance id
+        When I execute CLI with "seq send ../packages/hello.tar.gz"
+        When I execute CLI with "seq start - --inst-id <instanceId>"
+        When I execute CLI with "inst ls"
+        Then I confirm instance id is: <instanceId>
+        Examples:
+            | instanceId                           |
+            | Supervisor-Instance-0000-11111111111 |

--- a/bdd/lib/json.parser.ts
+++ b/bdd/lib/json.parser.ts
@@ -16,3 +16,22 @@ export function extractKillResponseFromSiInstRestart(data: any) {
 
     return killResponse;
 }
+
+export function extractInstanceFromSiInstLs(data: any, instanceId: string) {
+    const lines = data.split("\n");
+    const json = JSON.parse(lines[0]);
+    let instance: any = null;
+
+    if (json.length > 0) {
+        for (let i = 0; i < json.length; i++) {
+            const obj = json[i];
+            const id: string = obj.id;
+
+            if (id.localeCompare(instanceId) === 0) {
+                instance = obj;
+                break;
+            }
+        }
+    }
+    return instance;
+}

--- a/bdd/step-definitions/e2e/cli.ts
+++ b/bdd/step-definitions/e2e/cli.ts
@@ -12,7 +12,7 @@ import { CustomWorld } from "../world";
 import { spawn } from "child_process";
 import { once } from "events";
 import { addLoggerOutput, getLogger } from "@scramjet/logger";
-import { extractKillResponseFromSiInstRestart } from "../../lib/json.parser";
+import { extractInstanceFromSiInstLs, extractKillResponseFromSiInstRestart } from "../../lib/json.parser";
 
 addLoggerOutput(process.stdout, process.stdout);
 
@@ -345,4 +345,21 @@ Then("I confirm instance status is {string}", async function (this: CustomWorld,
     }
 
     assert.equal(response.status, expectedStatus);
+});
+
+Then(/^I confirm instance id is: (.*)$/, async function (this: CustomWorld, expectedInstanceId: string) {
+    const data = this.cliResources.stdio?.[0];
+    const isLogActive = process.env.SCRAMJET_TEST_LOG;
+
+    const instance = extractInstanceFromSiInstLs(data, expectedInstanceId);
+
+    if (isLogActive) {
+        logger.debug(`Cli resources: `);
+        logger.debug(data);
+        logger.debug(`Expected instance ID: ${expectedInstanceId}`);
+        logger.debug(`Instance received:`);
+        logger.debug(instance);
+    }
+
+    assert.equal(instance.id, expectedInstanceId);
 });

--- a/packages/cli/src/lib/commands/config.ts
+++ b/packages/cli/src/lib/commands/config.ts
@@ -53,9 +53,8 @@ export const config: CommandDefinition = (program) => {
         .description("Print out the current session configuration")
         .action(() => {
             const configuration = profileConfig.get();
-            const session = sessionConfig.get();
 
-            displayObject(session, configuration.log.format);
+            displayObject(sessionConfig.get(), configuration.log.format);
         });
 
     if (isProfileConfig(profileConfig)) {

--- a/packages/cli/src/lib/commands/sequence.ts
+++ b/packages/cli/src/lib/commands/sequence.ts
@@ -148,10 +148,11 @@ export const sequence: CommandDefinition = (program) => {
         .option("-o, --output <file.tar.gz>", "Output path - defaults to dirname")
         .option("-f, --config-file <path-to-file>", "Path to configuration file in JSON format to be passed to the Instance context")
         .option("-s, --config-string <json-string>", "Configuration in JSON format to be passed to the Instance context")
+        .option("--inst-id <string>", "Start Sequence with a custom Instance Id. Should consist of 36 characters")
         // TODO: check if output-topic and input-topic should be added after development
         .option("--args <json-string>", "Arguments to be passed to the first function in the Sequence")
         .description("Pack (if needed), send and start the Sequence")
-        .action(async (path: string, { output: fileoutput, configFile, configString, args: argsStr }: DeployArgs) => {
+        .action(async (path: string, { output: fileoutput, configFile, configString, args: argsStr, instId }: DeployArgs) => {
             let args;
 
             if (argsStr) args = sequenceParseArgs(argsStr);
@@ -180,7 +181,7 @@ export const sequence: CommandDefinition = (program) => {
                 displayObject(sequenceClient, profileManager.getProfileConfig().format);
             }
 
-            const instanceClient = await sequenceStart("-", { configFile, configString, args });
+            const instanceClient = await sequenceStart("-", { configFile, configString, args, instId });
 
             displayObject(instanceClient, format);
         });

--- a/packages/cli/src/lib/commands/sequence.ts
+++ b/packages/cli/src/lib/commands/sequence.ts
@@ -115,7 +115,7 @@ export const sequence: CommandDefinition = (program) => {
         // .option("--hub <provider>", "aws|ovh|gcp");
         .option("-f, --config-file <path-to-file>", "Path to configuration file in JSON format to be passed to the Instance context")
         .option("-s, --config-string <json-string>", "Configuration in JSON format to be passed to the Instance context")
-        .option("--inst-id <string>", "Start Sequence with a custom Instance Id.")
+        .option("--inst-id <string>", "Start Sequence with a custom Instance Id. Should consist of 36 characters")
         .option("--output-topic <string>", "Topic to which the output stream should be routed")
         .option("--input-topic <string>", "Topic to which the input stream should be routed")
         .option("--args <json-string>", "Arguments to be passed to the first function in the Sequence")

--- a/packages/cli/src/lib/commands/sequence.ts
+++ b/packages/cli/src/lib/commands/sequence.ts
@@ -115,19 +115,20 @@ export const sequence: CommandDefinition = (program) => {
         // .option("--hub <provider>", "aws|ovh|gcp");
         .option("-f, --config-file <path-to-file>", "Path to configuration file in JSON format to be passed to the Instance context")
         .option("-s, --config-string <json-string>", "Configuration in JSON format to be passed to the Instance context")
+        .option("--inst-id <string>", "Start Sequence with a custom Instance Id.")
         .option("--output-topic <string>", "Topic to which the output stream should be routed")
         .option("--input-topic <string>", "Topic to which the input stream should be routed")
         .option("--args <json-string>", "Arguments to be passed to the first function in the Sequence")
         .option("--limits <json-string>", "Instance limits")
         .description("Start the Sequence with or without given arguments")
-        .action(async (id, { configFile, configString, outputTopic, inputTopic, args: argsStr, limits: limitsStr }) => {
+        .action(async (id, { configFile, configString, outputTopic, inputTopic, args: argsStr, limits: limitsStr, instId }) => {
             let args;
 
             if (argsStr) args = sequenceParseArgs(argsStr);
             const limits = limitsStr ? JSON.parse(limitsStr) : {};
 
             const instanceClient = await sequenceStart(
-                id, { configFile, configString, args, outputTopic, inputTopic, limits });
+                id, { configFile, configString, args, outputTopic, inputTopic, limits, instId });
 
             displayObject(instanceClient, profileManager.getProfileConfig().format);
         });
@@ -136,6 +137,7 @@ export const sequence: CommandDefinition = (program) => {
         output: string;
         configFile: any;
         configString: string;
+        instId?: string;
         args?: string;
     };
 

--- a/packages/cli/src/lib/config/sessionConfig.ts
+++ b/packages/cli/src/lib/config/sessionConfig.ts
@@ -1,7 +1,6 @@
 import { ConfigFileDefault } from "@scramjet/utility";
 import { SessionConfigEntity } from "../../types";
 import { sessionId } from "../../utils/sessionId";
-import isUUID from "validator/lib/isUUID";
 import { sessionConfigFile } from "../paths";
 
 // Session configuration represents configuration used internally
@@ -42,16 +41,15 @@ export class SessionConfig extends ConfigFileDefault<SessionConfigEntity> {
     setLastHubId(lastHubId: string): boolean {
         return this.setEntry("lastHubId", lastHubId);
     }
-    protected validateEntry(key: string, value: any): boolean | null {
+    protected validateEntry(key: string): boolean | null {
         switch (key) {
             case "lastPackagePath":
             case "lastSpaceId":
             case "lastSequenceId":
             case "lastHubId":
+            case "lastInstanceId":
             case "sessionId":
                 return null;
-            case "lastInstanceId":
-                return value === "" || isUUID(value, 4);
             default:
                 return false;
         }

--- a/packages/cli/src/lib/helpers/sequence.ts
+++ b/packages/cli/src/lib/helpers/sequence.ts
@@ -149,14 +149,15 @@ export const sequenceSendPackage = async (
 };
 
 export const sequenceStart = async (
-    id: string, { configFile, configString, args, outputTopic, inputTopic, limits }:
+    id: string, { configFile, configString, args, outputTopic, inputTopic, limits, instId }:
         {
             configFile: any,
             configString: string,
             args?: any[],
             outputTopic?: string,
             inputTopic?: string,
-            limits?: InstanceLimits
+            limits?: InstanceLimits,
+            instId?: string
         }
 ): Promise<InstanceClient> => {
     if (configFile && configString) {
@@ -174,7 +175,9 @@ export const sequenceStart = async (
     const sequenceClient = SequenceClient.from(getSequenceId(id), getHostClient());
 
     try {
-        const instance = await sequenceClient.start({ appConfig, args, outputTopic, inputTopic, limits });
+        const instance = await sequenceClient.start({
+            appConfig, args, outputTopic, inputTopic, limits, instanceId: instId
+        });
 
         sessionConfig.setLastInstanceId(instance.id);
         return Promise.resolve(instance);

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -41,7 +41,7 @@ import { DataStream } from "scramjet";
 import { optionsMiddleware } from "./middlewares/options";
 import { corsMiddleware } from "./middlewares/cors";
 import { ConfigService, development } from "@scramjet/sth-config";
-import { isStartSequenceDTO, readJsonFile, defer, FileBuilder } from "@scramjet/utility";
+import { isStartSequenceDTO, isStartSequenceEndpointPayloadDTO, readJsonFile, defer, FileBuilder } from "@scramjet/utility";
 import { inspect } from "util";
 import { auditMiddleware, logger as auditMiddlewareLogger } from "./middlewares/audit";
 import { AuditedRequest, Auditor } from "./auditor";
@@ -916,44 +916,44 @@ export class Host implements IComponent {
      */
     // eslint-disable-next-line complexity
     async handleStartSequence(req: ParsedMessage): Promise<OpResponse<STHRestAPI.StartSequenceResponse>> {
-        if (await this.loadCheck.overloaded()) {
-            return {
-                opStatus: ReasonPhrases.INSUFFICIENT_SPACE_ON_RESOURCE,
-            };
-        }
-
-        const sequenceId = req.params?.id as string;
-        const payload = req.body || ({} as STHRestAPI.StartSequencePayload);
-
-        if (payload.instanceId) {
-            if (!IDProvider.isValid(payload.instanceId)) {
-                return { opStatus: ReasonPhrases.UNPROCESSABLE_ENTITY, error: "Invalid Instance id" };
-            }
-
-            if (this.instancesStore[payload.instanceId]) {
+        try {
+            if (await this.loadCheck.overloaded()) {
                 return {
-                    opStatus: ReasonPhrases.CONFLICT,
-                    error: "Instance with a given ID already exists"
+                    opStatus: ReasonPhrases.INSUFFICIENT_SPACE_ON_RESOURCE,
                 };
             }
-        }
 
-        let sequence = this.sequenceStore.getByNameOrId(sequenceId);
+            const sequenceId = req.params?.id as string;
+            const payload = req.body || ({} as STHRestAPI.StartSequencePayload);
 
-        if (this.cpmConnector?.connected) {
-            sequence ||= await this.getExternalSequence(sequenceId).catch((error: ReasonPhrases) => {
-                this.logger.error("Error getting sequence from external sources", error);
-                return undefined;
-            });
-        }
+            if (payload.instanceId) {
+                if (!isStartSequenceEndpointPayloadDTO(payload)) {
+                    return { opStatus: ReasonPhrases.UNPROCESSABLE_ENTITY, error: "Invalid Instance id" };
+                }
 
-        if (!sequence) {
-            return { opStatus: ReasonPhrases.NOT_FOUND };
-        }
+                if (this.instancesStore[payload.instanceId]) {
+                    return {
+                        opStatus: ReasonPhrases.CONFLICT,
+                        error: "Instance with a given ID already exists"
+                    };
+                }
+            }
 
-        this.logger.info("Start sequence", sequence.id, sequence.config.name);
+            let sequence = this.sequenceStore.getByNameOrId(sequenceId);
 
-        try {
+            if (this.cpmConnector?.connected) {
+                sequence ||= await this.getExternalSequence(sequenceId).catch((error: ReasonPhrases) => {
+                    this.logger.error("Error getting sequence from external sources", error);
+                    return undefined;
+                });
+            }
+
+            if (!sequence) {
+                return { opStatus: ReasonPhrases.NOT_FOUND };
+            }
+
+            this.logger.info("Start sequence", sequence.id, sequence.config.name);
+
             const csic = await this.startCSIController(sequence, payload);
 
             await this.cpmConnector?.sendInstanceInfo({
@@ -987,10 +987,10 @@ export class Host implements IComponent {
             };
         } catch (error: any) {
             this.pushTelemetry("Instance start failed", { error: error.message }, "error");
-
+            this.logger.error(error.message);
             return {
                 opStatus: ReasonPhrases.BAD_REQUEST,
-                error: error,
+                error: error.message
             };
         }
     }

--- a/packages/types/src/dto/index.ts
+++ b/packages/types/src/dto/index.ts
@@ -1,1 +1,1 @@
-export { StartSequenceDTO } from "./start-sequence";
+export { StartSequenceDTO, StartSequenceEndpointPayloadDTO } from "./start-sequence";

--- a/packages/types/src/dto/start-sequence.ts
+++ b/packages/types/src/dto/start-sequence.ts
@@ -6,3 +6,9 @@ export type StartSequenceDTO = {
     args?: string[],
     instanceId?: string;
 }
+
+export type StartSequenceEndpointPayloadDTO = {
+    appConfig?: AppConfig,
+    instanceId?: string;
+    args?: string[],
+}

--- a/packages/utility/src/typeguards/dto/sequence-start.ts
+++ b/packages/utility/src/typeguards/dto/sequence-start.ts
@@ -1,4 +1,4 @@
-import { StartSequenceDTO } from "@scramjet/types";
+import { StartSequenceDTO, StartSequenceEndpointPayloadDTO } from "@scramjet/types";
 
 // eslint-disable-next-line complexity
 export function isStartSequenceDTO(arg: any): arg is StartSequenceDTO {
@@ -14,8 +14,23 @@ export function isStartSequenceDTO(arg: any): arg is StartSequenceDTO {
         if (!Array.isArray(args)) throw new Error("DTO args are not an array");
         if ((args as string[]).some(x => typeof x !== "string")) throw new Error("DTO args are all strings");
     }
-    if (instanceId !== undefined && typeof instanceId === "string" && instanceId.length !== 36) throw new Error("DTO instanceId is 36 long");
+    if (instanceId !== undefined && typeof instanceId === "string" && instanceId.length !== 36) throw new Error("DTO instanceId is not 36 long");
     if (Object.keys(rest).length > 0) throw new Error(`DTO has unknown ${Object.keys(rest)} keys`);
+
+    return true;
+}
+
+export function isStartSequenceEndpointPayloadDTO(arg: any): arg is StartSequenceEndpointPayloadDTO {
+    if (typeof arg !== "object") {
+        throw new Error("DTO is not an object");
+    }
+    const { appConfig, instanceId } = arg;
+
+    if (!["object", "undefined"].includes(typeof appConfig)) throw new Error(`DTO appConfig is ${typeof appConfig}, not an object`);
+    if (instanceId && (typeof instanceId !== "string" || instanceId.length !== 36)) {
+        throw new Error("DTO instanceId is not valid string");
+    }
+    if (instanceId !== undefined && typeof instanceId === "string" && instanceId.length !== 36) throw new Error("DTO instanceId is not 36 long");
 
     return true;
 }

--- a/packages/utility/src/typeguards/dto/sequence-start.ts
+++ b/packages/utility/src/typeguards/dto/sequence-start.ts
@@ -6,15 +6,17 @@ export function isStartSequenceDTO(arg: any): arg is StartSequenceDTO {
     const { id, appConfig, args, instanceId, ...rest } = arg;
 
     if (typeof id !== "string") throw new Error("DTO id is not string");
-    if (!["object", "undefined"].includes(typeof appConfig)) throw new Error(`DTO appConfig is ${typeof appConfig}, not an object`);
-    if (instanceId && (typeof instanceId !== "string" || instanceId.length !== 36)) {
+    if (!["object", "undefined"].includes(typeof appConfig))
+        throw new Error(`DTO appConfig is ${typeof appConfig}, not an object`);
+    if (instanceId && typeof instanceId !== "string") {
         throw new Error("DTO instanceId is not valid string");
     }
     if (typeof args !== "undefined") {
         if (!Array.isArray(args)) throw new Error("DTO args are not an array");
-        if ((args as string[]).some(x => typeof x !== "string")) throw new Error("DTO args are all strings");
+        if ((args as string[]).some((x) => typeof x !== "string")) throw new Error("DTO args are all strings");
     }
-    if (instanceId !== undefined && typeof instanceId === "string" && instanceId.length !== 36) throw new Error("DTO instanceId is not 36 long");
+    if (instanceId !== undefined && typeof instanceId === "string" && instanceId.length !== 36)
+        throw new Error("DTO instanceId is not 36 long");
     if (Object.keys(rest).length > 0) throw new Error(`DTO has unknown ${Object.keys(rest)} keys`);
 
     return true;
@@ -26,11 +28,12 @@ export function isStartSequenceEndpointPayloadDTO(arg: any): arg is StartSequenc
     }
     const { appConfig, instanceId } = arg;
 
-    if (!["object", "undefined"].includes(typeof appConfig)) throw new Error(`DTO appConfig is ${typeof appConfig}, not an object`);
-    if (instanceId && (typeof instanceId !== "string" || instanceId.length !== 36)) {
+    if (!["object", "undefined"].includes(typeof appConfig))
+        throw new Error(`DTO appConfig is ${typeof appConfig}, not an object`);
+    if (instanceId !== undefined && typeof instanceId === "string" && instanceId.length !== 36)
+        throw new Error("DTO instanceId is not 36 long");
+    if (instanceId && typeof instanceId !== "string") {
         throw new Error("DTO instanceId is not valid string");
     }
-    if (instanceId !== undefined && typeof instanceId === "string" && instanceId.length !== 36) throw new Error("DTO instanceId is not 36 long");
-
     return true;
 }


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->
This option was missing. 

**To verify**  <!-- Two-sentence summary, understandable for a junior. -->
- start sth from source: `yarn start:dev`
- send any sequence
```
yarn start:dev:cli seq send packages/hello-input-out.tar.gz
```
- start sequence with `--inst-id` option
```
yarn start:dev:cli seq start - --inst-id "Supervisor-Instance-0000-11111111111"
```

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [x] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

