### PR TITLE
Auto set contenty-type in PANG

### DIFF
--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -1023,10 +1023,22 @@ export class Host implements IComponent {
 
         // eslint-disable-next-line complexity
         csic.on("pang", async (data) => {
-            this.logger.trace("PANG received", data);
+            this.logger.trace("PANG received", [{ ...data }]);
 
             if ((data.requires || data.provides) && !data.contentType) {
-                this.logger.warn("Missing topic content-type");
+                this.logger.warn("Missing topic content-type", data.provides, data.contentType);
+
+                if (data.provides) {
+                    data.contentType = this.serviceDiscovery.getTopics()
+                        .find(t => t.topic === data.provides)?.contentType;
+                }
+
+                if (data.contentType) {
+                    this.logger.warn("Content-type set to match existing topic", data.contentType);
+                } else {
+                    data.contentType = "application/x-ndjson";
+                    this.logger.warn("Content-type set to default", data.contentType);
+                }
             }
 
             if (data.requires && !csic.inputRouted && data.contentType) {


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
When Instance has overwritten output to topic, ie with command
```
si seq start --output-topic test-topic
``` 
but content-type is unknown, will set content-type to match topic content-type (if exists) or set to default content-type (`application/x-ndjson`)

So, to set prefered content-type one should create topic first
```
si topic create test-topic -t text/plain
```
and then 
```
si seq start <SEQ> --output-topic test-topic
```

otherwise topic will be created with default content-type

**Why?**  <!-- What is this needed for? You can link to an issue. -->
If Sequence's output Content-Type is not defined there is no possibility to redirect output to topic

**Usage:**
<!-- Example (if applicable), how to verify (if not covered by tests). -->
-
-
-

**Clickup Task:** <!-- Paste corresponding link to a clickup task -->


<!--------------------- For non-trivial changes: ---------------------->

**How it works:**
<!-- Share some starting points for understanding the code. -->
-
-
-

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

