### PR TITLE
fix variable name

### DIFF
--- a/packages/module-loader/src/index.ts
+++ b/packages/module-loader/src/index.ts
@@ -20,9 +20,9 @@ export async function loadModule<T>(opts: ModuleLoaderOpts): Promise<T> {
 
         return module!;
     } catch (e) {
-        logger.error(`Error loading module ${name}`);
+        logger.error(`Error loading module ${opts.name}`);
 
-        throw new Error(`Error loading module ${name}`);
+        throw new Error(`Error loading module ${opts.name}`);
     }
 }
 


### PR DESCRIPTION
when module won't be able to load it was giving following error:
`ReferenceError: name is not defined`
instead proper error
