### PR TITLE
fix(release): stage verified BDD artifacts

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -369,7 +369,7 @@ jobs:
           fi
           BDD_IMAGES="$(node -e 'const [repository, digest] = process.argv.slice(1); console.log(JSON.stringify([{ role: "bdd-node", reference: `${repository}@${digest}` }]));' "$BDD_IMAGE_REPOSITORY" "$bdd_image_digest")"
           export NPM_CONFIG_USERCONFIG="$RUNNER_TEMP/release-prerelease-read.npmrc"
-          trap 'rm -f "$NPM_CONFIG_USERCONFIG"; docker logout ghcr.io' EXIT
+          trap 'node scripts/release-prerelease-bdd.js cleanup-overlay --workspace-root . || true; rm -f "$NPM_CONFIG_USERCONFIG"; docker logout ghcr.io' EXIT
           umask 077
           {
             printf '%s\n' '@scramjetorg:registry=https://npm.pkg.github.com'
@@ -383,4 +383,5 @@ jobs:
           node scripts/release-prerelease-bdd.js activate --install-dir .release-prerelease-bdd --record "$RUNNER_TEMP/release-prerelease-bdd.json" --workspace-root .
           node scripts/release-prerelease-bdd.js validate-cli --workspace-root .
           cp "$RUNNER_TEMP/release-prerelease-bdd.json" .release-prerelease-bdd/verified-record.json
+          node scripts/release-prerelease-bdd.js overlay --install-dir .release-prerelease-bdd --record .release-prerelease-bdd/verified-record.json --workspace-root .
           SCRAMJET_RELEASE_PRERELEASE_BDD_RECORD=.release-prerelease-bdd/verified-record.json SCRAMJET_RELEASE_PRERELEASE_BDD_INSTALL_DIR=.release-prerelease-bdd BDD_NODE_IMAGE="$(node -p "require(process.env.RUNNER_TEMP + '/release-prerelease-bdd.json').images.find((image) => image.role === 'bdd-node').reference")" npm run test:bdd-ci-api-node

--- a/scripts/release-prerelease-bdd.js
+++ b/scripts/release-prerelease-bdd.js
@@ -11,6 +11,7 @@ const STH_SOURCE_NAME = "@scramjet/sth";
 const STH_BIN_NAME = "scramjet-transform-hub";
 const CLI_SOURCE_NAME = "@scramjet/cli";
 const CLI_BIN_NAME = "si";
+const DIST_OVERLAY_FORMAT = "transform-hub-release-prerelease-bdd-dist-overlay-v1";
 
 const DIGEST = /^sha256:[a-f0-9]{64}$/i;
 const IMAGE_REFERENCE = /^ghcr\.io\/scramjetorg\/[a-z0-9._/-]+@sha256:([a-f0-9]{64})$/i;
@@ -235,6 +236,59 @@ function activateVerifiedPackages({ installDir, record, workspaceRoot }) {
     }
     activateSthBin({ installDir, record, workspaceRoot });
     activateCliBin({ installDir, record, workspaceRoot });
+}
+
+function materializeDistOverlay({ installDir, record, workspaceRoot }) {
+    const root = resolve(workspaceRoot);
+    const installModules = realpathSync(resolve(installDir, "node_modules"));
+    const distRoot = resolve(root, "dist");
+    if (existsSync(distRoot)) throw new Error("Refusing to replace an existing root dist while creating the prerelease BDD overlay.");
+    if (record?.format !== "transform-hub-release-prerelease-bdd-v2" || !Array.isArray(record.packages)) throw new Error("Release-prerelease BDD dist overlay requires a verified consumption record.");
+
+    const entries = new Map();
+    for (const entry of record.packages) {
+        if (!entry || typeof entry.sourceName !== "string" || !entry.sourceName.startsWith("@scramjet/") || entry.name !== prereleasePackageName(entry.sourceName) || entry.registryName !== entry.name || typeof entry.version !== "string" || !entry.version.includes("-pr.") || entries.has(entry.sourceName)) {
+            throw new Error("Release-prerelease BDD context has an invalid verified package mapping.");
+        }
+        entries.set(entry.sourceName, entry);
+    }
+
+    const mappings = [];
+    for (const entry of entries.values()) {
+        const packageDirectory = entry.sourceName.slice("@scramjet/".length);
+        if (!/^[A-Za-z0-9._-]+$/.test(packageDirectory) || entry.name !== `@scramjetorg/${packageDirectory}`) throw new Error(`Refusing an unsafe prerelease dist overlay package path for ${entry.sourceName}.`);
+        const source = realpathSync(resolve(installModules, entry.name));
+        if (!isInside(installModules, source)) throw new Error(`Refusing a prerelease dist overlay source outside the verified install: ${entry.name}.`);
+        assertInstalledPackage(source, entry);
+        mappings.push({ packageDirectory, source });
+    }
+
+    try {
+        mkdirSync(distRoot, { recursive: true });
+        for (const { packageDirectory, source } of mappings) {
+            const destination = resolve(distRoot, packageDirectory);
+            if (!isInside(distRoot, destination)) throw new Error(`Refusing a prerelease dist overlay destination outside root dist: ${packageDirectory}.`);
+            symlinkSync(relative(dirname(destination), source), destination, "dir");
+            const resolvedDestination = realpathSync(destination);
+            if (resolvedDestination !== source || !isInside(installModules, resolvedDestination)) throw new Error(`Prerelease dist overlay does not resolve into the verified install: ${packageDirectory}.`);
+        }
+        writeJson(join(distRoot, ".release-prerelease-bdd-overlay.json"), { format: DIST_OVERLAY_FORMAT, workspaceRoot: root, installModules, packages: mappings.map(mapping => mapping.packageDirectory) });
+        return { distRoot, packages: mappings.map(mapping => mapping.packageDirectory) };
+    } catch (error) {
+        rmSync(distRoot, { force: true, recursive: true });
+        throw error;
+    }
+}
+
+function cleanupDistOverlay({ workspaceRoot }) {
+    const root = resolve(workspaceRoot);
+    const distRoot = resolve(root, "dist");
+    const markerPath = join(distRoot, ".release-prerelease-bdd-overlay.json");
+    if (!existsSync(markerPath)) return false;
+    const marker = parseJson(readFileSync(markerPath, "utf8"), "BDD dist overlay marker");
+    if (marker.format !== DIST_OVERLAY_FORMAT || marker.workspaceRoot !== root) throw new Error("Refusing to remove an unrecognized root dist overlay.");
+    rmSync(distRoot, { force: true, recursive: true });
+    return true;
 }
 
 /**
@@ -473,12 +527,21 @@ function main() {
             });
             return;
         }
+        if (command === "overlay") {
+            const result = materializeDistOverlay({ installDir: readOption(args, "--install-dir"), record: parseJson(readFileSync(readOption(args, "--record"), "utf8"), "Verified consumption record"), workspaceRoot: readOption(args, "--workspace-root") });
+            console.log(JSON.stringify(result));
+            return;
+        }
+        if (command === "cleanup-overlay") {
+            cleanupDistOverlay({ workspaceRoot: readOption(args, "--workspace-root") });
+            return;
+        }
         if (command === "validate-cli") {
             validateSthCli({ workspaceRoot: readOption(args, "--workspace-root") });
             console.log(JSON.stringify({ mode: "validated" }));
             return;
         }
-        throw new Error("Usage: release-prerelease-bdd.js verify|prepare|verify-lock|activate|validate-cli ...");
+        throw new Error("Usage: release-prerelease-bdd.js verify|prepare|verify-lock|activate|overlay|cleanup-overlay|validate-cli ...");
     } catch (error) {
         console.error(`[release-prerelease-bdd] ${error.message}`);
         process.exitCode = 1;
@@ -498,8 +561,10 @@ module.exports = {
     verifyInstallLock,
     writeInstallManifest,
     activateVerifiedPackages,
+    cleanupDistOverlay,
     activateCliBin,
     activateSthBin,
+    materializeDistOverlay,
     releasePrereleaseBddContext,
     validateSthCli
 };

--- a/scripts/test/pr-validate-workflow.spec.js
+++ b/scripts/test/pr-validate-workflow.spec.js
@@ -334,6 +334,8 @@ test("release PR BDD consumes only verified publisher output and exact prereleas
 	t.true(source.includes("release-prerelease-bdd.js prepare"));
 	t.true(source.includes("release-prerelease-bdd.js verify-lock"));
 	t.true(source.includes("release-prerelease-bdd.js activate"));
+	t.true(source.includes("release-prerelease-bdd.js overlay --install-dir .release-prerelease-bdd"));
+	t.true(source.includes("release-prerelease-bdd.js cleanup-overlay --workspace-root ."));
 	t.true(source.includes("release-prerelease-bdd.js validate-cli --workspace-root ."));
 	t.true(source.includes("cp \"$RUNNER_TEMP/release-prerelease-bdd.json\" .release-prerelease-bdd/verified-record.json"));
 	t.true(source.includes("SCRAMJET_RELEASE_PRERELEASE_BDD_RECORD=.release-prerelease-bdd/verified-record.json"));

--- a/scripts/test/release-prerelease-bdd.spec.js
+++ b/scripts/test/release-prerelease-bdd.spec.js
@@ -10,7 +10,9 @@ const { createManifest } = require("../release-prerelease.js");
 const {
 	activateVerifiedPackages,
 	assertPublisherManifest,
+	cleanupDistOverlay,
 	consumptionRecord,
+	materializeDistOverlay,
 	validateSthCli,
 	verifyImages,
 	verifyInstallLock,
@@ -300,6 +302,20 @@ test("activation repoints node_modules/.bin/scramjet-transform-hub into the veri
 	const binReal = realpathSync(binLink);
 	t.true(binReal.startsWith(packageReal + sep));
 	t.is(execFileSync(binLink, [], { encoding: "utf8" }), "FAKE STH CLI HELP\nUsage: sth [options...]\n");
+});
+
+test("dist overlay maps only verified prerelease packages and cleans up", (t) => {
+  const { installDir, record, workspaceRoot } = activatedFixture(t, { installInWorkspace: true });
+  const overlay = materializeDistOverlay({ installDir, record, workspaceRoot });
+  t.true(existsSync(join(workspaceRoot, "dist", "host", "package.json")));
+  t.is(realpathSync(join(workspaceRoot, "dist", "host")), realpathSync(join(installDir, "node_modules", "@scramjetorg", "host")));
+  t.true(overlay.packages.includes("host"));
+  t.true(cleanupDistOverlay({ workspaceRoot }));
+  t.false(existsSync(join(workspaceRoot, "dist")));
+
+  const unsafeRecord = { ...record, packages: record.packages.map(entry => ({ ...entry })) };
+  unsafeRecord.packages[0].sourceName = "@scramjet/../escape";
+  t.throws(() => materializeDistOverlay({ installDir, record: unsafeRecord, workspaceRoot }), { message: /invalid verified package mapping/i });
 });
 
 test("release activation selects the verified CLI with an isolated profile home and exact Host prerelease identity", async (t) => {


### PR DESCRIPTION
Fixes the release-PR prerelease BDD plan without changing existing BDD imports or building checked-out packages.

The verified prerelease installation is materialized as a temporary root `dist` overlay for existing BDD step-definition imports. The overlay is containment-checked, removed by a workflow trap, and cannot fall back to source artifacts.

Validated with focused prerelease/workflow tests, BDD build, and typecheck.