### PR TITLE
[Fix] Refapps update after release 0.26.0

### DIFF
--- a/bdd/features/e2e/E2E-007-host-client.feature
+++ b/bdd/features/e2e/E2E-007-host-client.feature
@@ -5,7 +5,7 @@ Feature: Test for host client used by sequences
     @ci-api @cli
     Scenario: E2E-007 TC-001 Test sequence with basic host client methods like getVersion(), getStatus(), etc.
         Given I set config for local Hub
-        When I execute CLI with "seq send ../packages/hostclient-basic.tar.gz"
+        When I execute CLI with "seq send ../packages/js-hostclient-basic.tar.gz"
         When I execute CLI with "seq start -"
         And wait for "3000" ms
         When I execute CLI with "inst output -" without waiting for the end
@@ -18,10 +18,10 @@ Feature: Test for host client used by sequences
     @ci-api @cli
     Scenario: E2E-007 TC-002 Test Sequence that starts another Sequence
         Given I set config for local Hub
-        When I execute CLI with "seq send ../packages/hostclient-basic.tar.gz"
+        When I execute CLI with "seq send ../packages/js-hostclient-basic.tar.gz"
         And I execute CLI with "seq info -"
         And I get sequence id
-        Then I start "hostclient-start-seq" with the first sequence id
+        Then I start "js-hostclient-start-seq" with the first sequence id
         When I execute CLI with "inst output -" without waiting for the end
         Then I confirm data received
         And I execute CLI with "inst kill - --removeImmediately"

--- a/bdd/features/e2e/E2E-010-cli.feature
+++ b/bdd/features/e2e/E2E-010-cli.feature
@@ -79,7 +79,7 @@ Feature: CLI tests
 
     @ci-api @cli
     Scenario: E2E-010 TC-009 Get 404 on health endpoint for finished Instance
-        When I execute CLI with "seq send ../packages/inert-function.tar.gz"
+        When I execute CLI with "seq send ../packages/js-inert-function.tar.gz"
         When I execute CLI with "seq start -"
         When I execute CLI with "inst health -"
         And I wait for Instance to end
@@ -88,7 +88,7 @@ Feature: CLI tests
 
     @ci-api @cli
     Scenario: E2E-010 TC-010 Test Instance 'log' option
-        When I execute CLI with "seq send ../packages/inert-function.tar.gz"
+        When I execute CLI with "seq send ../packages/js-inert-function.tar.gz"
         When I execute CLI with "seq start -"
         When I execute CLI with "inst log -" without waiting for the end
         Then I confirm instance logs received

--- a/bdd/features/e2e/E2E-016-errors.feature
+++ b/bdd/features/e2e/E2E-016-errors.feature
@@ -3,6 +3,6 @@ Feature: Test error handling while sequence is uploaded
     @ci-instance-node
     Scenario: E2E-016 TC-001 Run errored sequence
         Given I set config for local Hub
-		When I deploy sequence "bad-sequence.tar.gz"
+		When I deploy sequence "js-bad-sequence.tar.gz"
         Then I should see error message: "Sequence entrypoint path app.js is invalid. Check `main` field in Sequence package.json"
         Then I should see exitCode: "1"

--- a/bdd/features/hub/HUB-001-host-config.feature
+++ b/bdd/features/hub/HUB-001-host-config.feature
@@ -28,7 +28,7 @@ Feature: HUB-001 Host configuration
     @starts-host @docker-specific
     Scenario: HUB-001 TC-009  Set runner image (--runner-image)
         When hub process is started with parameters "-P 9002 --instances-server-port 19002 --runner-image repo.int.scp.ovh/scramjet/runner:0.10.0-pre.7"
-        And sequence "../packages/inert-function.tar.gz" is loaded
+        And sequence "../packages/js-inert-function.tar.gz" is loaded
         And instance started
         And get runner container information
         Then container uses "repo.int.scp.ovh/scramjet/runner:0.10.0-pre.7" image
@@ -38,7 +38,7 @@ Feature: HUB-001 Host configuration
     @starts-host @docker-specific
     Scenario: HUB-001 TC-010  Default runner image for js/ts sequences
         When hub process is started with parameters "-P 9002 --instances-server-port 19002"
-        And sequence "../packages/inert-function.tar.gz" is loaded
+        And sequence "../packages/js-inert-function.tar.gz" is loaded
         And instance started
         And get runner container information
         Then container uses node image defined in sth-config

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "clean": "yarn clean:root && scripts/run-script.js clean",
     "clean:root": "rm -rf ./dist/",
     "clean:modules": "find -name node_modules -or -name __pypackages__ -prune -exec rm -rf {} ';' 2> /dev/null",
+    "clean:refapps": "rm packages/*.tar.gz",
     "lint:full": "TIMING=1 NODE_OPTIONS=\"--max-old-space-size=3072\" eslint . --ext .ts --ext .js --cache --cache-strategy=content --cache-location=.eslintcache_scramjet-csi",
     "lint": "TIMING=1 NODE_OPTIONS=\"--max-old-space-size=2048\" scripts/run-script.js -w modules -j 4 -e \"! ls .eslintrc* > /dev/null || npx eslint ./ --ext .ts --ext .js --cache --cache-strategy=content\"",
     "lint:uncached": "find . -name .eslintcache -delete && yarn lint",


### PR DESCRIPTION
<!-- If writing isn't your strength, ask our Discord https://discord.com/invite/ngXmwvjSYF for help!  -->


**What?**  <!-- Two-sentence summary, understandable for a junior. -->
Edit refapps naming in cucumber tests after the last reference-apps release [v0.25.9](https://github.com/scramjetorg/reference-apps/releases/tag/v0.25.9)

**Why?**  <!-- What is this needed for? You can link to an issue. -->


**Usage:**
<!-- Example (if applicable), how to verify (if not covered by tests). -->
-
-
-

**Clickup Task:** <!-- Paste corresponding link to a clickup task -->


<!--------------------- For non-trivial changes: ---------------------->

**How it works:**
<!-- Share some starting points for understanding the code. -->
-
-
-

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

