### PR TITLE
Show Node version on Host start

### DIFF
--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -213,6 +213,8 @@ export class Host implements IComponent {
 
         if (isDevelopment) this.logger.info("config", this.config);
 
+        this.logger.info("Node version:", process.version);
+
         loadModuleLogger.pipe(this.logger);
 
         this.config.host.id ||= this.getId();


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
log node version on Host start:
```
2023-10-30T10:46:55.967Z INFO  Host Node version: [ 'v18.12.1' ]
```

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

