### PR TITLE
[HOST] Api remove support for getSequenceByName

### DIFF
--- a/packages/api-client/src/host-client.ts
+++ b/packages/api-client/src/host-client.ts
@@ -92,10 +92,9 @@ export class HostClient implements ClientProvider {
     async sendSequence(
         sequencePackage: Parameters<HttpClient["sendStream"]>[1],
         requestInit?: RequestInit,
-        update?: boolean
     ): Promise<SequenceClient> {
         const response = await this.client.sendStream<any>("sequence", sequencePackage, requestInit, {
-            parseResponse: "json", put: update
+            parseResponse: "json"
         });
 
         return SequenceClient.from(response.id, this);

--- a/packages/api-client/src/sequence-client.ts
+++ b/packages/api-client/src/sequence-client.ts
@@ -96,7 +96,7 @@ export class SequenceClient {
     }
 
     async overwrite(stream: Readable) {
-        const response = await this.clientUtils.sendStream<any>("sequence", stream, { method: "PUT" }, {
+        const response = await this.clientUtils.sendStream<any>(`sequence/${this.id}`, stream, { method: "put" }, {
             parseResponse: "json"
         });
 

--- a/packages/cli/src/lib/commands/sequence.ts
+++ b/packages/cli/src/lib/commands/sequence.ts
@@ -88,11 +88,10 @@ export const sequence: CommandDefinition = (program) => {
     sequenceCmd
         .command("send")
         .argument("<package>", "The file or directory to upload or '-' to use the last packed. If directory, it will be packed and sent.")
-        .option("--name <name>", "Allows to name sequence")
         .description("Send the Sequence package to the Hub")
         .action(
-            async (sequencePackage: string, { name }) => {
-                const sequenceClient = await sequenceSendPackage(sequencePackage, { name }, false, { progress: sequenceCmd.parent?.getOptionValue("progress") });
+            async (sequencePackage: string) => {
+                const sequenceClient = await sequenceSendPackage(sequencePackage, {}, false, { progress: sequenceCmd.parent?.getOptionValue("progress") });
 
                 displayObject(sequenceClient, profileManager.getProfileConfig().format);
             }
@@ -100,12 +99,12 @@ export const sequence: CommandDefinition = (program) => {
 
     sequenceCmd
         .command("update")
-        .argument("<query>", "Sequence id or name to be overwritten")
+        .argument("<query>", "Sequence id to be overwritten")
         .argument("<package>", "The file to upload")
         .description("Update Sequence with given name")
         .action(
             async (query: string, sequencePackage: string) => {
-                const sequenceClient = await sequenceSendPackage(sequencePackage, { name: query }, true);
+                const sequenceClient = await sequenceSendPackage(sequencePackage, { id: query }, true);
 
                 displayObject(sequenceClient, profileManager.getProfileConfig().format);
             }

--- a/packages/cli/src/lib/helpers/sequence.ts
+++ b/packages/cli/src/lib/helpers/sequence.ts
@@ -19,7 +19,7 @@ import { EOL } from "os";
 const { F_OK, R_OK } = constants;
 
 type SequenceUploadOptions = {
-    name?: string;
+    id?: string;
 }
 
 /**
@@ -84,8 +84,6 @@ export const sequenceSendPackage = async (
     sequencePackage: string, options: SequenceUploadOptions = {}, update = false, config: { progress?: boolean } = {}
 ): Promise<SequenceClient> => {
     try {
-        const id = getSequenceId(options.name!);
-
         let sequencePath = getPackagePath(sequencePackage);
 
         if ((await lstat(sequencePath)).isDirectory()) {
@@ -124,19 +122,14 @@ export const sequenceSendPackage = async (
         }
 
         if (update) {
+            const id = getSequenceId(options.id!);
+
             seq = await getHostClient().getSequenceClient(id)?.overwrite(
                 sequenceStream,
             );
         } else {
-            const headers: HeadersInit = {};
-
-            if (options.name) {
-                headers["x-name"] = options.name;
-            }
-
             seq = await getHostClient().sendSequence(
                 sequenceStream,
-                { headers }
             );
         }
 

--- a/packages/client-utils/src/client-utils.ts
+++ b/packages/client-utils/src/client-utils.ts
@@ -218,7 +218,7 @@ export abstract class ClientUtilsBase implements HttpClient {
         url: string,
         stream: any | string,
         requestInit: RequestInit = {},
-        { type = "application/octet-stream", end, parseResponse = "stream", put = false }: SendStreamOptions = {}
+        { type = "application/octet-stream", end, parseResponse = "stream" }: SendStreamOptions = {}
     ): Promise<T> {
         requestInit.headers ||= {} as Headers;
 
@@ -230,8 +230,11 @@ export abstract class ClientUtilsBase implements HttpClient {
         if (typeof end !== "undefined") {
             (requestInit.headers as Headers)["x-end-stream"] = end ? "true" : "false";
         }
+        let method: "post" | "put" = "post";
 
-        return this[put ? "put" : "post"]<T>(url, stream, requestInit, { parse: parseResponse });
+        if (requestInit.method === "put") method = "put";
+
+        return this[method]<T>(url, stream, requestInit, { parse: parseResponse });
     }
 
     /**

--- a/packages/client-utils/src/types/index.ts
+++ b/packages/client-utils/src/types/index.ts
@@ -8,7 +8,6 @@ export type SendStreamOptions = Partial<{
     type: string;
     end: boolean;
     parseResponse?: "json" | "text" | "stream";
-    put: boolean
 }>;
 
 /**

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -781,15 +781,13 @@ export class Host implements IComponent {
             const existingSequence = this.sequenceStore.getById(id as string);
 
             if (existingSequence) {
-                if (req.method !== "put") {
-                    this.logger.debug("Overriding sequence", id, existingSequence.id);
-
+                if (req.method?.toLowerCase() !== "put") {
                     return {
                         opStatus: ReasonPhrases.METHOD_NOT_ALLOWED,
                         error: `Sequence with name ${id} already exist`
                     };
                 }
-
+                this.logger.debug("Overriding sequence", id, existingSequence.id);
                 id = existingSequence.id;
             }
 
@@ -828,7 +826,6 @@ export class Host implements IComponent {
 
     async handleUpdateSequence(req: ParsedMessage): Promise<OpResponse<STHRestAPI.SendSequenceResponse>> {
         req.params ||= {};
-
         if (!req.params.id) return { opStatus: ReasonPhrases.BAD_REQUEST, error: "missing id parameter" };
 
         const id = req.params.id as string;
@@ -842,7 +839,7 @@ export class Host implements IComponent {
             return { opStatus: ReasonPhrases.CONFLICT, error: "Can't update sequence with instances" };
         }
 
-        this.logger.debug("Overriding sequence", existingSequence.name, existingSequence.id);
+        this.logger.debug("Sequence Update", existingSequence.id);
 
         return this.handleIncomingSequence(req, id);
     }

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -629,6 +629,7 @@ export class Host implements IComponent {
      */
     async handleDeleteSequence(req: ParsedMessage): Promise<OpResponse<STHRestAPI.DeleteSequenceResponse>> {
         if (!req.params?.id) return { opStatus: ReasonPhrases.BAD_REQUEST, error: "Missing id parameter" };
+
         const id = req.params.id as string;
         const sequence: SequenceInfo| undefined = this.sequenceStore.getById(req.params.id as string);
 
@@ -828,7 +829,7 @@ export class Host implements IComponent {
     async handleUpdateSequence(req: ParsedMessage): Promise<OpResponse<STHRestAPI.SendSequenceResponse>> {
         req.params ||= {};
 
-        if (!req.params?.id) return { opStatus: ReasonPhrases.BAD_REQUEST, error: "missing id parameter" };
+        if (!req.params.id) return { opStatus: ReasonPhrases.BAD_REQUEST, error: "missing id parameter" };
 
         const id = req.params.id as string;
         const existingSequence: SequenceInfo | undefined = this.sequenceStore.getById(req.params.id as string);
@@ -1138,6 +1139,7 @@ export class Host implements IComponent {
      */
     getSequence(req: ParsedMessage): OpResponse<STHRestAPI.GetSequenceResponse> {
         if (!req.params?.id) return { opStatus: ReasonPhrases.BAD_REQUEST, error: "Missing id parameter" };
+
         const id = req.params.id;
         const sequence = this.sequenceStore.getById(id);
 

--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -628,10 +628,12 @@ export class Host implements IComponent {
      * @returns {Promise<STHRestAPI.DeleteSequenceResponse>} Promise resolving to operation result object.
      */
     async handleDeleteSequence(req: ParsedMessage): Promise<OpResponse<STHRestAPI.DeleteSequenceResponse>> {
-        if (!req.params?.id) return { opStatus: ReasonPhrases.BAD_REQUEST, error: "Missing id parameter" };
+        if (!req.params?.id || typeof req.params.id !== "string") {
+            return { opStatus: ReasonPhrases.BAD_REQUEST, error: "Missing id parameter" };
+        }
 
-        const id = req.params.id as string;
-        const sequence: SequenceInfo| undefined = this.sequenceStore.getById(req.params.id as string);
+        const id = req.params.id;
+        const sequence: SequenceInfo| undefined = this.sequenceStore.getById(id);
 
         const force = req.headers[HostHeaders.SEQUENCE_FORCE_REMOVE];
 
@@ -826,10 +828,13 @@ export class Host implements IComponent {
 
     async handleUpdateSequence(req: ParsedMessage): Promise<OpResponse<STHRestAPI.SendSequenceResponse>> {
         req.params ||= {};
-        if (!req.params.id) return { opStatus: ReasonPhrases.BAD_REQUEST, error: "missing id parameter" };
 
-        const id = req.params.id as string;
-        const existingSequence: SequenceInfo | undefined = this.sequenceStore.getById(req.params.id as string);
+        if (!req.params.id || typeof req.params.id !== "string") {
+            return { opStatus: ReasonPhrases.BAD_REQUEST, error: "missing id parameter" };
+        }
+
+        const id = req.params.id;
+        const existingSequence: SequenceInfo | undefined = this.sequenceStore.getById(id);
 
         if (!existingSequence) {
             return { opStatus: ReasonPhrases.NOT_FOUND, error: `Sequence with id: ${id} not found` };

--- a/packages/manager-api-client/src/manager-client.ts
+++ b/packages/manager-api-client/src/manager-client.ts
@@ -84,8 +84,8 @@ export class ManagerClient implements ClientProvider {
         sequencePackage: Readable,
         id: string = ""
     ) {
-        return this.client.sendStream<MRestAPI.PutStoreItemResponse>(`s3/${id}`, sequencePackage, {}, {
-            parseResponse: "json", put: true
+        return this.client.sendStream<MRestAPI.PutStoreItemResponse>(`s3/${id}`, sequencePackage, { method: "put" }, {
+            parseResponse: "json"
         });
     }
 


### PR DESCRIPTION
**What?**  <!-- Two-sentence summary, understandable for a junior. -->
- Change host api Api sequence endpoint to be compatible with REST standard.
- Small changes to implement naming consistency 
- fix issues related to updating sequence via CLI. (When updating sequence cli was requesting using post method instead of put)

<!-- Example (if applicable), how to verify (if not covered by tests). -->
### Endpoints before:
`http://{host-apiBase}/sequence/:id_name`
Accepts both id/name

### After changes
`http://{host-apiBase}/sequence/:id`
Accepts only id now


###  New endpoint work structure works for all available methods for this url (GET, UPDATE, DELETE)

**Clickup Task:** <!-- Paste corresponding link to a clickup task -->
https://app.clickup.com/t/24308805/VDM-1423

