### PR TITLE
[CLI]add path option to si init

### DIFF
--- a/packages/cli/src/lib/commands/init.ts
+++ b/packages/cli/src/lib/commands/init.ts
@@ -13,12 +13,21 @@ export const init: CommandDefinition = (program) => {
     initCmd
         .command("sequence")
         .alias("seq")
-        .addArgument(new Argument("[language]", "Choose the language to develop the sequence").choices(["ts", "js", "py"]).default("js"))
-        .addArgument(new Argument("[type]", "Choose transformation type of the sequence").choices(["generator", "transformer", "consumer"]).default("transformer"))
+        .addArgument(
+            new Argument("[language]", "Choose the language to develop the sequence")
+                .choices(["ts", "js", "py"])
+                .default("js")
+        )
+        .addArgument(
+            new Argument("[type]", "Choose transformation type of the sequence")
+                .choices(["generator", "transformer", "consumer"])
+                .default("transformer")
+        )
+        .option("-p, --path <dir-path>", "Path to create sequence")
         .description("Create all the necessary files and start working on your Sequence")
-        .action(async (language: string, type: string) => {
+        .action(async (language: string, type: string, { path }) => {
             const args = `init scramjetorg/sequence ${language}-${type}`;
 
-            spawnSync("npm", args.split(" "), { stdio: "inherit" });
+            spawnSync("npm", args.split(" "), { stdio: "inherit", cwd: path });
         });
 };


### PR DESCRIPTION
**What?**
Add option to create template sequence in specified folder

**Usage:**
- `si init seq js transformer -p <dir-path>`
- `si init seq js transformer --path <dir-path>`

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

