### PR TITLE
Immediately send loadCheck to cmp when available

### DIFF
--- a/packages/host/src/lib/cpm-connector.ts
+++ b/packages/host/src/lib/cpm-connector.ts
@@ -255,8 +255,6 @@ export class CPMConnector extends TypedEmitter<Events> {
 
         this.logger.info(`${EOL}${EOL}\t\x1b[33m${this.config.id} connected to ${this.cpmId}\x1b[0m${EOL} `);
 
-        await this.setLoadCheckMessageSender();
-
         StringStream.from(duplex.input as Readable)
             .JSONParse()
             .map(async (message: EncodedControlMessage) => {
@@ -298,6 +296,8 @@ export class CPMConnector extends TypedEmitter<Events> {
 
         this.communicationStream = new StringStream().JSONStringify().resume();
         this.communicationStream.pipe(duplex.output);
+
+        await this.setLoadCheckMessageSender();
 
         this.communicationStream.on("pause", () => {
             this.logger.warn("Communication stream paused");


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Move call to `setLoadCheckMessageSender` after communicationStream is set.
Now loadCheck is called in second iteration because cs is not ready at first call


**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

