### PR TITLE
Fix reconnect logging and memleak

### DIFF
--- a/packages/host/src/lib/host.ts
+++ b/packages/host/src/lib/host.ts
@@ -1149,11 +1149,17 @@ export class Host implements IComponent {
                     new CommunicationHandler(),
                     this.config,
                     this.instanceProxy);
-            }
 
-            await this.instancesStore[id].handleInstanceConnect(
-                streams
-            );
+                await this.instancesStore[id].handleInstanceConnect(
+                    streams
+                );
+            } else {
+                this.logger.info("Instance already exists", id);
+
+                await this.instancesStore[id].handleInstanceReconnect(
+                    streams
+                );
+            }
         });
     }
 

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -746,7 +746,7 @@ export class Runner<X extends AppConfig> implements IComponent {
         }
 
         // eslint-disable-next-line complexity
-        await new Promise<void>((res) => {
+        await new Promise<void>((res, rej) => {
             /**
              * @analyze-how-to-pass-in-out-streams
              * We need to make sure to close input and output streams
@@ -780,6 +780,12 @@ export class Runner<X extends AppConfig> implements IComponent {
                 this.logger.info("Stream encoding is", this.instanceOutput.readableEncoding);
 
                 this.instanceOutput
+                    .on("error", (e) => {
+                        this.logger.error("Sequence output stream error", e);
+                        this.status = InstanceStatus.ERRORED;
+
+                        rej(new RunnerError("SEQUENCE_RUNTIME_ERROR", e));
+                    })
                     .once("end", () => {
                         this.logger.debug("Sequence stream ended");
                         res();


### PR DESCRIPTION
**What?**  <!-- Two-sentence summary, understandable for a junior. -->

* Fix the logging levels on reconnect from the runner
* Unhook streams before reconnecting an instance

**Why?**  <!-- What is this needed for? You can link to an issue. -->

Currently a reconnect causes a double call to `hookupStreams` which pipes multiple streams to the input. This unhooks the streams on reconnect, so there are no extra listeners and we're not causing a refleak.

This only happens when a sequence stream errors out.

Additionally stream connect and reconnect errors are muted while connecting and logging happens only on disconnection.

**Reproduce:**

- Create an instance that sends an error on output (`out.emit("error", new Error())`)
- Observe the chain of reconnects

**Review checks:**

These aspects need to be checked by the reviewer:

- [ ] Verify and confirm operation (please post a screenshot) <!-- remove if trivial tag added -->
- [ ] All STH tests pass
- [ ] All [Scramjet Cloud Platform](https://docs.scramjet.org/platform) tests pass
- [ ] Documentation is updated or no changes

