### PR TITLE
Change in makeRequest method

### DIFF
--- a/packages/verser/src/lib/verser-connection.ts
+++ b/packages/verser/src/lib/verser-connection.ts
@@ -166,11 +166,18 @@ export class VerserConnection {
     public async makeRequest(options: RequestOptions): Promise<VerserRequestResult> {
         if (!this.connected) throw new Error("Not connected");
 
-        this.logger.debug("making request", options);
         return new Promise((resolve, reject) => {
+            let expectedEvent = "response";
+
+            if (options.headers?.Expect) {
+                expectedEvent = "continue";
+            }
+
+            this.logger.debug("making request and waiting for event", options, expectedEvent);
+
             const clientRequest = httpRequest({ ...options, agent: this.agent })
-                .on("response", (incomingMessage: IncomingMessage) => {
-                    this.logger.debug("Got Response", options);
+                .on(expectedEvent, (incomingMessage: IncomingMessage) => {
+                    this.logger.debug(`Got event ${expectedEvent}`);
                     resolve({ incomingMessage, clientRequest });
                 })
                 .on("error", (error: Error) => {


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
In this change, modifications were made to the makeRequest method to improve the handling of HTTP requests. Below is a detailed description of the changes:

A new variable `expectedEvent` was added, which is set to "response" or "continue" depending on the value of `options.headers?.Expect`. This change allows for more flexible event management depending on the expected HTTP headers.

Logging was changed, adding the event name to the debugging message. Now, instead of logging “making request”, we log “making request and waiting for event”, which gives more information about what event is expected.

The way events are handled by `clientRequest` was also changed. Now instead of always listening for the `response` event, we listen for the event specified by `expectedEvent`.

These changes should improve the handling of HTTP requests and provide more flexibility in handling different types of requests. Please review and approve these changes.

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

