### PR TITLE
Set default runner envs with `--runner-envs` STH param

### DIFF
--- a/packages/adapters/src/docker-instance-adapter.ts
+++ b/packages/adapters/src/docker-instance-adapter.ts
@@ -32,6 +32,7 @@ IComponent {
     private dockerHelper: IDockerHelper;
     private _limits?: InstanceLimits = {};
     private resources: DockerAdapterResources = {};
+    private sthConfig: STHConfiguration;
     id: string = "";
 
     logger: IObjectLogger;
@@ -41,7 +42,8 @@ IComponent {
     get limits() { return this._limits || {} as InstanceLimits; }
     private set limits(value: InstanceLimits) { this._limits = value; }
 
-    constructor(_sthConfig: STHConfiguration, id: string = "") {
+    constructor(sthConfig: STHConfiguration, id: string = "") {
+        this.sthConfig = sthConfig;
         this.dockerHelper = new DockerodeDockerHelper();
 
         this.logger = new ObjLogger(this, { id });
@@ -191,7 +193,9 @@ IComponent {
             instancesServerPort,
             instancesServerHost: networkSetup.host,
             instanceId,
-            pipesPath: ""
+            pipesPath: "",
+        }, {
+            ...this.sthConfig.runnerEnvs
         }).map(([k, v]) => `${k}=${v}`);
 
         this.logger.debug("Runner will start with envs", envs);

--- a/packages/adapters/src/docker-instance-adapter.ts
+++ b/packages/adapters/src/docker-instance-adapter.ts
@@ -193,7 +193,7 @@ IComponent {
             instancesServerPort,
             instancesServerHost: networkSetup.host,
             instanceId,
-            pipesPath: "",
+            pipesPath: ""
         }, {
             ...this.sthConfig.runnerEnvs
         }).map(([k, v]) => `${k}=${v}`);

--- a/packages/adapters/src/kubernetes-instance-adapter.ts
+++ b/packages/adapters/src/kubernetes-instance-adapter.ts
@@ -45,6 +45,7 @@ IComponent {
         // @TODO this is a redundant check (it was already checked in sequence adapter)
         // We should move this to config service decoding: https://github.com/scramjetorg/transform-hub/issues/279
         this.sthConfig = sthConfig;
+
         const decodedAdapterConfig = adapterConfigDecoder.decode(sthConfig.kubernetes);
 
         if (!decodedAdapterConfig.isOk()) {

--- a/packages/adapters/src/kubernetes-instance-adapter.ts
+++ b/packages/adapters/src/kubernetes-instance-adapter.ts
@@ -31,6 +31,7 @@ IComponent {
     logger: IObjectLogger;
     name = "KubernetesInstanceAdapter";
 
+    private sthConfig: STHConfiguration;
     private _runnerName?: string;
     private _kubeClient?: KubernetesClientAdapter;
 
@@ -43,6 +44,7 @@ IComponent {
     constructor(sthConfig: STHConfiguration) {
         // @TODO this is a redundant check (it was already checked in sequence adapter)
         // We should move this to config service decoding: https://github.com/scramjetorg/transform-hub/issues/279
+        this.sthConfig = sthConfig;
         const decodedAdapterConfig = adapterConfigDecoder.decode(sthConfig.kubernetes);
 
         if (!decodedAdapterConfig.isOk()) {
@@ -109,7 +111,10 @@ IComponent {
                 instancesServerPort,
                 instancesServerHost: this.adapterConfig.sthPodHost,
                 instanceId,
-                pipesPath: ""
+                pipesPath: "",
+                ...this.sthConfig.runnerEnvs
+            }, {
+                ...this.sthConfig.runnerEnvs
             }).map(([name, value]) => ({ name, value }));
 
         const runnerImage = config.engines.python3

--- a/packages/adapters/src/kubernetes-instance-adapter.ts
+++ b/packages/adapters/src/kubernetes-instance-adapter.ts
@@ -111,8 +111,7 @@ IComponent {
                 instancesServerPort,
                 instancesServerHost: this.adapterConfig.sthPodHost,
                 instanceId,
-                pipesPath: "",
-                ...this.sthConfig.runnerEnvs
+                pipesPath: ""
             }, {
                 ...this.sthConfig.runnerEnvs
             }).map(([name, value]) => ({ name, value }));

--- a/packages/adapters/src/process-instance-adapter.ts
+++ b/packages/adapters/src/process-instance-adapter.ts
@@ -134,7 +134,7 @@ class ProcessInstanceAdapter implements
             instancesServerHost: "127.0.0.1",
             instancesServerPort,
             instanceId,
-            pipesPath: "",
+            pipesPath: ""
         }, {
             PYTHONPATH: this.getPythonpath(config.sequenceDir),
             ...this.sthConfig.runnerEnvs

--- a/packages/adapters/src/process-instance-adapter.ts
+++ b/packages/adapters/src/process-instance-adapter.ts
@@ -134,9 +134,10 @@ class ProcessInstanceAdapter implements
             instancesServerHost: "127.0.0.1",
             instancesServerPort,
             instanceId,
-            pipesPath: ""
+            pipesPath: "",
         }, {
             PYTHONPATH: this.getPythonpath(config.sequenceDir),
+            ...this.sthConfig.runnerEnvs
         });
 
         this.logger.debug("Spawning Runner process with command", runnerCommand);

--- a/packages/sth/src/bin/hub.ts
+++ b/packages/sth/src/bin/hub.ts
@@ -8,7 +8,7 @@ import { resolve } from "path";
 import { HostError } from "@scramjet/model";
 import { inspect } from "util";
 import { Host } from "@scramjet/host";
-import { FileBuilder, processCommanderEnvs } from "@scramjet/utility";
+import { FileBuilder, processCommanderRunnerEnvs } from "@scramjet/utility";
 
 const stringToIntSanitizer = (str : string) => {
     const parsedValue = parseInt(str, 10);
@@ -92,7 +92,7 @@ const options: OptionValues & STHCommandOptions = program
         configService.update(configContents);
     }
     if (options.runnerEnvs) {
-        processCommanderEnvs(options.runnerEnvs);
+        configService.update({ runnerEnvs: processCommanderRunnerEnvs(options.runnerEnvs) });
     }
     if (options.tags.length) {
         configService.update({ tags: options.tags.split(",") });

--- a/packages/sth/src/bin/hub.ts
+++ b/packages/sth/src/bin/hub.ts
@@ -94,6 +94,7 @@ const options: OptionValues & STHCommandOptions = program
     if (options.runnerEnvs) {
         configService.update({ runnerEnvs: processCommanderRunnerEnvs(options.runnerEnvs) });
     }
+
     if (options.tags.length) {
         configService.update({ tags: options.tags.split(",") });
     }

--- a/packages/sth/src/bin/hub.ts
+++ b/packages/sth/src/bin/hub.ts
@@ -74,7 +74,7 @@ const options: OptionValues & STHCommandOptions = program
     .option("--healtz-port <healtz-port>", "Starts monitoring sever on a selected port")
     .option("--healtz-host <healtz-host>", "Starts monitoring sever on a specified interface e.g [\"0.0.0.0\"]. Requires --healtz-port")
     .option("--healtz-path <healtz-path>", "Exposes monitoring endpoint on specified path. Requires --healtz-port")
-    .option("-e, --runner-envs <runnerEnvs>", "Additional ENVs for Runners. e.g ENV1=1;ENV2=2")
+    .option("--runner-envs <runnerEnvs>", "Additional ENVs for Runners. e.g ENV1=1;ENV2=2")
 
     .parse(process.argv)
     .opts() as STHCommandOptions;

--- a/packages/sth/src/bin/hub.ts
+++ b/packages/sth/src/bin/hub.ts
@@ -8,7 +8,7 @@ import { resolve } from "path";
 import { HostError } from "@scramjet/model";
 import { inspect } from "util";
 import { Host } from "@scramjet/host";
-import { FileBuilder } from "@scramjet/utility";
+import { FileBuilder, processCommanderEnvs } from "@scramjet/utility";
 
 const stringToIntSanitizer = (str : string) => {
     const parsedValue = parseInt(str, 10);
@@ -74,6 +74,7 @@ const options: OptionValues & STHCommandOptions = program
     .option("--healtz-port <healtz-port>", "Starts monitoring sever on a selected port")
     .option("--healtz-host <healtz-host>", "Starts monitoring sever on a specified interface e.g [\"0.0.0.0\"]. Requires --healtz-port")
     .option("--healtz-path <healtz-path>", "Exposes monitoring endpoint on specified path. Requires --healtz-port")
+    .option("-e, --env <envVars...>", "Array of environment variables")
 
     .parse(process.argv)
     .opts() as STHCommandOptions;
@@ -89,6 +90,9 @@ const options: OptionValues & STHCommandOptions = program
         const configContents = configFile.read() as DeepPartial<STHConfiguration>;
 
         configService.update(configContents);
+    }
+    if (options.env) {
+        processCommanderEnvs(options.env);
     }
 
     if (options.tags.length) {

--- a/packages/sth/src/bin/hub.ts
+++ b/packages/sth/src/bin/hub.ts
@@ -74,7 +74,7 @@ const options: OptionValues & STHCommandOptions = program
     .option("--healtz-port <healtz-port>", "Starts monitoring sever on a selected port")
     .option("--healtz-host <healtz-host>", "Starts monitoring sever on a specified interface e.g [\"0.0.0.0\"]. Requires --healtz-port")
     .option("--healtz-path <healtz-path>", "Exposes monitoring endpoint on specified path. Requires --healtz-port")
-    .option("-e, --env <envVars...>", "Array of environment variables")
+    .option("-e, --runner-envs <runnerEnvs>", "Set Runner environmental variables")
 
     .parse(process.argv)
     .opts() as STHCommandOptions;
@@ -91,10 +91,9 @@ const options: OptionValues & STHCommandOptions = program
 
         configService.update(configContents);
     }
-    if (options.env) {
-        processCommanderEnvs(options.env);
+    if (options.runnerEnvs) {
+        processCommanderEnvs(options.runnerEnvs);
     }
-
     if (options.tags.length) {
         configService.update({ tags: options.tags.split(",") });
     }

--- a/packages/sth/src/bin/hub.ts
+++ b/packages/sth/src/bin/hub.ts
@@ -74,7 +74,7 @@ const options: OptionValues & STHCommandOptions = program
     .option("--healtz-port <healtz-port>", "Starts monitoring sever on a selected port")
     .option("--healtz-host <healtz-host>", "Starts monitoring sever on a specified interface e.g [\"0.0.0.0\"]. Requires --healtz-port")
     .option("--healtz-path <healtz-path>", "Exposes monitoring endpoint on specified path. Requires --healtz-port")
-    .option("-e, --runner-envs <runnerEnvs>", "Set Runner environmental variables")
+    .option("-e, --runner-envs <runnerEnvs>", "Additional ENVs for Runners. e.g ENV1=1;ENV2=2")
 
     .parse(process.argv)
     .opts() as STHCommandOptions;

--- a/packages/types/src/sth-command-options.ts
+++ b/packages/types/src/sth-command-options.ts
@@ -52,5 +52,5 @@ export type STHCommandOptions = {
     environmentName?: string;
     telemetry: TelemetryConfig["status"]
     monitoringServer: { port: number },
-    env?: string[];
+    runnerEnvs?: string;
 }

--- a/packages/types/src/sth-command-options.ts
+++ b/packages/types/src/sth-command-options.ts
@@ -51,5 +51,6 @@ export type STHCommandOptions = {
     instanceLifetimeExtensionDelay: number;
     environmentName?: string;
     telemetry: TelemetryConfig["status"]
-    monitoringServer: { port: number }
+    monitoringServer: { port: number },
+    env?: string[];
 }

--- a/packages/types/src/sth-command-options.ts
+++ b/packages/types/src/sth-command-options.ts
@@ -51,6 +51,6 @@ export type STHCommandOptions = {
     instanceLifetimeExtensionDelay: number;
     environmentName?: string;
     telemetry: TelemetryConfig["status"]
-    monitoringServer: { port: number },
+    monitoringServer: { port: number };
     runnerEnvs?: string;
 }

--- a/packages/types/src/sth-configuration.ts
+++ b/packages/types/src/sth-configuration.ts
@@ -273,7 +273,7 @@ export type STHConfiguration = {
 
     monitorgingServer?: MonitoringServerConfig;
 
-    runnerEnvs?: Record<string, string>
+    runnerEnvs?: Record<string, string>;
 }
 
 export type PublicSTHConfiguration = Omit<Omit<Omit<STHConfiguration, "sequencesRoot">, "cpmSslCaPath">, "kubernetes"> & {

--- a/packages/types/src/sth-configuration.ts
+++ b/packages/types/src/sth-configuration.ts
@@ -272,6 +272,8 @@ export type STHConfiguration = {
     telemetry: TelemetryConfig;
 
     monitorgingServer?: MonitoringServerConfig;
+
+    runnerEnvs?: Record<string, string>
 }
 
 export type PublicSTHConfiguration = Omit<Omit<Omit<STHConfiguration, "sequencesRoot">, "cpmSslCaPath">, "kubernetes"> & {

--- a/packages/utility/src/index.ts
+++ b/packages/utility/src/index.ts
@@ -13,3 +13,4 @@ export * from "./file";
 export * from "./constants";
 export * from "./validators";
 export * from "./keygen";
+export * from "./process-env";

--- a/packages/utility/src/process-env.ts
+++ b/packages/utility/src/process-env.ts
@@ -1,17 +1,10 @@
-export function processCommanderEnvs(env: string[]) {
-    const keyValuePairs = env.map((item: string) => {
-        const [key, value] = item.split(":");
+export function processCommanderEnvs(envString: string) {
+    const pairs = envString.split(";").map(pair => pair.split("="));
 
+    pairs.forEach(([key, value]) => {
         if (!key || key === "" || !value || value === "") {
-            throw new Error("Invalid format for ENV variables. Please use the format KEY:VALUE.");
+            throw new Error("Invalid format for ENV variables. Please use the format key1=value1;key2=value2.");
         }
-
-        return [key, value];
     });
-
-    keyValuePairs.forEach((e) => {
-        const name = e[0];
-
-        process.env[name] = e[1];
-    });
+    return pairs;
 }

--- a/packages/utility/src/process-env.ts
+++ b/packages/utility/src/process-env.ts
@@ -1,10 +1,13 @@
-export function processCommanderEnvs(envString: string) {
+export function processCommanderRunnerEnvs(envString: string): Record<string, string> {
     const pairs = envString.split(";").map(pair => pair.split("="));
 
-    pairs.forEach(([key, value]) => {
+    const transformedObject = pairs.reduce((acc, [key, value]) => {
         if (!key || key === "" || !value || value === "") {
             throw new Error("Invalid format for ENV variables. Please use the format key1=value1;key2=value2.");
         }
-    });
-    return pairs;
+
+        return { ...acc, [key]: value };
+    }, {});
+
+    return transformedObject;
 }

--- a/packages/utility/src/process-env.ts
+++ b/packages/utility/src/process-env.ts
@@ -1,0 +1,17 @@
+export function processCommanderEnvs(env: string[]) {
+    const keyValuePairs = env.map((item: string) => {
+        const [key, value] = item.split(":");
+
+        if (!key || key === "" || !value || value === "") {
+            throw new Error("Wrong ENV syntax");
+        }
+
+        return [key, value];
+    });
+
+    keyValuePairs.forEach((e) => {
+        const name = e[0];
+
+        process.env[name] = e[1];
+    });
+}

--- a/packages/utility/src/process-env.ts
+++ b/packages/utility/src/process-env.ts
@@ -3,7 +3,7 @@ export function processCommanderEnvs(env: string[]) {
         const [key, value] = item.split(":");
 
         if (!key || key === "" || !value || value === "") {
-            throw new Error("Wrong ENV syntax");
+            throw new Error("Invalid format for ENV variables. Please use the format KEY:VALUE.");
         }
 
         return [key, value];


### PR DESCRIPTION
Added option to start declare env variablers when starting sth

#### Example:
`DEVELOPMENT=1 yarn start:dev --runner-envs "KEY1=VALUE1;KEY2=VALUE2" `

Only acceptable format is providing variables in a key:value format with a space between them.
Otherwise error will be thrown


**Clickup Task:** <!-- Paste corresponding link to a clickup task -->
https://app.clickup.com/t/24308805/VDM-1268


