### PR TITLE
added alias to delete hub

### DIFF
--- a/packages/cli/src/lib/commands/hub.ts
+++ b/packages/cli/src/lib/commands/hub.ts
@@ -91,6 +91,7 @@ export const hub: CommandDefinition = (program) => {
 
         hubCmd
             .command("delete")
+            .alias("rm")
             .description("Delete self hosted Hub from space")
             .argument("<id>", "Hub Id")
             .option("-f, --force", "Enable deleting Hubs that are not disconnected", false)


### PR DESCRIPTION
**What?** 

Added missed rm alias to delete hub 

**Why?**  

Everywhere rm alias is used to delete

**Usage:**

Add self hosted hub.
Connect to space.
type: `yarn start:dev:cli hub rm <HUB_ID>`

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

