### PR TITLE
Add option to provide file with arguments to start/deploy sequence

### DIFF
--- a/packages/cli/src/lib/commands/sequence.ts
+++ b/packages/cli/src/lib/commands/sequence.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 import { CommandDefinition } from "../../types";
-import { createWriteStream, lstatSync } from "fs";
+import { createWriteStream, lstatSync, readFileSync } from "fs";
 import { displayEntity, displayError, displayMessage, displayObject } from "../output";
 import { getHostClient } from "../common";
 import { getSequenceId, profileManager, sessionConfig } from "../config";
@@ -10,9 +10,11 @@ import { PassThrough, Writable } from "stream";
 import { isDevelopment } from "../../utils/envs";
 
 import { resolve } from "path";
-import { sequenceDelete, sequencePack, sequenceParseArgs, sequenceSendPackage, sequenceStart } from "../helpers/sequence";
+import { sequenceDelete, sequencePack, sequenceParseArgs, sequenceParseConfig, sequenceSendPackage, sequenceStart } from "../helpers/sequence";
 import { ClientError } from "@scramjet/client-utils";
 import { initPlatform } from "../platform";
+import { AppConfig, DeepPartial, InstanceLimits } from "@scramjet/types";
+import { isStartSequenceEndpointPayloadDTO, merge } from "@scramjet/utility";
 
 /**
  * Initializes `sequence` command.
@@ -108,6 +110,49 @@ export const sequence: CommandDefinition = (program) => {
             }
         );
 
+    type ProcessedDeployArgs = {
+        output?: string;
+        config: AppConfig;
+        instanceId?: string;
+        inputTopic?: string;
+        outputTopic?: string;
+        args?: any[];
+        appConfig: AppConfig,
+        limits: InstanceLimits
+    };
+
+    type SequenceStartParams = Omit<ProcessedDeployArgs, "instanceId"> & {
+        startupConfig: DeepPartial<ProcessedDeployArgs>
+        args?: string;
+        instId?: string;
+        limits: string;
+        configFile: any;
+        configString: any;
+
+    };
+
+    function validateStartupConfig(config: DeepPartial<ProcessedDeployArgs>) {
+        return isStartSequenceEndpointPayloadDTO(config);
+    }
+
+    function loadStartupConfig(filename: string): DeepPartial<ProcessedDeployArgs> {
+        if (!filename) return {};
+
+        let json = {};
+
+        try {
+            const data = readFileSync(filename, "utf8");
+
+            json = JSON.parse(data);
+        } catch (e) {
+            // eslint-disable-next-line no-console
+            console.error(e);
+            process.exit(1);
+        }
+
+        return json;
+    }
+
     sequenceCmd
         .command("start")
         .argument("<id>", "Sequence id to start or '-' for the last uploaded")
@@ -119,27 +164,39 @@ export const sequence: CommandDefinition = (program) => {
         .option("--output-topic <string>", "Topic to which the output stream should be routed")
         .option("--input-topic <string>", "Topic to which the input stream should be routed")
         .option("--args <json-string>", "Arguments to be passed to the first function in the Sequence")
+        .option("--startup-config <path-to-config>", "Path to startup config", loadStartupConfig)
         .option("--limits <json-string>", "Instance limits")
         .description("Start the Sequence with or without given arguments")
-        .action(async (id, { configFile, configString, outputTopic, inputTopic, args: argsStr, limits: limitsStr, instId }) => {
-            let args;
-
-            if (argsStr) args = sequenceParseArgs(argsStr);
+        .action(async (id, { startupConfig, configFile, configString, outputTopic, inputTopic, args: argsStr, limits: limitsStr, instId }: SequenceStartParams) => {
+            const args = argsStr ? sequenceParseArgs(argsStr) : undefined;
+            const appConfig = await sequenceParseConfig(configFile, configString);
             const limits = limitsStr ? JSON.parse(limitsStr) : {};
 
-            const instanceClient = await sequenceStart(
-                id, { configFile, configString, args, outputTopic, inputTopic, limits, instId });
+            startupConfig ||= {};
+            merge(startupConfig, {
+                appConfig,
+                args,
+                instanceId: instId,
+                inputTopic,
+                outputTopic,
+                limits
+            });
+
+            if (!validateStartupConfig(startupConfig)) {
+                throw new Error("Invalid startup config",);
+            }
+
+            const instanceClient = await sequenceStart(id, {
+                appConfig: startupConfig.appConfig as SequenceStartParams["appConfig"],
+                args: startupConfig.args,
+                limits: startupConfig.limits,
+                instanceId: startupConfig.instanceId,
+                outputTopic: startupConfig.outputTopic,
+                inputTopic: startupConfig.inputTopic
+            });
 
             displayObject(instanceClient, profileManager.getProfileConfig().format);
         });
-
-    type DeployArgs = {
-        output: string;
-        configFile: any;
-        configString: string;
-        instId?: string;
-        args?: string;
-    };
 
     sequenceCmd
         .command("deploy")
@@ -150,30 +207,49 @@ export const sequence: CommandDefinition = (program) => {
         .option("-s, --config-string <json-string>", "Configuration in JSON format to be passed to the Instance context")
         .option("--inst-id <string>", "Start Sequence with a custom Instance Id. Should consist of 36 characters")
         // TODO: check if output-topic and input-topic should be added after development
+        .option("--output-topic <string>", "Topic to which the output stream should be routed")
+        .option("--input-topic <string>", "Topic to which the input stream should be routed")
         .option("--args <json-string>", "Arguments to be passed to the first function in the Sequence")
+        .option("--startup-config <path-to-config>", "Path to startup config", loadStartupConfig)
+        .option("--limits <json-string>", "Instance limits")
         .description("Pack (if needed), send and start the Sequence")
-        .action(async (path: string, { output: fileoutput, configFile, configString, args: argsStr, instId }: DeployArgs) => {
-            let args;
+        .action(async (path: string, { startupConfig, output, configFile, configString, outputTopic, inputTopic, args: argsStr, limits: limitsStr, instId }: SequenceStartParams) => {
+            const args = argsStr ? sequenceParseArgs(argsStr) : undefined;
+            const appConfig = await sequenceParseConfig(configFile, configString);
+            const limits = limitsStr ? JSON.parse(limitsStr) : {};
 
-            if (argsStr) args = sequenceParseArgs(argsStr);
+            startupConfig ||= {};
+            merge(startupConfig, {
+                output,
+                appConfig,
+                args,
+                instanceId: instId,
+                inputTopic,
+                outputTopic,
+                limits
+            });
 
-            const output = new PassThrough();
+            if (!validateStartupConfig(startupConfig)) {
+                throw new Error("Invalid startup config",);
+            }
 
-            if (fileoutput) {
-                const outputPath = fileoutput ? resolve(fileoutput) : `${resolve(path)}.tar.gz`;
+            const compressedPackageStream = new PassThrough();
 
-                output.pipe(createWriteStream(outputPath));
+            if (startupConfig.output) {
+                const outputPath = startupConfig.output ? resolve(startupConfig.output) : `${resolve(path)}.tar.gz`;
+
+                compressedPackageStream.pipe(createWriteStream(outputPath));
                 sessionConfig.setLastPackagePath(outputPath);
             }
             const format = profileManager.getProfileConfig().format;
 
             if (lstatSync(path).isDirectory()) {
                 // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                const sendSeqPromise = getHostClient().sendSequence(output).then(seq => {
+                const sendSeqPromise = getHostClient().sendSequence(compressedPackageStream).then(seq => {
                     sessionConfig.setLastSequenceId(seq.id);
                 });
 
-                await sequencePack(path, { output });
+                await sequencePack(path, { output: compressedPackageStream });
                 await sendSeqPromise;
             } else {
                 const sequenceClient = await sequenceSendPackage(path, {}, false, { progress: sequenceCmd.parent?.getOptionValue("progress") });
@@ -181,7 +257,14 @@ export const sequence: CommandDefinition = (program) => {
                 displayObject(sequenceClient, profileManager.getProfileConfig().format);
             }
 
-            const instanceClient = await sequenceStart("-", { configFile, configString, args, instId });
+            const instanceClient = await sequenceStart("-", {
+                appConfig: startupConfig.appConfig as SequenceStartParams["appConfig"],
+                args: startupConfig.args,
+                limits: startupConfig.limits,
+                instanceId: startupConfig.instanceId,
+                outputTopic: startupConfig.outputTopic,
+                inputTopic: startupConfig.inputTopic
+            });
 
             displayObject(instanceClient, format);
         });

--- a/packages/cli/src/lib/helpers/sequence.ts
+++ b/packages/cli/src/lib/helpers/sequence.ts
@@ -148,7 +148,7 @@ export const sequenceSendPackage = async (
     }
 };
 
-export const sequenceParseConfig = async (configFile: string, configString: string): Promise<AppConfig> => {
+export const sequenceParseConfig = async (configFile: string = "", configString: string = ""): Promise<AppConfig> => {
     if (configFile && configString) {
         return Promise.reject(new Error("Provide one source of configuration"));
     }

--- a/packages/cli/src/types/params/index.ts
+++ b/packages/cli/src/types/params/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Arguments types
+ */
+
+export * from "./sequence";

--- a/packages/cli/src/types/params/sequence.ts
+++ b/packages/cli/src/types/params/sequence.ts
@@ -1,0 +1,17 @@
+import { DeepPartial, STHRestAPI } from "@scramjet/types";
+
+export type SequenceDeployArgs = STHRestAPI.StartSequencePayload & {
+    output?: string;
+};
+
+export type SequenceStartCLIArgs = {
+    args?: string;
+    configFile?: string;
+    configString?: string;
+    instId?: string;
+    inputTopic?: string;
+    limits?: string;
+    output?: string;
+    outputTopic?: string;
+    startupConfig: DeepPartial<SequenceDeployArgs>;
+};

--- a/packages/types/src/rest-api-sth/start-sequence.ts
+++ b/packages/types/src/rest-api-sth/start-sequence.ts
@@ -1,13 +1,13 @@
 import { AppConfig } from "../app-config";
 import { InstanceLimits } from "../instance-limits";
 
-export type StartSequenceResponse = { id: string }
+export type StartSequenceResponse = { id: string };
 
 export type StartSequencePayload = {
-    appConfig: AppConfig,
-    args?: any[],
-    outputTopic?: string,
-    inputTopic?: string,
-    limits?: InstanceLimits,
-    instanceId?: string
-}
+    appConfig: AppConfig;
+    args?: any[];
+    outputTopic?: string;
+    inputTopic?: string;
+    limits?: InstanceLimits;
+    instanceId?: string;
+};


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->


**Why?**  <!-- What is this needed for? You can link to an issue. -->
All parameters user can provide in command line can be supplied with config file.

**Usage:**
seq-startup-config.json:
```json
{
    "outputTopic": "test-topic",
    "args": ["arg1", "arg2"],
    "limits": {
        "memory": 64
    },
    "appConfig": { "a": 1 }
}
```

Test with `args-config-test` Sequence
https://github.com/scramjetorg/reference-apps/blob/main/js/args-config-test/index.ts

```
si seq <start|deploy> --startup-config seq-startup-config.json
```

```bash
si seq deploy packages/args-config-test.tar.gz --startup-config seq-startup-config.json
Request ok: http://127.0.0.1:8000/api/v1/sequence status: 200 OK
{"_id":"0e55aae1-25a5-4f0d-82ac-1b7192a4c788","host":{"apiBase":"http://127.0.0.1:8000/api/v1"},"sequenceURL":"sequence/0e55aae1-25a5-4f0d-82ac-1b7192a4c788"}
Request ok: http://127.0.0.1:8000/api/v1/sequence/0e55aae1-25a5-4f0d-82ac-1b7192a4c788/start status: 200 OK
{"host":{"apiBase":"http://127.0.0.1:8000/api/v1"},"_id":"db06246c-996b-49f7-9f0a-be79c01413f2","instanceURL":"instance/db06246c-996b-49f7-9f0a-be79c01413f2"}
Done in 5.92s.
```

```bash
$ si topic get test-topic
Request ok: http://127.0.0.1:8000/api/v1/topic/test-topic status: 200 OK
config: {"a":1}
string, "arg1"
string, "arg2"
```

params from file can be overwritten with cli params, ie:
```bash
si seq deploy packages/args-config-test.tar.gz --startup-config seq-startup-config.json --output-topic other-topic
Request ok: http://127.0.0.1:8000/api/v1/sequence status: 200 OK
{"_id":"8c72da12-a69c-4fbc-aeb1-2d7fad84e140","host":{"apiBase":"http://127.0.0.1:8000/api/v1"},"sequenceURL":"sequence/8c72da12-a69c-4fbc-aeb1-2d7fad84e140"}
Request ok: http://127.0.0.1:8000/api/v1/sequence/8c72da12-a69c-4fbc-aeb1-2d7fad84e140/start status: 200 OK
{"host":{"apiBase":"http://127.0.0.1:8000/api/v1"},"_id":"e4c4ea28-0ab8-4760-a22e-d2d98fc7c4d4","instanceURL":"instance/e4c4ea28-0ab8-4760-a22e-d2d98fc7c4d4"}
Done in 6.04s.
```
```bash
$ si topic get other-topic
Request ok: http://127.0.0.1:8000/api/v1/topic/other-topic status: 200 OK
config: {"a":1}
string, "arg1"
string, "arg2"
```


**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

