### PR TITLE
Fix ObjLogger arguments reference

### DIFF
--- a/packages/obj-logger/src/obj-logger.ts
+++ b/packages/obj-logger/src/obj-logger.ts
@@ -119,21 +119,27 @@ export class ObjLogger implements IObjectLogger {
             return;
         }
 
+        let paramsCopy;
+
+        if (optionalParams.length) {
+            paramsCopy = JSON.parse(JSON.stringify(optionalParams));
+        }
+
         if (typeof entry === "string") {
             entry = { msg: entry };
         }
 
-        const a: any = { ...entry, level, ts: entry.ts || Date.now() };
-
-        a.from = entry.from || this.name;
+        const a: any = {
+            ...entry,
+            level,
+            ts: entry.ts || Date.now(),
+            data: paramsCopy,
+            from: entry.from || this.name
+        };
 
         a[this.name] = {
             ...this.baseLog
         };
-
-        if (optionalParams.length) {
-            a.data = optionalParams;
-        }
 
         this.outputs.forEach(output => {
             if (output.writableObjectMode) {


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Fix logging with ObjLogger

see:
```js
let a = "initial value";
logger.debug("Value of a", a)
a = "changed";
logger.debug("Value of a", a)
```

could result with 
```
Value of a ["changed"]
Value of a ["changed"]
```

before the log is processed the value has changed
and because logger uses reference to provided variable instead of its value.


**Clickup Task:** <!-- Paste corresponding link to a clickup task -->


<!--------------------- For non-trivial changes: ---------------------->

**How it works:**
<!-- Share some starting points for understanding the code. -->
-
-
-

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

