### PR TITLE
feat: expose raw and typed instance RPC clients

### DIFF
--- a/packages/api-router/src/client-transports.ts
+++ b/packages/api-router/src/client-transports.ts
@@ -6,9 +6,11 @@ export type FetchLike = (url: string, init: {
     method: string;
     headers?: Record<string, string>;
     body?: any;
+    duplex?: "half";
 }) => Promise<{
     status: number;
     headers: { forEach(callback: (value: string, key: string) => void): void };
+    body?: unknown;
     json(): Promise<unknown>;
     text(): Promise<string>;
 }>;
@@ -39,7 +41,7 @@ function appendQuery(url: string, query: unknown): string {
 
     const text = params.toString();
 
-    return text ? `${url}?${text}` : url;
+    return text ? `${url}${url.includes("?") ? "&" : "?"}${text}` : url;
 }
 
 function appendRepeatedQuery(url: string, query: unknown): string {
@@ -61,7 +63,7 @@ function appendRepeatedQuery(url: string, query: unknown): string {
 
     const text = params.toString();
 
-    return text ? `${url}?${text}` : url;
+    return text ? `${url}${url.includes("?") ? "&" : "?"}${text}` : url;
 }
 
 function minimumTimeout(...values: Array<number | undefined>): number | undefined {
@@ -87,8 +89,22 @@ export function createHttpClientTransport({ baseUrl, fetch }: { baseUrl: string;
             const response = await fetch(url, {
                 method: request.route.method.toUpperCase(),
                 headers: request.headers,
-                body: request.body === undefined ? undefined : JSON.stringify(request.body)
+                body: request.body === undefined ? undefined : request.raw ? request.body as any : JSON.stringify(request.body),
+                duplex: request.raw && request.body instanceof Readable ? "half" : undefined
             });
+
+            if (request.raw) {
+                const body = response.body;
+
+                return {
+                    status: response.status,
+                    headers: collectHeaders(response.headers),
+                    body: (body && typeof body === "object" && "getReader" in body && typeof Readable.fromWeb === "function"
+                        ? Readable.fromWeb(body as any)
+                        : body) as T
+                };
+            }
+
             const text = await response.text();
 
             return {

--- a/packages/api-router/src/client.ts
+++ b/packages/api-router/src/client.ts
@@ -6,6 +6,8 @@ export type ApiClientRequest = {
     query?: unknown;
     headers?: Record<string, string>;
     body?: unknown;
+    /** Bypass transport-level JSON encoding/decoding for an opaque request. */
+    raw?: boolean;
     timeoutMs?: number;
     signal?: AbortSignal;
 };

--- a/packages/api-router/test/client-transports.spec.ts
+++ b/packages/api-router/test/client-transports.spec.ts
@@ -4,6 +4,7 @@ const test: typeof baseTest = createAvaMemoryGuard(baseTest);
 
 import { ApiClientRequest, createApiClient, createHttpClientTransport, createRouter, createVerser2ClientTransport } from "../src";
 import { ClientRequestProbeError, createClientRequestProbe } from "./lib/no-circumvention";
+import { Readable } from "stream";
 
 test("HTTP client transport materializes params, query, headers and body", async t => {
     const manifest = createRouter({ basePath: "/api/v2" }).post("/sequence/:id").collect();
@@ -38,6 +39,62 @@ test("HTTP client transport materializes params, query, headers and body", async
     t.is(seen[0].init.body, '{"start":true}');
     t.is(response.status, 201);
     t.deepEqual(response.body, { ok: true });
+});
+
+test("HTTP client transport preserves raw bodies and existing path query strings", async t => {
+    const seen: any[] = [];
+    const transport = createHttpClientTransport({
+        baseUrl: "http://localhost:8000",
+        async fetch(url, init) {
+            seen.push({ url, init });
+            return {
+                status: 202,
+                headers: { forEach: callback => callback("text/plain", "content-type") },
+                body: "opaque response",
+                async json() { return undefined; },
+                async text() { return "not used for raw requests"; }
+            };
+        }
+    });
+    const body = Buffer.from("opaque request");
+    const response = await transport.request({
+        route: { id: "PATCH <raw>", method: "patch", path: "/legacy?enabled=true", fullPath: "/legacy?enabled=true", kind: "duplex" },
+        raw: true,
+        query: { tag: "a" },
+        headers: { "content-type": "application/octet-stream" },
+        body
+    });
+
+    t.is(seen[0].url, "http://localhost:8000/legacy?enabled=true&tag=a");
+    t.is(seen[0].init.body, body);
+    t.is(response.body, "opaque response");
+});
+
+test("HTTP client transport marks raw readable bodies as streaming requests", async t => {
+    const seen: any[] = [];
+    const transport = createHttpClientTransport({
+        baseUrl: "http://localhost:8000",
+        async fetch(_, init) {
+            seen.push(init);
+            return {
+                status: 200,
+                headers: { forEach: callback => callback("application/octet-stream", "content-type") },
+                body: "raw",
+                async json() { return undefined; },
+                async text() { return "not used for raw requests"; }
+            };
+        }
+    });
+    const body = Readable.from([Buffer.from("stream")]);
+
+    await transport.request({
+        route: { id: "PUT <raw>", method: "put", path: "/upload", fullPath: "/upload", kind: "duplex" },
+        raw: true,
+        body
+    });
+
+    t.is(seen[0].body, body);
+    t.is(seen[0].duplex, "half");
 });
 
 test("verser2 client transport delegates to broker request", async t => {

--- a/packages/host/src/lib/api/instance-api-v2.ts
+++ b/packages/host/src/lib/api/instance-api-v2.ts
@@ -3,6 +3,7 @@ import { summarizeHealth } from "@scramjet/load-check";
 import { HostError } from "@scramjet/model";
 import { RestAPI2, RestAPI2RouteSets } from "@scramjet/rest-api2";
 import { IObjectLogger } from "@scramjet/runtime-types";
+import type { APIRoute } from "@scramjet/api-types";
 import EventEmitter from "events";
 import { IncomingHttpHeaders } from "http";
 
@@ -49,6 +50,20 @@ export class InstanceAPIV2 {
             getNextEvent: ({ params }) => this.handleEvent(params.name, true),
             sendEvent: ({ body }) => this.handleSendEvent(body),
             rpc: routeBinding.handler(((req: any, res?: any) => this.handleRpc(req, res)) as any)
+        });
+    }
+
+    /**
+     * RPC exposure is a raw application proxy: unlike the documented POST
+     * duplex route, this middleware deliberately accepts every HTTP method.
+     */
+    attachRpcMiddleware(router: Pick<APIRoute, "use">): void {
+        router.use("/rpc", async (req, res, next) => {
+            try {
+                await this.handleRpc(req, res);
+            } catch (error) {
+                next(error as Error);
+            }
         });
     }
 

--- a/packages/host/src/lib/csi-controller.ts
+++ b/packages/host/src/lib/csi-controller.ts
@@ -880,6 +880,7 @@ export class CSIController extends TypedEmitter<CSIEvents> implements ICSI {
         const v2Router = this.v2Router;
 
         this.api.attach(router, this.communicationHandler!);
+        this.apiV2.attachRpcMiddleware(v2Router);
         registerHttpRoutes(v2Router, this.apiV2.createRouter());
     }
 

--- a/packages/host/test/api-v2-instance-hotwire.spec.ts
+++ b/packages/host/test/api-v2-instance-hotwire.spec.ts
@@ -195,6 +195,24 @@ test("InstanceAPIV2 v2 RPC route forwards through CSI RPC forwarding", async t =
     t.is(calls[0].forwardRpcRequest[0].headers, headerRecord);
 });
 
+test("InstanceAPIV2 raw RPC middleware forwards every HTTP method unchanged", async t => {
+    const recorder = new RouteRecorder();
+    const calls: any[] = [];
+    const api = new InstanceAPIV2(createCsiStub(calls), logger);
+    const req = { url: "/rpc/custom/action?force=true", method: "PATCH", headers: { "x-request-id": "raw-1" } };
+    const res = createResponseStub();
+
+    api.attachRpcMiddleware(recorder.asApiRoute());
+    await (recorder.require("use", "/rpc").handler as Function)(req, res, () => t.fail());
+
+    t.is(calls.length, 1);
+    t.is(calls[0].forwardRpcRequest[0], req);
+    t.is(calls[0].forwardRpcRequest[1], res);
+    t.is(calls[0].forwardRpcRequest[2], "/custom/action?force=true");
+    t.is(calls[0].forwardRpcRequest[0].method, "PATCH");
+    t.deepEqual(calls[0].forwardRpcRequest[0].headers, { "x-request-id": "raw-1" });
+});
+
 test("InstanceAPIV2 local handlers adapt CSI behavior", async t => {
     const recorder = new RouteRecorder();
     const calls: any[] = [];

--- a/packages/rest-api2/src/client.ts
+++ b/packages/rest-api2/src/client.ts
@@ -10,6 +10,7 @@ import {
     createHttpClientTransport,
     createVerser2ClientTransport
 } from "@scramjet/api-router";
+import { Readable } from "stream";
 
 import { RestAPI2 } from "./contracts";
 import { RestAPI2RouteTree, RestAPI2RouteTreeRouteNode, RestAPI2Routes, getOpaqueRouteKeys } from "./routes";
@@ -30,6 +31,9 @@ export function createRestAPI2Client({ manifest, transport }: RestAPI2ClientOpti
                 operationId: request.operationId,
                 ...response
             };
+        },
+        api: {
+            request: <TBody = unknown>(request: RestAPI2.RawRequest) => rawTransportRequest<TBody>(transport, request)
         }
     };
 }
@@ -38,6 +42,86 @@ export type FluentClientRequest<TContract extends RouteDefinition> = Partial<Omi
 
 export type FluentEndpoint<TContract extends RouteDefinition> = {
     [M in TContract["method"]]: (request?: FluentClientRequest<TContract>) => Promise<RestAPI2.ClientResponse<RestAPI2.OperationId, RouteResponseFor<TContract>>>;
+};
+
+/**
+ * Caller-owned guard for application-provided RPC input or response data.
+ */
+export type InstanceRpcTypeGuard<TValue> = (value: unknown) => value is TValue;
+
+/**
+ * Caller-owned declaration for one JSON RPC procedure.
+ *
+ * The API package deliberately does not know application RPC names or payloads;
+ * callers provide those as a contract to {@link InstanceClient.rpc}.
+ */
+export type InstanceRpcProcedure<TInput = unknown, TResult = unknown> = {
+    /** Runtime validation before the opaque request body is sent. */
+    request: InstanceRpcTypeGuard<TInput>;
+    /** Runtime validation after the JSON response body is decoded. */
+    response: InstanceRpcTypeGuard<TResult>;
+};
+
+/** Contract declaration for a GET RPC procedure without an application body. */
+export type InstanceRpcReadProcedure<TResult = unknown> = {
+    response: InstanceRpcTypeGuard<TResult>;
+    request?: undefined;
+};
+
+type InstanceRpcProcedureName<TContract> = {
+    [TProcedure in keyof TContract]-?: TContract[TProcedure] extends InstanceRpcProcedure | InstanceRpcReadProcedure ? TProcedure : never;
+}[keyof TContract] & string;
+
+type InstanceRpcInput<TContract, TProcedure extends InstanceRpcProcedureName<TContract>> =
+    TContract[TProcedure] extends InstanceRpcProcedure<infer TInput> ? TInput : never;
+
+type InstanceRpcResult<TContract, TProcedure extends InstanceRpcProcedureName<TContract>> =
+    TContract[TProcedure] extends InstanceRpcProcedure<any, infer TResult> ? TResult : never;
+
+type InstanceRpcReadResult<TContract, TProcedure extends InstanceRpcProcedureName<TContract>> =
+    TContract[TProcedure] extends InstanceRpcReadProcedure<infer TResult> ? TResult : never;
+
+type InstanceRpcWriteProcedureName<TContract> = {
+    [TProcedure in InstanceRpcProcedureName<TContract>]: TContract[TProcedure] extends InstanceRpcProcedure ? TProcedure : never;
+}[InstanceRpcProcedureName<TContract>];
+
+type InstanceRpcReadProcedureName<TContract> = {
+    [TProcedure in InstanceRpcProcedureName<TContract>]: TContract[TProcedure] extends InstanceRpcReadProcedure ? TProcedure : never;
+}[InstanceRpcProcedureName<TContract>];
+
+/** Raw RPC request options; `body` is forwarded directly to the application RPC endpoint. */
+export type InstanceRpcRequest = RestAPI2.RawRequest;
+
+/**
+ * The typed RPC transport envelope. `body` preserves the underlying transport
+ * value until {@link json} is explicitly requested with an external guard.
+ */
+export type InstanceRpcResponse<TBody = unknown> = RestAPI2.ClientResponse<RestAPI2.OperationId, TBody> & {
+};
+
+/**
+ * A typed, procedure-only view of an instance's opaque RPC endpoint.
+ *
+ * It intentionally has no generic request/path method. Each call is POSTed to
+ * `/rpc/:procedure`; procedure paths use conservative, unescaped relative
+ * segments. The contract guards validate both the JSON request and response.
+ */
+export type InstanceRpcClient<TContract> = {
+    call<TProcedure extends InstanceRpcReadProcedureName<TContract>>(
+        procedure: TProcedure,
+        options?: Omit<InstanceRpcRequest, "method" | "path" | "body">
+    ): Promise<InstanceRpcReadResult<TContract, TProcedure>>;
+    call<TProcedure extends InstanceRpcWriteProcedureName<TContract>>(
+        procedure: TProcedure,
+        input: InstanceRpcInput<TContract, TProcedure>,
+        options?: Omit<InstanceRpcRequest, "method" | "path" | "body">
+    ): Promise<InstanceRpcResult<TContract, TProcedure>>;
+};
+
+/** Contract-free RPC path for native/streaming request and response bodies. */
+export type InstanceRpcNamespace = {
+    <TContract>(contract: TContract): InstanceRpcClient<TContract>;
+    request(request: InstanceRpcRequest): Promise<InstanceRpcResponse>;
 };
 
 type FluentRouteMethods<TSet extends Record<string, RouteDefinition>> = {
@@ -62,7 +146,10 @@ type HubRouteSet = ReturnType<typeof RestAPI2RouteTree.hub.routes>;
 type InstanceRouteSet = ReturnType<typeof RestAPI2RouteTree.instance.routes>;
 type InstanceStandardRouteSet = Omit<InstanceRouteSet, "rpc">;
 
-export type InstanceClient = FluentRouteMethods<InstanceStandardRouteSet>;
+export type InstanceClient = FluentRouteMethods<InstanceStandardRouteSet> & {
+    /** Contract-bound JSON RPC calls and contract-free native RPC requests. */
+    rpc: InstanceRpcNamespace;
+};
 
 export type HubClient = FluentRouteMethods<HubRouteSet> & {
     instance(instanceId: string): InstanceClient;
@@ -85,6 +172,7 @@ export type RestAPI2FluentClientOptions = {
 type FluentBuildContext = {
     manifest: RouteManifest;
     client: RestAPI2.Client;
+    transport: ApiClientTransport;
     prefix: string;
     params: Record<string, string>;
 };
@@ -151,8 +239,155 @@ function standardRouteMethods<TSet extends Record<string, RouteDefinition>>(
     return routeMethods(context, standardRoutes);
 }
 
+function validateRpcProcedurePath(procedure: string): string[] {
+    if (!procedure || /[\\?#%\s]/.test(procedure)) {
+        throw new Error("Instance RPC procedure path must contain only unescaped relative segments");
+    }
+
+    const segments = procedure.split("/");
+
+    if (segments.some((segment) => !segment || segment === "." || segment === "..")) {
+        throw new Error("Instance RPC procedure path must contain only unescaped relative segments");
+    }
+
+    return segments;
+}
+
+function procedureGuards(contract: unknown, procedure: string): { request?: (value: unknown) => boolean; response: (value: unknown) => boolean } {
+    if (!contract || typeof contract !== "object") {
+        throw new Error(`Instance RPC contract is missing guards for procedure: ${procedure}`);
+    }
+    const definition = (contract as Record<string, unknown>)[procedure];
+
+    if (!definition || typeof definition !== "object") {
+        throw new Error(`Instance RPC contract is missing guards for procedure: ${procedure}`);
+    }
+    const { request, response } = definition as { request?: unknown; response?: unknown };
+
+    if (request !== undefined && typeof request !== "function" || typeof response !== "function") {
+        throw new Error(`Instance RPC contract is missing guards for procedure: ${procedure}`);
+    }
+
+    return { request: request as ((value: unknown) => boolean) | undefined, response: response as (value: unknown) => boolean };
+}
+
+async function parseRpcJsonBody(body: unknown, cleanup?: () => Promise<void>): Promise<unknown> {
+    if (!(body instanceof Readable)) {
+        if (typeof body !== "string" && !Buffer.isBuffer(body)) return body;
+
+        try {
+            return JSON.parse(body.toString()) as unknown;
+        } catch (error) {
+            throw new Error(`Instance RPC response must be valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+        }
+    }
+
+    const chunks: Buffer[] = [];
+
+    try {
+        for await (const chunk of body) {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        }
+        const text = Buffer.concat(chunks).toString();
+
+        if (!text) return undefined;
+
+        try {
+            return JSON.parse(text) as unknown;
+        } catch (error) {
+            throw new Error(`Instance RPC response must be valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+        }
+    } finally {
+        await cleanup?.();
+    }
+}
+
+function rpcHeaders(headers: Record<string, string> | undefined): Record<string, string> {
+    if (Object.keys(headers || {}).some((name) => name.toLowerCase() === "content-type")) {
+        return { ...headers };
+    }
+
+    return { "content-type": "application/json", ...headers };
+}
+
+function rawRoute(request: RestAPI2.RawRequest, fullPath = request.path): RouteManifestEntry {
+    return {
+        id: `${request.method.toUpperCase()} <raw>` as RestAPI2.OperationId,
+        method: request.method.toLowerCase() as RouteManifestEntry["method"],
+        path: fullPath,
+        fullPath,
+        kind: "duplex"
+    };
+}
+
+async function rawTransportRequest<TBody = unknown>(
+    transport: ApiClientTransport,
+    request: RestAPI2.RawRequest,
+    fullPath = request.path,
+    params?: Record<string, string>,
+    raw = true
+): Promise<RestAPI2.RawResponse<TBody>> {
+    const route = rawRoute(request, fullPath);
+    const response = await transport.request<TBody>({
+        route,
+        params,
+        query: request.query,
+        headers: request.headers,
+        body: request.body,
+        raw,
+        timeoutMs: request.timeoutMs,
+        signal: request.signal
+    });
+
+    return { operationId: route.id as RestAPI2.OperationId, ...response };
+}
+
+async function requestInstanceRpc(context: FluentBuildContext, request: InstanceRpcRequest, raw = true): Promise<InstanceRpcResponse> {
+    const path = request.path.startsWith("/") ? request.path.slice(1) : request.path;
+    const prefix = context.prefix.endsWith("/") ? context.prefix.slice(0, -1) : context.prefix;
+
+    return rawTransportRequest(context.transport, request, `${prefix}/rpc/${path}`, context.params, raw);
+}
+
+function buildInstanceRpcClient<TContract>(context: FluentBuildContext, contractDefinition: TContract): InstanceRpcClient<TContract> {
+
+    const call = async (procedure: string, inputOrOptions?: unknown, maybeOptions?: Omit<InstanceRpcRequest, "method" | "path" | "body">): Promise<unknown> => {
+            const guards = procedureGuards(contractDefinition, procedure);
+            const hasBody = Boolean(guards.request);
+            const input = hasBody ? inputOrOptions : undefined;
+            const options = (hasBody ? maybeOptions : inputOrOptions) as Omit<InstanceRpcRequest, "method" | "path" | "body"> | undefined;
+
+            if (guards.request && !guards.request(input)) {
+                throw new Error(`Instance RPC request failed the supplied type guard for procedure: ${procedure}`);
+            }
+            const encodedPath = validateRpcProcedurePath(procedure).map(encodeURIComponent).join("/");
+            const response = await requestInstanceRpc(context, {
+                ...options,
+                method: hasBody ? "POST" : "GET",
+                path: encodedPath,
+                headers: hasBody ? rpcHeaders(options?.headers) : options?.headers,
+                ...(hasBody ? { body: input } : {})
+            }, false);
+            const result = await parseRpcJsonBody(response.body, response.cleanup);
+
+            if (!guards.response(result)) {
+                throw new Error(`Instance RPC response failed the supplied type guard for procedure: ${procedure}`);
+            }
+
+            return result;
+        };
+
+    return { call: call as InstanceRpcClient<TContract>["call"] };
+}
+
 function buildInstanceClient(context: FluentBuildContext): InstanceClient {
-    return standardRouteMethods(context, RestAPI2RouteTree.instance.routes(), getOpaqueRouteKeys(RestAPI2RouteTree.instance)) as InstanceClient;
+    return {
+        ...standardRouteMethods(context, RestAPI2RouteTree.instance.routes(), getOpaqueRouteKeys(RestAPI2RouteTree.instance)),
+        rpc: Object.assign(
+            <TContract>(contractDefinition: TContract) => buildInstanceRpcClient(context, contractDefinition),
+            { request: (request: InstanceRpcRequest) => requestInstanceRpc(context, request) }
+        ) as unknown as InstanceRpcNamespace
+    } as InstanceClient;
 }
 
 function buildHubClient(context: FluentBuildContext): HubClient {
@@ -198,6 +433,7 @@ function createFluentContext(manifest: RouteManifest, transport: ApiClientTransp
     return {
         manifest,
         client: createRestAPI2Client({ manifest, transport }),
+        transport,
         prefix,
         params: {}
     };

--- a/packages/rest-api2/src/contracts.ts
+++ b/packages/rest-api2/src/contracts.ts
@@ -244,8 +244,10 @@ export namespace RestAPI2 {
     export type AuditQueryResponse = ListResponse<AuditRecord>;
     export type Params<TScope> = IdParams<string> & { scope?: TScope };
     export type StdIODescriptorList = { channels: Array<{ fd: 0 | 1 | 2; readable: boolean; writable: boolean }> };
-    export type RpcRequest = { method: string; path: string; headers?: Record<string, string>; body?: unknown };
-    export type RpcResponse = { status: number; headers: Record<string, string>; body?: unknown };
+    /** Opaque application payload forwarded as the instance RPC request body. */
+    export type RpcRequest = unknown;
+    /** Opaque application payload forwarded as the instance RPC response body. */
+    export type RpcResponse = unknown;
     export type RouteOwner = "root" | "space" | "hub";
     export type RouteOwnership = {
         owner: RouteOwner;
@@ -278,11 +280,27 @@ export namespace RestAPI2 {
         cleanup?: () => Promise<void>;
     };
 
+    /** Unrouted request passed directly to the configured client transport. */
+    export type RawRequest = {
+        method: string;
+        path: string;
+        query?: unknown;
+        headers?: Record<string, string>;
+        body?: unknown;
+        timeoutMs?: number;
+        signal?: AbortSignal;
+    };
+
+    export type RawResponse<TBody = unknown> = ClientResponse<OperationId, TBody>;
+
     export type ClientTransport = {
         request<TBody = unknown>(request: ClientRequest): Promise<ClientResponse<OperationId, TBody>>;
     };
 
     export type Client = {
         request<TBody = unknown, TOperation extends OperationId = OperationId>(request: ClientRequest<TOperation>): Promise<ClientResponse<TOperation, TBody>>;
+        api: {
+            request<TBody = unknown>(request: RawRequest): Promise<RawResponse<TBody>>;
+        };
     };
 }

--- a/packages/rest-api2/src/schemas.ts
+++ b/packages/rest-api2/src/schemas.ts
@@ -365,18 +365,11 @@ export const SendEventResponse = z.object({
     delivered: z.boolean()
 });
 
-export const RpcRequest = z.object({
-    method: z.string(),
-    path: z.string(),
-    headers: z.record(z.string(), z.string()).optional(),
-    body: z.unknown().optional()
-});
+/** Instance RPC forwards the application request body without a synthetic envelope. */
+export const RpcRequest = z.unknown();
 
-export const RpcResponse = z.object({
-    status: z.number().int(),
-    headers: z.record(z.string(), z.string()),
-    body: z.unknown().optional()
-});
+/** Instance RPC forwards the application response body without a synthetic envelope. */
+export const RpcResponse = z.unknown();
 
 export const Root = z.object({
     id: z.string(),

--- a/packages/rest-api2/test/client.spec.ts
+++ b/packages/rest-api2/test/client.spec.ts
@@ -1,7 +1,8 @@
 import test from "ava";
+import { Readable } from "stream";
 
 import { ApiClientRequest, ApiClientTransport, HttpMethod, Router, createRouter } from "@scramjet/api-router";
-import { RestAPI2, RestAPI2Routes, createFluentClientFromRouteTreeNode, createHubClient, createInstanceClient, createRestAPI2Client, createRootClient, createSpaceClient } from "../src";
+import { InstanceRpcProcedure, InstanceRpcTypeGuard, RestAPI2, RestAPI2Routes, createFluentClientFromRouteTreeNode, createHttpClientTransport, createHubClient, createInstanceClient, createRestAPI2Client, createRootClient, createSpaceClient, createVerser2ClientTransport } from "../src";
 
 const representativeOperations: Array<{ scope: RestAPI2.ScopeName; operationId: RestAPI2.OperationId; path: string }> = [
     { scope: "root", operationId: "GET /api/v2/spaces", path: "/spaces" },
@@ -47,6 +48,28 @@ test("common client dispatches representative v2 operation ids through one trans
     }
 
     t.deepEqual(seen, representativeOperations.map(operation => operation.operationId));
+});
+
+test("top-level raw API forwards undocumented and v1 paths without manifest lookup", async t => {
+    const seen: ApiClientRequest[] = [];
+    const client = createRestAPI2Client({
+        manifest: { basePath: "/api/v2", routes: [] },
+        transport: {
+            async request<T>(request: ApiClientRequest) {
+                seen.push(request);
+                return { status: 207, headers: { "x-raw": "true" }, body: Readable.from(["raw"]) as unknown as T };
+            }
+        }
+    });
+
+    const response = await client.api.request({ method: "PATCH", path: "/api/v1/rpc/custom", headers: { "x-request-id": "raw-1" }, body: "payload" });
+
+    t.is(response.status, 207);
+    t.is(seen[0].route.fullPath, "/api/v1/rpc/custom");
+    t.is(seen[0].route.method, "patch");
+    t.is(seen[0].route.kind, "duplex");
+    t.deepEqual(seen[0].headers, { "x-request-id": "raw-1" });
+    t.is(seen[0].body, "payload");
 });
 
 test("generic contract shapes are independent v2 outputs", t => {
@@ -201,7 +224,7 @@ test("fluent client forwards body query and headers for representative endpoints
     t.deepEqual(seen[1].query, { force: true });
 });
 
-test("fluent clients omit opaque RPC route exceptions from standard endpoint methods", t => {
+test("fluent clients expose contract-bound and contract-free RPC entry points", t => {
     const instance = createInstanceClient({
         transport: {
             async request<T>() {
@@ -210,7 +233,167 @@ test("fluent clients omit opaque RPC route exceptions from standard endpoint met
         }
     });
 
-    t.false("rpc" in instance);
+    t.true("rpc" in instance);
+    t.is(typeof instance.rpc, "function");
+    t.is(typeof instance.rpc.request, "function");
+    t.false("post" in instance.rpc);
+});
+
+const isAddResult: InstanceRpcTypeGuard<{ total: number }> = (value): value is { total: number } =>
+    !!value && typeof value === "object" && "total" in value && typeof (value as { total?: unknown }).total === "number";
+const isAddInput: InstanceRpcTypeGuard<[number, number]> = (value): value is [number, number] =>
+    Array.isArray(value) && value.length === 2 && value.every((item) => typeof item === "number");
+const addContract = { "math/add": { request: isAddInput, response: isAddResult } };
+const versionContract = { version: { response: (value: unknown): value is { version: string } => !!value && typeof value === "object" && "version" in value } };
+
+test("contract-bound RPC validates JSON guards and returns the inferred HTTP result", async t => {
+    const requests: Array<{ url: string; init: { method: string; headers?: Record<string, string>; body?: any } }> = [];
+    const instance = createInstanceClient({
+        transport: createHttpClientTransport({
+            baseUrl: "http://hub.internal",
+            fetch: async (url, init) => {
+                requests.push({ url, init });
+                return {
+                    status: 200,
+                    headers: { forEach(callback) { callback("application/json", "content-type"); } },
+                    async json() { return { total: 6 }; },
+                    async text() { return JSON.stringify({ total: 6 }); }
+                };
+            }
+        })
+    });
+    const result = await instance.rpc(addContract).call("math/add", [2, 4], { headers: { "x-request-id": "request-1" }, timeoutMs: 500 });
+
+    t.is(result.total, 6);
+    t.is(requests[0].url, "http://hub.internal/rpc/math/add");
+    t.deepEqual(requests[0].init.body, JSON.stringify([2, 4]));
+    t.deepEqual(requests[0].init.headers, { "content-type": "application/json", "x-request-id": "request-1" });
+});
+
+test("contract-bound RPC uses GET when its procedure has no request body", async t => {
+    const requests: Array<{ url: string; init: { method: string; body?: any } }> = [];
+    const instance = createInstanceClient({
+        transport: createHttpClientTransport({
+            baseUrl: "http://hub.internal",
+            fetch: async (url, init) => {
+                requests.push({ url, init });
+                return {
+                    status: 200,
+                    headers: { forEach(callback) { callback("application/json", "content-type"); } },
+                    async json() { return { version: "1.0.0" }; },
+                    async text() { return JSON.stringify({ version: "1.0.0" }); }
+                };
+            }
+        })
+    });
+
+    const result = await instance.rpc(versionContract).call("version");
+
+    t.is(result.version, "1.0.0");
+    t.is(requests[0].url, "http://hub.internal/rpc/version");
+    t.is(requests[0].init.method, "GET");
+    t.is(requests[0].init.body, undefined);
+});
+
+test("contract-free RPC request preserves the native Verser2 duplex stream envelope", async t => {
+    const requests: Array<{ method: string; path: string; body?: unknown }> = [];
+    let cleanups = 0;
+    const stream = Readable.from([JSON.stringify({ total: 3 })]);
+    const transport = createVerser2ClientTransport({
+        transport: {
+            getRoutes: () => [{ domain: "hub.internal", targetId: "hub" }],
+            isRouteReady: () => true,
+            waitForRoute: async () => undefined,
+            async request(request) {
+                requests.push({ method: request.method, path: request.path, body: request.body });
+                return {
+                    status: 200,
+                    headers: { "content-type": "application/json" },
+                    body: stream,
+                    async cleanup() { cleanups += 1; }
+                };
+            }
+        },
+        routeDomain: "hub.internal"
+    });
+    const response = await createInstanceClient({ transport }).rpc.request({
+        method: "PATCH",
+        path: "math/add/nested",
+        body: [2, 4],
+        headers: { "content-type": "application/json" }
+    });
+
+    t.is(response.body, stream);
+    t.is(response.status, 200);
+    t.deepEqual(response.headers, { "content-type": "application/json" });
+    t.is(requests[0].path, "/rpc/math/add/nested");
+    t.is(requests[0].method, "PATCH");
+    t.deepEqual(requests[0].body, [2, 4]);
+    t.is(cleanups, 0);
+    await transport.close();
+    t.true(cleanups >= 1);
+});
+
+test("contract-bound RPC consumes Verser2 JSON streams and validates the response guard", async t => {
+    const transport = createVerser2ClientTransport({
+        transport: {
+            getRoutes: () => [{ domain: "hub.internal", targetId: "hub" }],
+            isRouteReady: () => true,
+            waitForRoute: async () => undefined,
+            async request() {
+                return {
+                    status: 200,
+                    headers: { "content-type": "application/json" },
+                    body: Readable.from([JSON.stringify({ total: 6 })]),
+                    async cleanup() {}
+                };
+            }
+        },
+        routeDomain: "hub.internal"
+    });
+
+    const result = await createInstanceClient({ transport }).rpc(addContract).call("math/add", [2, 4]);
+
+    t.is(result.total, 6);
+    await transport.close();
+});
+
+test("contract-bound RPC rejects request and response guard failures", async t => {
+    let requests = 0;
+    const rpc = createInstanceClient({
+        transport: {
+            async request<T>() {
+                requests += 1;
+                return { status: 200, headers: {}, body: { total: "not-a-number" } as unknown as T };
+            }
+        }
+    }).rpc(addContract);
+
+    await t.throwsAsync(() => rpc.call("math/add", [2, "4"] as unknown as [number, number]), {
+        message: "Instance RPC request failed the supplied type guard for procedure: math/add"
+    });
+    t.is(requests, 0);
+    await t.throwsAsync(() => rpc.call("math/add", [2, 4]), {
+        message: "Instance RPC response failed the supplied type guard for procedure: math/add"
+    });
+    t.is(requests, 1);
+});
+
+test("raw instance RPC request forwards complex paths without contract-path validation", async t => {
+    const seen: ApiClientRequest[] = [];
+    const instance = createInstanceClient({
+        transport: {
+            async request<T>(request: ApiClientRequest) {
+                seen.push(request);
+                return { status: 200, headers: {}, body: undefined as unknown as T };
+            }
+        }
+    });
+
+    await instance.rpc.request({ method: "DELETE", path: "math/../custom%2froute?force=true" });
+
+    t.is(seen[0].route.fullPath, "/rpc/math/../custom%2froute?force=true");
+    t.is(seen[0].route.method, "delete");
 });
 
 test("fluent client reports missing manifest route coverage", async t => {
@@ -377,8 +560,33 @@ test("fluent client compile-time route method and schema assertions", t => {
         client.space("space-1").hub("hub-1").deleteTopic.delete({ params: { topic: "wrong" } });
         // @ts-expect-error topic create body must match route schema
         client.space("space-1").hub("hub-1").createTopic.post({ body: { name: "topic-1" } });
-        // @ts-expect-error opaque RPC routes are not standard fluent methods
+        // @ts-expect-error RPC has no raw HTTP method; callers must provide a procedure contract
         client.space("space-1").hub("hub-1").instance("inst-1").rpc.post();
+        type RpcContract = {
+            "math/add": InstanceRpcProcedure<[number, number], { total: number }>;
+        };
+        const inputGuard: InstanceRpcTypeGuard<[number, number]> = (value): value is [number, number] =>
+            Array.isArray(value) && value.length === 2 && value.every((item) => typeof item === "number");
+        const resultGuard: InstanceRpcTypeGuard<{ total: number }> = (value): value is { total: number } =>
+            !!value && typeof value === "object" && "total" in value;
+        const rpcContract: RpcContract = {
+            "math/add": { request: inputGuard, response: resultGuard }
+        };
+        const rpc = client.space("space-1").hub("hub-1").instance("inst-1").rpc(rpcContract);
+        rpc.call("math/add", [2, 4]).then((result) => {
+            const total: number = result.total;
+            void total;
+        });
+        client.space("space-1").hub("hub-1").instance("inst-1").rpc.request({ method: "PUT", path: "math/add", body: [2, 4] }).then((response) => {
+            const envelope: RestAPI2.ClientResponse<RestAPI2.OperationId, unknown> = response;
+            void envelope;
+            // @ts-expect-error contract-free response bodies remain opaque
+            response.body.total;
+        });
+        // @ts-expect-error procedure names come only from the caller-provided contract
+        rpc.call("math/subtract", [2, 4]);
+        // @ts-expect-error input is selected by the caller-provided procedure contract
+        rpc.call("math/add", ["2", 4]);
     }
 
     t.pass();

--- a/packages/rest-api2/test/routes.spec.ts
+++ b/packages/rest-api2/test/routes.spec.ts
@@ -105,3 +105,10 @@ test("RPC route group is an explicit opaque route-tree exception", t => {
     t.true(RestAPI2RouteTree.instance.groups.rpc.opaque);
     t.true(RestAPI2RouteTree.instance.routes().rpc.path.includes("/rpc"));
 });
+
+test("RPC route contract preserves opaque application wire bodies", t => {
+    const rpc = RestAPI2RouteTree.instance.routes().rpc;
+
+    t.true(rpc.schemas?.body?.safeParse({ arbitrary: "caller payload" }).success);
+    t.true(rpc.schemas?.response?.safeParse("raw proxy response").success);
+});


### PR DESCRIPTION
## Summary
- add raw configured-transport `api.request()` and instance RPC request passthroughs
- add typed instance RPC convenience calls with GET reads and POST writes
- forward arbitrary V2 instance RPC methods through the Host to runner Verser2 transport

## Validation
- `npm test --workspace @scramjet/api-router`
- `npm test --workspace @scramjet/rest-api2`
- `npm test --workspace @scramjet/host`
- TypeScript checks and targeted Biome lint for changed packages

## Notes
- Legacy V1 APIs are unchanged.
- Host-to-runner RPC forwarding uses Verser2; raw client requests preserve the configured transport behavior.