### PR TITLE
Shorten instance/<instanceID>/events/:name endpoint response

### DIFF
--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -110,14 +110,14 @@ Feature: CLI tests
         When I execute CLI with "seq deploy ../packages/event-sequence-v2.tar.gz"
         When I execute CLI with "inst event emit - test-event test message"
         When I execute CLI with "inst event on - test-event-response"
-        Then I get event "test-event-response" with event message "{\"eventName\":\"test-event-response\",\"message\":\"message from sequence\"}" from Instance
+        Then I get event "test-event-response" with event message "\"message from sequence\"" from Instance
 
     @ci-api @cli
     Scenario: E2E-010 TC-013a Test Instance 'event' option without payload
         When I execute CLI with "seq deploy ../packages/event-sequence-v2.tar.gz"
         When I execute CLI with "inst event emit - test-event"
         When I execute CLI with "inst event on - test-event-response"
-        Then I get event "test-event-response" with event message "{\"eventName\":\"test-event-response\",\"message\":\"message from sequence\"}" from Instance
+        Then I get event "test-event-response" with event message "\"message from sequence\"" from Instance
 
     @ci-api @cli
     Scenario: E2E-010 TC-014 Test Sequence 'start' with multiple JSON arguments

--- a/bdd/features/e2e/E2E-012-stream-flooding-test.feature
+++ b/bdd/features/e2e/E2E-012-stream-flooding-test.feature
@@ -11,7 +11,7 @@ Feature: Stream flooding tests. Ensure that even if a large amount of data is se
         And wait for "3000" ms
         And send event "test-event" to instance with message "test message"
         Then get event "test-event-response" from instance
-        Then instance response body is "{\"eventName\":\"test-event-response\",\"message\":\"message from sequence\"}"
+        Then instance response body is "\"message from sequence\""
         Then host is still running
 
     @ci-api @runner-cleanup
@@ -23,6 +23,6 @@ Feature: Stream flooding tests. Ensure that even if a large amount of data is se
         And get runner PID
         Then get event "test-event-response" from instance
         When wait for "1000" ms
-        Then instance response body is "{\"eventName\":\"test-event-response\",\"message\":\"message from sequence\"}"
+        Then instance response body is "\"message from sequence\""
         Then host is still running
 

--- a/bdd/features/e2e/E2E-015-unified.feature
+++ b/bdd/features/e2e/E2E-015-unified.feature
@@ -75,6 +75,6 @@ Feature: Test our shiny new Python runner
         And send event "test-event" to instance with message "foo"
         Then instance emits event "test-response" with body
             """
-            {"eventName":"test-response","message":"reply to foo"}
+            "reply to foo"
             """
         And host is still running

--- a/packages/cli/src/lib/commands/instance.ts
+++ b/packages/cli/src/lib/commands/instance.ts
@@ -190,9 +190,9 @@ export const instance: CommandDefinition = (program) => {
         .action(async (id: string, event: string, { next, stream }) => {
             if (stream) return displayStream(getInstance(getInstanceId(id)).getEventStream(event));
             if (next) return displayEntity(getInstance(getInstanceId(id)).getNextEvent(event),
-                profileManager.getProfileConfig().format);
+                "json");
             return displayEntity(
-                getInstance(getInstanceId(id)).getEvent(event), profileManager.getProfileConfig().format
+                getInstance(getInstanceId(id)).getEvent(event), "json"
             );
         });
 

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -672,7 +672,14 @@ export class CSIController extends TypedEmitter<Events> {
             }
 
             const out = new DataStream();
-            const handler = (data: any) => out.write(data);
+            const handler = (data: any) => {
+                if (typeof data !== "object") {
+                    out.write(data);
+                }
+                const { eventName, ...message} = data;
+
+                out.write(message ? message : {} );
+            }
             const clean = () => {
                 this.logger.debug(`Event stream "${name}" disconnected`);
 

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -662,9 +662,10 @@ export class CSIController extends TypedEmitter<Events> {
 
             if (!event.eventName) return;
 
-            localEmitter.lastEvents[event.eventName] = event;
+            localEmitter.lastEvents[event.eventName] = event.message;
             localEmitter.emit(event.eventName, event);
         });
+
         this.router.upstream("/events/:name", async (req: ParsedMessage, res: ServerResponse) => {
             const name = req.params?.name;
 
@@ -700,14 +701,14 @@ export class CSIController extends TypedEmitter<Events> {
             return out.JSONStringify();
         });
 
-        const awaitEvent = async (req: ParsedMessage): Promise<unknown> => new Promise(res => {
+        const awaitEvent = async (req: ParsedMessage): Promise<unknown> => new Promise((res) => {
             const name = req.params?.name;
 
             if (!name) {
                 throw new HostError("EVENT_NAME_MISSING");
             }
 
-            localEmitter.once(name, res);
+            localEmitter.once(name, (data) => res(data.message));
         });
 
         this.router.get("/event/:name", async (req) => {

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -23,6 +23,7 @@ import {
     OpResponse,
     StopSequenceMessageData,
     HostProxy,
+    EventMessageData,
 } from "@scramjet/types";
 import {
     AppError,
@@ -670,17 +671,19 @@ export class CSIController extends TypedEmitter<Events> {
             if (!name) {
                 throw new HostError("EVENT_NAME_MISSING");
             }
-
             const out = new DataStream();
-            const handler = (data: any) => {
+            const handler = (data: EventMessageData) => {
                 if (typeof data !== "object") {
                     out.write(data);
+
+                    return;
                 }
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                const { _eventName, ...message } = data;
+
+                const { message } = data;
 
                 out.write(message ? message : {});
             };
+
             const clean = () => {
                 this.logger.debug(`Event stream "${name}" disconnected`);
 

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -676,10 +676,11 @@ export class CSIController extends TypedEmitter<Events> {
                 if (typeof data !== "object") {
                     out.write(data);
                 }
-                const { eventName, ...message} = data;
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                const { _eventName, ...message } = data;
 
-                out.write(message ? message : {} );
-            }
+                out.write(message ? message : {});
+            };
             const clean = () => {
                 this.logger.debug(`Event stream "${name}" disconnected`);
 

--- a/packages/types/src/api-expose.ts
+++ b/packages/types/src/api-expose.ts
@@ -6,7 +6,10 @@ import { ControlMessageCode, MonitoringMessageCode } from "./message-streams";
 import { IObjectLogger } from "./object-logger";
 import { MaybePromise } from "./utils";
 
-export type ParsedMessage = IncomingMessage & { body?: any; params?: { [key: string]: any } | undefined };
+export type ParsedMessage = IncomingMessage & {
+    body?: any;
+    params?: { [key: string]: any }
+};
 export type HttpMethod = "get" | "head" | "post" | "put" | "delete" | "connect" | "trace" | "patch";
 
 export type StreamInput =


### PR DESCRIPTION
Make events data more readable with removal of redundant data in output
`http://0.0.0.0:8000/api/v1/instance/{instanceId}/events/{eventName}`

before:
```
{ "eventName": "msg", "message": { "a": 1 } }
{ "eventName": "msg", "message": { "a": 2 } }
{ "eventName": "msg", "message": { "a": 3 } }
```
now returns:
```
{ "a": 1 }
{ "a": 2 }
{ "a": 3 }
```
without message used to return:
```
{ "eventName": "msg"  }
{ "eventName": "msg"  }
{ "eventName": "msg"  }
```
now returns 
```
 {}
 {}
 {}
```

### Screenshots
events with no message:
![image](https://github.com/scramjetorg/transform-hub/assets/53794300/7b922b86-f000-4ade-980b-d04fa61efef5)

events with object as a message:
![image](https://github.com/scramjetorg/transform-hub/assets/53794300/74d57a62-d987-48fc-9827-c028a4323a17)

events with string as a message:
![image](https://github.com/scramjetorg/transform-hub/assets/53794300/1fc79519-6c3c-4bbd-b4b9-63ee770c9c90)


**Clickup Task:** <!-- Paste corresponding link to a clickup task -->
https://app.clickup.com/t/24308805/VDM-1283
**Issue:**
https://github.com/scramjetorg/transform-hub/issues/328

